### PR TITLE
reverting #15, adding original detokenized texts and SpaceAfter=No

### DIFF
--- a/he-ud-dev.conllu
+++ b/he-ud-dev.conllu
@@ -1,5 +1,5 @@
 # sent_id = 1
-# text = עשרות אנשים מגיעים מתאילנד לישראל כשהם נרשמים כמתנדבים , אך למעשה משמשים עובדים שכירים זולים .
+# text = עשרות אנשים מגיעים מתאילנד לישראל כשהם נרשמים כמתנדבים, אך למעשה משמשים עובדים שכירים זולים.
 1	עשרות	עשר	NUM	NUM	Definite=Cons|Gender=Fem|Number=Plur	2	nummod	_	_
 2	אנשים	איש	NOUN	NOUN	Gender=Masc|Number=Plur	3	nsubj	_	_
 3	מגיעים	הגיע	VERB	VERB	Gender=Masc|HebBinyan=HIFIL|Number=Plur|Person=1,2,3|VerbForm=Part|Voice=Act	0	root	_	_
@@ -13,7 +13,7 @@
 8	כש	כש	SCONJ	SCONJ	Case=Tem	10	mark	_	_
 9	הם	הוא	PRON	PRON	Gender=Masc|Number=Plur|Person=3|PronType=Prs	10	nsubj	_	_
 10	נרשמים	נרשם	VERB	VERB	Gender=Masc|HebBinyan=NIFAL|Number=Plur|Person=1,2,3|VerbForm=Part|Voice=Mid	3	advcl	_	_
-11-12	כמתנדבים	_	_	_	_	_	_	_	_
+11-12	כמתנדבים	_	_	_	_	_	_	_	SpaceAfter=No
 11	כ	כ	ADP	ADP	_	12	case	_	_
 12	מתנדבים	מתנדב	NOUN	NOUN	Gender=Masc|Number=Plur	10	obl	_	_
 13	,	_	PUNCT	PUNCT	_	10	punct	_	_
@@ -22,11 +22,11 @@
 16	משמשים	שימש	VERB	VERB	Gender=Masc|HebBinyan=PIEL|Number=Plur|Person=1,2,3|VerbForm=Part|Voice=Act	10	conj	_	_
 17	עובדים	עובד	NOUN	NOUN	Gender=Masc|Number=Plur	16	obj	_	_
 18	שכירים	שכיר	ADJ	ADJ	Gender=Masc|Number=Plur	17	amod	_	_
-19	זולים	זול	ADJ	ADJ	Gender=Masc|Number=Plur	17	amod	_	_
+19	זולים	זול	ADJ	ADJ	Gender=Masc|Number=Plur	17	amod	_	SpaceAfter=No
 20	.	_	PUNCT	PUNCT	_	3	punct	_	_
 
 # sent_id = 2
-# text = תופעה זו התבררה אתמול בוועדת העבודה והרווחה של הכנסת , שדנה בנושא העסקת עובדים זרים .
+# text = תופעה זו התבררה אתמול בוועדת העבודה והרווחה של הכנסת, שדנה בנושא העסקת עובדים זרים.
 1	תופעה	תופעה	NOUN	NOUN	Gender=Fem|Number=Sing	3	nsubj	_	_
 2	זו	זו	PRON	PRON	Gender=Fem|Number=Sing|Person=3|PronType=Dem	1	amod	_	_
 3	התבררה	התברר	VERB	VERB	Gender=Fem|HebBinyan=HITPAEL|Number=Sing|Person=3|Tense=Past	0	root	_	_
@@ -42,7 +42,7 @@
 10	ה	ה	DET	DET	PronType=Art	11	det:def	_	_
 11	רווחה	רווחה	NOUN	NOUN	Gender=Fem|Number=Sing	8	conj	_	_
 12	של	של	PART	PART	Case=Gen	14	case:gen	_	_
-13-14	הכנסת	_	_	_	_	_	_	_	_
+13-14	הכנסת	_	_	_	_	_	_	_	SpaceAfter=No
 13	ה	ה	DET	DET	PronType=Art	14	det:def	_	_
 14	כנסת	כנסת	PROPN	PROPN	_	6	nmod:poss	_	_
 15	,	_	PUNCT	PUNCT	_	6	punct	_	_
@@ -54,26 +54,26 @@
 19	נושא	נושא	NOUN	NOUN	Definite=Cons|Gender=Masc|Number=Sing	17	iobj	_	_
 20	העסקת	העסקה	NOUN	NOUN	Definite=Cons|Gender=Fem|Number=Sing	19	compound:smixut	_	_
 21	עובדים	עובד	NOUN	NOUN	Gender=Masc|Number=Plur	20	compound:smixut	_	_
-22	זרים	זר	ADJ	ADJ	Gender=Masc|Number=Plur	21	amod	_	_
+22	זרים	זר	ADJ	ADJ	Gender=Masc|Number=Plur	21	amod	_	SpaceAfter=No
 23	.	_	PUNCT	PUNCT	_	3	punct	_	_
 
 # sent_id = 3
-# text = יו"ר הוועדה , ח"כ אורה נמיר ( מערך ) , טענה כי " מביאים עובדים זרים לישראל על תקן של מתנדבים מתאילנד , רק כדי לא לשלם להם שכר מינימום .
+# text = יו"ר הוועדה, ח"כ אורה נמיר (מערך), טענה כי "מביאים עובדים זרים לישראל על תקן של מתנדבים מתאילנד, רק כדי לא לשלם להם שכר מינימום.
 1	יו"ר	יו"ר	NOUN	NOUN	Abbr=Yes|Definite=Cons|Gender=Masc|Number=Sing	12	nsubj	_	_
-2-3	הוועדה	_	_	_	_	_	_	_	_
+2-3	הוועדה	_	_	_	_	_	_	_	SpaceAfter=No
 2	ה	ה	DET	DET	PronType=Art	3	det:def	_	_
 3	וועדה	ועדה	NOUN	NOUN	Gender=Fem|Number=Sing	1	compound:smixut	_	_
 4	,	_	PUNCT	PUNCT	_	1	punct	_	_
 5	ח"כ	ח"ך	NOUN	NOUN	Abbr=Yes|Gender=Masc|Number=Sing	1	appos	_	_
 6	אורה	אורה	PROPN	PROPN	_	5	appos	_	_
 7	נמיר	נמיר	PROPN	PROPN	_	6	flat:name	_	_
-8	(	_	PUNCT	PUNCT	_	9	punct	_	_
-9	מערך	מערך	PROPN	PROPN	_	5	appos	_	_
-10	)	_	PUNCT	PUNCT	_	9	punct	_	_
+8	(	_	PUNCT	PUNCT	_	9	punct	_	SpaceAfter=No
+9	מערך	מערך	PROPN	PROPN	_	5	appos	_	SpaceAfter=No
+10	)	_	PUNCT	PUNCT	_	9	punct	_	SpaceAfter=No
 11	,	_	PUNCT	PUNCT	_	1	punct	_	_
 12	טענה	טען	VERB	VERB	Gender=Fem|HebBinyan=PAAL|Number=Sing|Person=3|Tense=Past|Voice=Act	0	root	_	_
 13	כי	כי	SCONJ	SCONJ	_	15	mark	_	_
-14	"	_	PUNCT	PUNCT	_	15	punct	_	_
+14	"	_	PUNCT	PUNCT	_	15	punct	_	SpaceAfter=No
 15	מביאים	הביא	VERB	VERB	Gender=Masc|HebBinyan=HIFIL|Number=Plur|Person=1,2,3|VerbForm=Part|Voice=Act	12	ccomp	_	_
 16	עובדים	עובד	NOUN	NOUN	Gender=Masc|Number=Plur	15	obj	_	_
 17	זרים	זר	ADJ	ADJ	Gender=Masc|Number=Plur	16	amod	_	_
@@ -84,7 +84,7 @@
 21	תקן	תקן	NOUN	NOUN	Gender=Masc|Number=Sing	15	obl	_	_
 22	של	של	PART	PART	Case=Gen	23	case:gen	_	_
 23	מתנדבים	מתנדב	NOUN	NOUN	Gender=Masc|Number=Plur	21	nmod:poss	_	_
-24-25	מתאילנד	_	_	_	_	_	_	_	_
+24-25	מתאילנד	_	_	_	_	_	_	_	SpaceAfter=No
 24	מ	מ	ADP	ADP	_	25	case	_	_
 25	תאילנד	תאילנד	PROPN	PROPN	_	23	nmod	_	_
 26	,	_	PUNCT	PUNCT	_	15	punct	_	_
@@ -96,11 +96,11 @@
 31	להם	ל	ADP	ADP	_	32	case	_	_
 32	_הם	הוא	PRON	PRON	Gender=Masc|Number=Plur|Person=3|PronType=Prs	30	obl	_	_
 33	שכר	שכר	NOUN	NOUN	Definite=Cons|Gender=Masc|Number=Sing	30	obj	_	_
-34	מינימום	מינימום	NOUN	NOUN	Gender=Masc|Number=Sing	33	compound:smixut	_	_
+34	מינימום	מינימום	NOUN	NOUN	Gender=Masc|Number=Sing	33	compound:smixut	_	SpaceAfter=No
 35	.	_	PUNCT	PUNCT	_	12	punct	_	_
 
 # sent_id = 4
-# text = מצד אחד רוצה האוצר להוריד את שכר המינימום , ומצד שני מתיר משרד העבודה והרווחה להעסיק עובדים זרים בפחות משכר זה " .
+# text = מצד אחד רוצה האוצר להוריד את שכר המינימום, ומצד שני מתיר משרד העבודה והרווחה להעסיק עובדים זרים בפחות משכר זה".
 1-2	מצד	_	_	_	_	_	_	_	_
 1	מ	מ	ADP	ADP	_	2	case	_	_
 2	צד	צד	NOUN	NOUN	Gender=Masc|Number=Sing	4	obl	_	_
@@ -112,7 +112,7 @@
 7	להוריד	הוריד	VERB	VERB	HebBinyan=HIFIL|VerbForm=Inf|Voice=Act	4	xcomp	_	_
 8	את	את	PART	PART	Case=Acc	9	case:acc	_	_
 9	שכר	שכר	NOUN	NOUN	Definite=Cons|Gender=Masc|Number=Sing	7	obj	_	_
-10-11	המינימום	_	_	_	_	_	_	_	_
+10-11	המינימום	_	_	_	_	_	_	_	SpaceAfter=No
 10	ה	ה	DET	DET	PronType=Art	11	det:def	_	_
 11	מינימום	מינימום	NOUN	NOUN	Gender=Masc|Number=Sing	9	compound:smixut	_	_
 12	,	_	PUNCT	PUNCT	_	4	punct	_	_
@@ -139,12 +139,12 @@
 29-30	משכר	_	_	_	_	_	_	_	_
 29	מ	מ	ADP	ADP	_	30	det	_	_
 30	שכר	שכר	NOUN	NOUN	Gender=Masc|Number=Sing	24	obl	_	_
-31	זה	זה	PRON	PRON	Gender=Masc|Number=Sing|Person=3|PronType=Dem	30	amod	_	_
-32	"	_	PUNCT	PUNCT	_	4	punct	_	_
+31	זה	זה	PRON	PRON	Gender=Masc|Number=Sing|Person=3|PronType=Dem	30	amod	_	SpaceAfter=No
+32	"	_	PUNCT	PUNCT	_	4	punct	_	SpaceAfter=No
 33	.	_	PUNCT	PUNCT	_	4	punct	_	_
 
 # sent_id = 5
-# text = נמיר הודיעה כי תפנה לשרי הפנים והעבודה והרווחה ולמזכיר תנועת המושבים , בתביעה לבטל את הזמנתם של 500 עובדים זרים מתאילנד כמתנדבים כביכול .
+# text = נמיר הודיעה כי תפנה לשרי הפנים והעבודה והרווחה ולמזכיר תנועת המושבים, בתביעה לבטל את הזמנתם של 500 עובדים זרים מתאילנד כמתנדבים כביכול.
 1	נמיר	נמיר	PROPN	PROPN	_	2	nsubj	_	_
 2	הודיעה	הודיע	VERB	VERB	Gender=Fem|HebBinyan=HIFIL|Number=Sing|Person=3|Tense=Past|Voice=Act	0	root	_	_
 3	כי	כי	SCONJ	SCONJ	_	4	mark	_	_
@@ -168,7 +168,7 @@
 16	ל	ל	ADP	ADP	_	17	case	_	_
 17	מזכיר	מזכיר	NOUN	NOUN	Definite=Cons|Gender=Masc|Number=Sing	6	conj	_	_
 18	תנועת	תנועה	NOUN	NOUN	Definite=Cons|Gender=Fem|Number=Sing	17	compound:smixut	_	_
-19-20	המושבים	_	_	_	_	_	_	_	_
+19-20	המושבים	_	_	_	_	_	_	_	SpaceAfter=No
 19	ה	ה	DET	DET	PronType=Art	20	det:def	_	_
 20	מושבים	מושב	NOUN	NOUN	Gender=Masc|Number=Plur	18	compound:smixut	_	_
 21	,	_	PUNCT	PUNCT	_	4	punct	_	_
@@ -191,11 +191,11 @@
 35-36	כמתנדבים	_	_	_	_	_	_	_	_
 35	כ	כ	ADP	ADP	_	36	case	_	_
 36	מתנדבים	מתנדב	NOUN	NOUN	Gender=Masc|Number=Plur	26	nmod	_	_
-37	כביכול	כביכול	ADV	ADV	HebSource=ConvUncertainHead	36	dep	_	_
+37	כביכול	כביכול	ADV	ADV	HebSource=ConvUncertainHead	36	dep	_	SpaceAfter=No
 38	.	_	PUNCT	PUNCT	_	2	punct	_	_
 
 # sent_id = 6
-# text = היא הודיעה כי הוועדה תגבש הצעת חוק בנושא העובדים הזרים , שתכלול איסור על מתן שכר לעובדים מתחת לשכר המינימום ומתן התנאים הסוציאליים המקובלים במקום העבודה .
+# text = היא הודיעה כי הוועדה תגבש הצעת חוק בנושא העובדים הזרים, שתכלול איסור על מתן שכר לעובדים מתחת לשכר המינימום ומתן התנאים הסוציאליים המקובלים במקום העבודה.
 1	היא	הוא	PRON	PRON	Gender=Fem|Number=Sing|Person=3|PronType=Prs	2	nsubj	_	_
 2	הודיעה	הודיע	VERB	VERB	Gender=Fem|HebBinyan=HIFIL|Number=Sing|Person=3|Tense=Past|Voice=Act	0	root	_	_
 3	כי	כי	SCONJ	SCONJ	_	6	mark	_	_
@@ -211,7 +211,7 @@
 11-12	העובדים	_	_	_	_	_	_	_	_
 11	ה	ה	DET	DET	PronType=Art	12	det:def	_	_
 12	עובדים	עובד	NOUN	NOUN	Gender=Masc|Number=Plur	10	compound:smixut	_	_
-13-14	הזרים	_	_	_	_	_	_	_	_
+13-14	הזרים	_	_	_	_	_	_	_	SpaceAfter=No
 13	ה	ה	DET	DET	PronType=Art	14	det:def	_	_
 14	זרים	זר	ADJ	ADJ	Gender=Masc|Number=Plur	12	amod	_	_
 15	,	_	PUNCT	PUNCT	_	7	punct	_	_
@@ -248,15 +248,15 @@
 38-39	במקום	_	_	_	_	_	_	_	_
 38	ב	ב	ADP	ADP	_	39	case	_	_
 39	מקום	מקום	NOUN	NOUN	Definite=Cons|Gender=Masc|Number=Sing	31	nmod	_	_
-40-41	העבודה	_	_	_	_	_	_	_	_
+40-41	העבודה	_	_	_	_	_	_	_	SpaceAfter=No
 40	ה	ה	DET	DET	PronType=Art	41	det:def	_	_
 41	עבודה	עבודה	NOUN	NOUN	Gender=Fem|Number=Sing	39	compound:smixut	_	_
 42	.	_	PUNCT	PUNCT	_	2	punct	_	_
 
 # sent_id = 7
-# text = כמו כן , תציב הצעת החוק עונשי מאסר והטלת קנסות כבדים למי שיעסיק עובדים זרים בלא רשיון .
+# text = כמו כן, תציב הצעת החוק עונשי מאסר והטלת קנסות כבדים למי שיעסיק עובדים זרים בלא רשיון.
 1	כמו	כמו	ADP	ADP	_	2	case	_	_
-2	כן	_	PRON	PRON	Person=3|PronType=Dem	4	obl	_	_
+2	כן	_	PRON	PRON	Person=3|PronType=Dem	4	obl	_	SpaceAfter=No
 3	,	_	PUNCT	PUNCT	_	4	punct	_	_
 4	תציב	הציב	VERB	VERB	Gender=Fem|HebBinyan=HIFIL|Number=Sing|Person=3|Tense=Fut|Voice=Act	0	root	_	_
 5	הצעת	הצעה	NOUN	NOUN	Definite=Cons|Gender=Fem|Number=Sing	4	nsubj	_	_
@@ -279,13 +279,13 @@
 18	עובדים	עובד	NOUN	NOUN	Gender=Masc|Number=Plur	17	obj	_	_
 19	זרים	זר	ADJ	ADJ	Gender=Masc|Number=Plur	18	amod	_	_
 20	בלא	בלא	ADP	ADP	_	21	case	_	_
-21	רשיון	רישיון	NOUN	NOUN	Gender=Masc|Number=Sing	17	obl	_	_
+21	רשיון	רישיון	NOUN	NOUN	Gender=Masc|Number=Sing	17	obl	_	SpaceAfter=No
 22	.	_	PUNCT	PUNCT	_	4	punct	_	_
 
 # sent_id = 8
-# text = מרגלית אילת , הממונה על מתן היתרי עבודה לזרים בשירות התעסוקה , מסרה כי תנועת המושבים הפעילה לחץ שיותר לה להביא עובדים זרים מתאילנד .
+# text = מרגלית אילת, הממונה על מתן היתרי עבודה לזרים בשירות התעסוקה, מסרה כי תנועת המושבים הפעילה לחץ שיותר לה להביא עובדים זרים מתאילנד.
 1	מרגלית	מרגלית	PROPN	PROPN	_	17	nsubj	_	_
-2	אילת	אילת	PROPN	PROPN	_	1	flat:name	_	_
+2	אילת	אילת	PROPN	PROPN	_	1	flat:name	_	SpaceAfter=No
 3	,	_	PUNCT	PUNCT	_	1	punct	_	_
 4-5	הממונה	_	_	_	_	_	_	_	_
 4	ה	ה	SCONJ	SCONJ	_	5	mark	_	_
@@ -300,7 +300,7 @@
 12-13	בשירות	_	_	_	_	_	_	_	_
 12	ב	ב	ADP	ADP	_	13	case	_	_
 13	שירות	שירות	NOUN	NOUN	Definite=Cons|Gender=Masc|Number=Sing	5	obl	_	_
-14-15	התעסוקה	_	_	_	_	_	_	_	_
+14-15	התעסוקה	_	_	_	_	_	_	_	SpaceAfter=No
 14	ה	ה	DET	DET	PronType=Art	15	det:def	_	_
 15	תעסוקה	תעסוקה	NOUN	NOUN	Gender=Fem|Number=Sing	13	compound:smixut	_	_
 16	,	_	PUNCT	PUNCT	_	17	punct	_	_
@@ -321,13 +321,13 @@
 28	להביא	הביא	VERB	VERB	HebBinyan=HIFIL|VerbForm=Inf|Voice=Act	25	xcomp	_	_
 29	עובדים	עובד	NOUN	NOUN	Gender=Masc|Number=Plur	28	obj	_	_
 30	זרים	זר	ADJ	ADJ	Gender=Masc|Number=Plur	29	amod	_	_
-31-32	מתאילנד	_	_	_	_	_	_	_	_
+31-32	מתאילנד	_	_	_	_	_	_	_	SpaceAfter=No
 31	מ	מ	ADP	ADP	_	32	case	_	_
 32	תאילנד	תאילנד	PROPN	PROPN	_	28	obl	_	_
 33	.	_	PUNCT	PUNCT	_	17	punct	_	_
 
 # sent_id = 9
-# text = היא אמרה כי שירות התעסוקה הציע להביא עובדים מדרום לבנון , אך תנועת המושבים סירבה .
+# text = היא אמרה כי שירות התעסוקה הציע להביא עובדים מדרום לבנון, אך תנועת המושבים סירבה.
 1	היא	הוא	PRON	PRON	Gender=Fem|Number=Sing|Person=3|PronType=Prs	2	nsubj	_	_
 2	אמרה	אמר	VERB	VERB	Gender=Fem|HebBinyan=PAAL|Number=Sing|Person=3|Tense=Past|Voice=Act	0	root	_	_
 3	כי	כי	SCONJ	SCONJ	_	7	mark	_	_
@@ -341,26 +341,26 @@
 10-11	מדרום	_	_	_	_	_	_	_	_
 10	מ	מ	ADP	ADP	_	11	case	_	_
 11	דרום	דרום	NOUN	NOUN	Definite=Cons|Gender=Masc|Number=Sing	8	obl	_	_
-12	לבנון	לבנון	PROPN	PROPN	_	11	compound:smixut	_	_
+12	לבנון	לבנון	PROPN	PROPN	_	11	compound:smixut	_	SpaceAfter=No
 13	,	_	PUNCT	PUNCT	_	7	punct	_	_
 14	אך	אך	CCONJ	CCONJ	_	18	cc	_	_
 15	תנועת	תנועה	NOUN	NOUN	Definite=Cons|Gender=Fem|Number=Sing	18	nsubj	_	_
 16-17	המושבים	_	_	_	_	_	_	_	_
 16	ה	ה	DET	DET	PronType=Art	17	det:def	_	_
 17	מושבים	מושב	NOUN	NOUN	Gender=Masc|Number=Plur	15	compound:smixut	_	_
-18	סירבה	סירב	VERB	VERB	Gender=Fem|HebBinyan=PIEL|Number=Sing|Person=3|Tense=Past|Voice=Act	7	conj	_	_
+18	סירבה	סירב	VERB	VERB	Gender=Fem|HebBinyan=PIEL|Number=Sing|Person=3|Tense=Past|Voice=Act	7	conj	_	SpaceAfter=No
 19	.	_	PUNCT	PUNCT	_	2	punct	_	_
 
 # sent_id = 10
-# text = ישראל ארד , סמנכ"ל הביטוח הלאומי , אמר כי ממלא מקום שר העבודה והרווחה , דוד מגן , הקים ועדה בין - משרדית , שהמליצה להגדיל באופן משמעותי את הקנסות למעסיקים .
+# text = ישראל ארד, סמנכ"ל הביטוח הלאומי, אמר כי ממלא מקום שר העבודה והרווחה, דוד מגן, הקים ועדה בין-משרדית, שהמליצה להגדיל באופן משמעותי את הקנסות למעסיקים.
 1	ישראל	ישראל	PROPN	PROPN	_	10	nsubj	_	_
-2	ארד	ארד	PROPN	PROPN	_	1	flat:name	_	_
+2	ארד	ארד	PROPN	PROPN	_	1	flat:name	_	SpaceAfter=No
 3	,	_	PUNCT	PUNCT	_	1	punct	_	_
 4	סמנכ"ל	סמנכ"ל	NOUN	NOUN	Abbr=Yes|Gender=Masc|Number=Sing	1	appos	_	_
 5-6	הביטוח	_	_	_	_	_	_	_	_
 5	ה	ה	DET	DET	PronType=Art	6	det:def	_	_
 6	ביטוח	ביטוח	NOUN	NOUN	Gender=Masc|Number=Sing	4	compound:smixut	_	_
-7-8	הלאומי	_	_	_	_	_	_	_	_
+7-8	הלאומי	_	_	_	_	_	_	_	SpaceAfter=No
 7	ה	ה	DET	DET	PronType=Art	8	det:def	_	_
 8	לאומי	לאומי	ADJ	ADJ	Gender=Masc|Number=Sing	6	amod	_	_
 9	,	_	PUNCT	PUNCT	_	10	punct	_	_
@@ -372,19 +372,19 @@
 15-16	העבודה	_	_	_	_	_	_	_	_
 15	ה	ה	DET	DET	PronType=Art	16	det:def	_	_
 16	עבודה	עבודה	NOUN	NOUN	Gender=Fem|Number=Sing	14	compound:smixut	_	_
-17-19	והרווחה	_	_	_	_	_	_	_	_
+17-19	והרווחה	_	_	_	_	_	_	_	SpaceAfter=No
 17	ו	ו	CCONJ	CCONJ	_	19	cc	_	_
 18	ה	ה	DET	DET	PronType=Art	19	det:def	_	_
 19	רווחה	רווחה	NOUN	NOUN	Gender=Fem|Number=Sing	16	conj	_	_
 20	,	_	PUNCT	PUNCT	_	12	punct	_	_
 21	דוד	דוד	PROPN	PROPN	_	12	appos	_	_
-22	מגן	מגן	PROPN	PROPN	_	21	flat:name	_	_
+22	מגן	מגן	PROPN	PROPN	_	21	flat:name	_	SpaceAfter=No
 23	,	_	PUNCT	PUNCT	_	12	punct	_	_
 24	הקים	הקים	VERB	VERB	Gender=Masc|HebBinyan=HIFIL|Number=Sing|Person=3|Tense=Past|Voice=Act	10	ccomp	_	_
 25	ועדה	ועדה	NOUN	NOUN	Gender=Fem|Number=Sing	24	obj	_	_
-26	בין	בין	ADV	ADV	Prefix=Yes	28	advmod	_	_
-27	-	_	PUNCT	PUNCT	_	28	punct	_	_
-28	משרדית	משרדי	ADJ	ADJ	Gender=Fem|Number=Sing	25	amod	_	_
+26	בין	בין	ADV	ADV	Prefix=Yes	28	advmod	_	SpaceAfter=No
+27	-	_	PUNCT	PUNCT	_	28	punct	_	SpaceAfter=No
+28	משרדית	משרדי	ADJ	ADJ	Gender=Fem|Number=Sing	25	amod	_	SpaceAfter=No
 29	,	_	PUNCT	PUNCT	_	25	punct	_	_
 30-31	שהמליצה	_	_	_	_	_	_	_	_
 30	ש	ש	SCONJ	SCONJ	_	31	mark	_	_
@@ -398,19 +398,19 @@
 37-38	הקנסות	_	_	_	_	_	_	_	_
 37	ה	ה	DET	DET	PronType=Art	38	det:def	_	_
 38	קנסות	קנס	NOUN	NOUN	Gender=Masc|Number=Plur	32	obj	_	_
-39-41	למעסיקים	_	_	_	_	_	_	_	_
+39-41	למעסיקים	_	_	_	_	_	_	_	SpaceAfter=No
 39	ל	ל	ADP	ADP	_	41	case	_	_
 40	ה_	ה	DET	DET	PronType=Art	41	det:def	_	_
 41	מעסיקים	מעסיק	NOUN	NOUN	Gender=Masc|Number=Plur	38	nmod	_	_
 42	.	_	PUNCT	PUNCT	_	10	punct	_	_
 
 # sent_id = 11
-# text = ח"כ אלי דיין ( מערך ) הגיש הצעת חוק שלפיה יוטל היטל על מעסיקי עובדים זרים , כדי למנוע העדפתם על עובדים ישראליים .
+# text = ח"כ אלי דיין (מערך) הגיש הצעת חוק שלפיה יוטל היטל על מעסיקי עובדים זרים, כדי למנוע העדפתם על עובדים ישראליים.
 1	ח"כ	ח"ך	NOUN	NOUN	Abbr=Yes|Gender=Masc|Number=Sing	7	nsubj	_	_
 2	אלי	אלי	PROPN	PROPN	_	1	appos	_	_
 3	דיין	דיין	PROPN	PROPN	_	2	flat:name	_	_
-4	(	_	PUNCT	PUNCT	_	5	punct	_	_
-5	מערך	מערך	PROPN	PROPN	_	1	appos	_	_
+4	(	_	PUNCT	PUNCT	_	5	punct	_	SpaceAfter=No
+5	מערך	מערך	PROPN	PROPN	_	1	appos	_	SpaceAfter=No
 6	)	_	PUNCT	PUNCT	_	5	punct	_	_
 7	הגיש	הגיש	VERB	VERB	Gender=Masc|HebBinyan=HIFIL|Number=Sing|Person=3|Tense=Past|Voice=Act	0	root	_	_
 8	הצעת	הצעה	NOUN	NOUN	Definite=Cons|Gender=Fem|Number=Sing	7	obj	_	_
@@ -424,7 +424,7 @@
 15	על	על	ADP	ADP	_	16	case	_	_
 16	מעסיקי	מעסיק	NOUN	NOUN	Definite=Cons|Gender=Masc|Number=Plur	13	iobj	_	_
 17	עובדים	עובד	NOUN	NOUN	Gender=Masc|Number=Plur	16	compound:smixut	_	_
-18	זרים	זר	ADJ	ADJ	Gender=Masc|Number=Plur	17	amod	_	_
+18	זרים	זר	ADJ	ADJ	Gender=Masc|Number=Plur	17	amod	_	SpaceAfter=No
 19	,	_	PUNCT	PUNCT	_	7	punct	_	_
 20	כדי	_	ADP	ADP	_	21	case	_	_
 21	למנוע	מנע	VERB	VERB	HebBinyan=PAAL|VerbForm=Inf|Voice=Act	7	advcl	_	_
@@ -434,11 +434,11 @@
 24	_הם	הוא	PRON	PRON	Case=Gen|Gender=Masc|Number=Plur|Person=3|PronType=Prs	22	nmod:poss	_	_
 25	על	על	ADP	ADP	_	26	case	_	_
 26	עובדים	עובד	NOUN	NOUN	Gender=Masc|Number=Plur	22	iobj	_	_
-27	ישראליים	ישראלי	ADJ	ADJ	Gender=Masc|Number=Plur	26	amod	_	_
+27	ישראליים	ישראלי	ADJ	ADJ	Gender=Masc|Number=Plur	26	amod	_	SpaceAfter=No
 28	.	_	PUNCT	PUNCT	_	7	punct	_	_
 
 # sent_id = 12
-# text = חברות המעסיקות עובדים זרים זוכות במכרזים , היות והן מציעות שירותים זולים יותר .
+# text = חברות המעסיקות עובדים זרים זוכות במכרזים, היות והן מציעות שירותים זולים יותר.
 1	חברות	חברה	NOUN	NOUN	Gender=Fem|Number=Plur	6	nsubj	_	_
 2-3	המעסיקות	_	_	_	_	_	_	_	_
 2	ה	ה	SCONJ	SCONJ	_	3	mark	_	_
@@ -446,7 +446,7 @@
 4	עובדים	עובד	NOUN	NOUN	Gender=Masc|Number=Plur	3	obj	_	_
 5	זרים	זר	ADJ	ADJ	Gender=Masc|Number=Plur	4	amod	_	_
 6	זוכות	זכה	VERB	VERB	Gender=Fem|HebBinyan=PAAL|Number=Plur|Person=1,2,3|VerbForm=Part|Voice=Act	0	root	_	_
-7-8	במכרזים	_	_	_	_	_	_	_	_
+7-8	במכרזים	_	_	_	_	_	_	_	SpaceAfter=No
 7	ב	ב	ADP	ADP	_	8	case	_	_
 8	מכרזים	מכרז	NOUN	NOUN	Gender=Masc|Number=Plur	6	iobj	_	_
 9	,	_	PUNCT	PUNCT	_	6	punct	_	_
@@ -457,16 +457,16 @@
 13	מציעות	הציע	VERB	VERB	Gender=Fem|HebBinyan=HIFIL|HebSource=ConvUncertainHead|Number=Plur|Person=1,2,3|VerbForm=Part|Voice=Act	10	dep	_	_
 14	שירותים	שירות	NOUN	NOUN	Gender=Masc|Number=Plur	13	obj	_	_
 15	זולים	זול	ADJ	ADJ	Gender=Masc|Number=Plur	14	amod	_	_
-16	יותר	יותר	ADV	ADV	_	15	advmod	_	_
+16	יותר	יותר	ADV	ADV	_	15	advmod	_	SpaceAfter=No
 17	.	_	PUNCT	PUNCT	_	6	punct	_	_
 
 # sent_id = 13
-# text = ח"כ רן כהן ( רץ ) אמר כי על הוועדה לפנות לממשלה בדרישה לחסל את העסקת העובדים הזרים לאלתר , על רקע היצע העולים המוכנים לעבוד בכל עבודה בשכר המינימום .
+# text = ח"כ רן כהן (רץ) אמר כי על הוועדה לפנות לממשלה בדרישה לחסל את העסקת העובדים הזרים לאלתר, על רקע היצע העולים המוכנים לעבוד בכל עבודה בשכר המינימום.
 1	ח"כ	ח"ך	NOUN	NOUN	Abbr=Yes|Gender=Masc|Number=Sing	7	dep	_	_
 2	רן	רן	PROPN	PROPN	_	1	appos	_	_
 3	כהן	כהן	PROPN	PROPN	_	2	flat:name	_	_
-4	(	_	PUNCT	PUNCT	_	5	punct	_	_
-5	רץ	רצ	PROPN	PROPN	_	1	appos	_	_
+4	(	_	PUNCT	PUNCT	_	5	punct	_	SpaceAfter=No
+5	רץ	רצ	PROPN	PROPN	_	1	appos	_	SpaceAfter=No
 6	)	_	PUNCT	PUNCT	_	5	punct	_	_
 7	אמר	אמר	VERB	VERB	Gender=Masc|HebBinyan=PAAL|Number=Sing|Person=3|Tense=Past|Voice=Act	0	root	_	_
 8	כי	כי	SCONJ	SCONJ	_	11	mark	_	_
@@ -491,7 +491,7 @@
 23-24	הזרים	_	_	_	_	_	_	_	_
 23	ה	ה	DET	DET	PronType=Art	24	det:def	_	_
 24	זרים	זר	ADJ	ADJ	Gender=Masc|Number=Plur	22	amod	_	_
-25	לאלתר	לאלתר	ADV	ADV	_	18	advmod	_	_
+25	לאלתר	לאלתר	ADV	ADV	_	18	advmod	_	SpaceAfter=No
 26	,	_	PUNCT	PUNCT	_	12	punct	_	_
 27	על	על	ADP	ADP	_	29	case	_	_
 28	רקע	רקע	NOUN	NOUN	Definite=Cons|Gender=Masc|Number=Sing	27	fixed	_	_
@@ -510,14 +510,14 @@
 38-39	בשכר	_	_	_	_	_	_	_	_
 38	ב	ב	ADP	ADP	_	39	case	_	_
 39	שכר	שכר	NOUN	NOUN	Definite=Cons|Gender=Masc|Number=Sing	34	obl	_	_
-40-41	המינימום	_	_	_	_	_	_	_	_
+40-41	המינימום	_	_	_	_	_	_	_	SpaceAfter=No
 40	ה	ה	DET	DET	PronType=Art	41	det:def	_	_
 41	מינימום	מינימום	NOUN	NOUN	Gender=Masc|Number=Sing	39	compound:smixut	_	_
 42	.	_	PUNCT	PUNCT	_	7	punct	_	_
 
 # sent_id = 14
-# text = לדבריו , יש לפנות למשרד העבודה והרווחה בדרישה לבטל בתוך חודש את עבודת העובדים הזרים המועסקים כיום תחת הכותרת " מתנדבים " .
-1-4	לדבריו	_	_	_	_	_	_	_	_
+# text = לדבריו, יש לפנות למשרד העבודה והרווחה בדרישה לבטל בתוך חודש את עבודת העובדים הזרים המועסקים כיום תחת הכותרת "מתנדבים".
+1-4	לדבריו	_	_	_	_	_	_	_	SpaceAfter=No
 1	ל	ל	ADP	ADP	_	2	case	_	_
 2	דבר_	דבר	NOUN	NOUN	Definite=Def|Gender=Masc|Number=Plur	6	parataxis	_	_
 3	_של_	של	ADP	ADP	_	4	case:gen	_	_
@@ -557,18 +557,18 @@
 30-31	הכותרת	_	_	_	_	_	_	_	_
 30	ה	ה	DET	DET	PronType=Art	31	det:def	_	_
 31	כותרת	כותרת	NOUN	NOUN	Gender=Fem|Number=Sing	27	obl	_	_
-32	"	_	PUNCT	PUNCT	_	33	punct	_	_
-33	מתנדבים	מתנדב	NOUN	NOUN	Gender=Masc|Number=Plur	31	appos	_	_
-34	"	_	PUNCT	PUNCT	_	33	punct	_	_
+32	"	_	PUNCT	PUNCT	_	33	punct	_	SpaceAfter=No
+33	מתנדבים	מתנדב	NOUN	NOUN	Gender=Masc|Number=Plur	31	appos	_	SpaceAfter=No
+34	"	_	PUNCT	PUNCT	_	33	punct	_	SpaceAfter=No
 35	.	_	PUNCT	PUNCT	_	6	punct	_	_
 
 # sent_id = 15
-# text = ח"כ יאיר צבן ( מפם ) אמר כי פרשת המתנדבים התאילנדיים היא " כתם חרפה על פרצופנו הלאומי .
+# text = ח"כ יאיר צבן (מפם) אמר כי פרשת המתנדבים התאילנדיים היא "כתם חרפה על פרצופנו הלאומי.
 1	ח"כ	ח"ך	NOUN	NOUN	Abbr=Yes|Gender=Masc|Number=Sing	7	nsubj	_	_
 2	יאיר	יאיר	PROPN	PROPN	_	1	appos	_	_
 3	צבן	צבן	PROPN	PROPN	_	2	flat:name	_	_
-4	(	_	PUNCT	PUNCT	_	5	punct	_	_
-5	מפם	מפם	PROPN	PROPN	_	1	appos	_	_
+4	(	_	PUNCT	PUNCT	_	5	punct	_	SpaceAfter=No
+5	מפם	מפם	PROPN	PROPN	_	1	appos	_	SpaceAfter=No
 6	)	_	PUNCT	PUNCT	_	5	punct	_	_
 7	אמר	אמר	VERB	VERB	Gender=Masc|HebBinyan=PAAL|Number=Sing|Person=3|Tense=Past|Voice=Act	0	root	_	_
 8	כי	כי	SCONJ	SCONJ	_	16	mark	_	_
@@ -580,7 +580,7 @@
 12	ה	ה	DET	DET	PronType=Art	13	det:def	_	_
 13	תאילנדיים	תאילנדי	ADJ	ADJ	Gender=Masc|Number=Plur	11	amod	_	_
 14	היא	הוא	VERB	VERB	Gender=Fem|Number=Sing|Person=3|Polarity=Pos|VerbForm=Part|VerbType=Cop	16	cop	_	_
-15	"	_	PUNCT	PUNCT	_	16	punct	_	_
+15	"	_	PUNCT	PUNCT	_	16	punct	_	SpaceAfter=No
 16	כתם	כתם	NOUN	NOUN	Definite=Cons|Gender=Masc|Number=Sing	7	ccomp	_	_
 17	חרפה	חרפה	NOUN	NOUN	Gender=Fem|Number=Sing	16	compound:smixut	_	_
 18	על	על	ADP	ADP	_	19	case	_	_
@@ -588,13 +588,13 @@
 19	פרצוף_	פרצוף	NOUN	NOUN	Definite=Def|Gender=Masc|Number=Sing	16	nmod	_	_
 20	_של_	של	ADP	ADP	_	21	case:gen	_	_
 21	_אנחנו	הוא	PRON	PRON	Case=Gen|Gender=Fem,Masc|Number=Plur|Person=1|PronType=Prs	19	nmod:poss	_	_
-22-23	הלאומי	_	_	_	_	_	_	_	_
+22-23	הלאומי	_	_	_	_	_	_	_	SpaceAfter=No
 22	ה	ה	DET	DET	PronType=Art	23	det:def	_	_
 23	לאומי	לאומי	ADJ	ADJ	Gender=Masc|Number=Sing	19	amod	_	_
 24	.	_	PUNCT	PUNCT	_	7	punct	_	_
 
 # sent_id = 16
-# text = המוח מתפלץ לא רק מהתופעה המבישה אלא גם מדרכי ההערמה .
+# text = המוח מתפלץ לא רק מהתופעה המבישה אלא גם מדרכי ההערמה.
 1-2	המוח	_	_	_	_	_	_	_	_
 1	ה	ה	DET	DET	PronType=Art	2	det:def	_	_
 2	מוח	מוח	NOUN	NOUN	Gender=Masc|Number=Sing	3	nsubj	_	_
@@ -613,13 +613,13 @@
 13-14	מדרכי	_	_	_	_	_	_	_	_
 13	מ	מ	ADP	ADP	_	14	case	_	_
 14	דרכי	דרך	NOUN	NOUN	Definite=Cons|Gender=Fem|Number=Plur	8	conj	_	_
-15-16	ההערמה	_	_	_	_	_	_	_	_
+15-16	ההערמה	_	_	_	_	_	_	_	SpaceAfter=No
 15	ה	ה	DET	DET	PronType=Art	16	det:def	_	_
 16	הערמה	הערמה	NOUN	NOUN	Gender=Fem|Number=Sing	14	compound:smixut	_	_
 17	.	_	PUNCT	PUNCT	_	3	punct	_	_
 
 # sent_id = 17
-# text = הראש היהודי ממציא לנו פטנטים בדמות מתנדבים , המשולמים שכר מחפיר " .
+# text = הראש היהודי ממציא לנו פטנטים בדמות מתנדבים, המשולמים שכר מחפיר".
 1-2	הראש	_	_	_	_	_	_	_	_
 1	ה	ה	DET	DET	PronType=Art	2	det:def	_	_
 2	ראש	ראש	NOUN	NOUN	Gender=Masc|Number=Sing	5	nsubj	_	_
@@ -634,18 +634,18 @@
 9-10	בדמות	_	_	_	_	_	_	_	_
 9	ב	ב	ADP	ADP	_	10	case	_	_
 10	דמות	דמות	NOUN	NOUN	Definite=Cons|Gender=Fem|Number=Sing	8	nmod	_	_
-11	מתנדבים	מתנדב	NOUN	NOUN	Gender=Masc|Number=Plur	10	compound:smixut	_	_
+11	מתנדבים	מתנדב	NOUN	NOUN	Gender=Masc|Number=Plur	10	compound:smixut	_	SpaceAfter=No
 12	,	_	PUNCT	PUNCT	_	11	punct	_	_
 13-14	המשולמים	_	_	_	_	_	_	_	_
 13	ה	ה	SCONJ	SCONJ	_	14	mark	_	_
 14	משולמים	שולם	VERB	VERB	Gender=Masc|HebBinyan=PUAL|Number=Plur|Person=1,2,3|VerbForm=Part|Voice=Pass	11	acl:relcl	_	_
 15	שכר	שכר	NOUN	NOUN	Gender=Masc|Number=Sing	14	obj	_	_
-16	מחפיר	מחפיר	ADJ	ADJ	Gender=Masc|Number=Sing	15	amod	_	_
-17	"	_	PUNCT	PUNCT	_	5	punct	_	_
+16	מחפיר	מחפיר	ADJ	ADJ	Gender=Masc|Number=Sing	15	amod	_	SpaceAfter=No
+17	"	_	PUNCT	PUNCT	_	5	punct	_	SpaceAfter=No
 18	.	_	PUNCT	PUNCT	_	5	punct	_	_
 
 # sent_id = 18
-# text = הוא קרא להפסקת התופעה ולמתן תשלומים רטרואקטיוויים לתאילנדים , שישלימו את שכר המינימום .
+# text = הוא קרא להפסקת התופעה ולמתן תשלומים רטרואקטיוויים לתאילנדים, שישלימו את שכר המינימום.
 1	הוא	הוא	PRON	PRON	Gender=Masc|Number=Sing|Person=3|PronType=Prs	2	nsubj	_	_
 2	קרא	קרא	VERB	VERB	Gender=Masc|HebBinyan=PAAL|Number=Sing|Person=3|Tense=Past|Voice=Act	0	root	_	_
 3-4	להפסקת	_	_	_	_	_	_	_	_
@@ -660,7 +660,7 @@
 9	מתן	מתן	NOUN	NOUN	Definite=Cons|Gender=Masc|Number=Sing	4	conj	_	_
 10	תשלומים	תשלום	NOUN	NOUN	Gender=Masc|Number=Plur	9	compound:smixut	_	_
 11	רטרואקטיוויים	רטרואקטיבי	ADJ	ADJ	Gender=Masc|Number=Plur	10	amod	_	_
-12-14	לתאילנדים	_	_	_	_	_	_	_	_
+12-14	לתאילנדים	_	_	_	_	_	_	_	SpaceAfter=No
 12	ל	ל	ADP	ADP	_	14	case	_	_
 13	ה_	ה	DET	DET	PronType=Art	14	det:def	_	_
 14	תאילנדים	תאילנדי	NOUN	NOUN	Gender=Masc|Number=Plur	10	nmod	_	_
@@ -670,13 +670,13 @@
 17	ישלימו	השלים	VERB	VERB	Gender=Fem,Masc|HebBinyan=HIFIL|Number=Plur|Person=3|Tense=Fut|Voice=Act	10	acl:relcl	_	_
 18	את	את	PART	PART	Case=Acc	19	case:acc	_	_
 19	שכר	שכר	NOUN	NOUN	Definite=Cons|Gender=Masc|Number=Sing	17	obj	_	_
-20-21	המינימום	_	_	_	_	_	_	_	_
+20-21	המינימום	_	_	_	_	_	_	_	SpaceAfter=No
 20	ה	ה	DET	DET	PronType=Art	21	det:def	_	_
 21	מינימום	מינימום	NOUN	NOUN	Gender=Masc|Number=Sing	19	compound:smixut	_	_
 22	.	_	PUNCT	PUNCT	_	2	punct	_	_
 
 # sent_id = 19
-# text = דוברת שירות התעסוקה מסרה אתמול בתגובה , כי השירות פועל לצמצום מספרם של העובדים הזרים ולהכנסת עולים חדשים במקומם .
+# text = דוברת שירות התעסוקה מסרה אתמול בתגובה, כי השירות פועל לצמצום מספרם של העובדים הזרים ולהכנסת עולים חדשים במקומם.
 1	דוברת	דובר	NOUN	NOUN	Definite=Cons|Gender=Fem|Number=Sing	5	nsubj	_	_
 2	שירות	שירות	NOUN	NOUN	Definite=Cons|Gender=Masc|Number=Sing	1	compound:smixut	_	_
 3-4	התעסוקה	_	_	_	_	_	_	_	_
@@ -684,7 +684,7 @@
 4	תעסוקה	תעסוקה	NOUN	NOUN	Gender=Fem|Number=Sing	2	compound:smixut	_	_
 5	מסרה	מסר	VERB	VERB	Gender=Fem|HebBinyan=PAAL|Number=Sing|Person=3|Tense=Past|Voice=Act	0	root	_	_
 6	אתמול	אתמול	ADV	ADV	_	5	obl:tmod	_	_
-7-8	בתגובה	_	_	_	_	_	_	_	_
+7-8	בתגובה	_	_	_	_	_	_	_	SpaceAfter=No
 7	ב	ב	ADP	ADP	_	8	case	_	_
 8	תגובה	תגובה	NOUN	NOUN	Gender=Fem|Number=Sing	5	obl	_	_
 9	,	_	PUNCT	PUNCT	_	5	punct	_	_
@@ -713,7 +713,7 @@
 26	הכנסת	הכנסה	NOUN	NOUN	Definite=Cons|Gender=Fem|Number=Sing	15	conj	_	_
 27	עולים	עולה	NOUN	NOUN	Gender=Masc|Number=Plur	26	compound:smixut	_	_
 28	חדשים	חדש	ADJ	ADJ	Gender=Masc|Number=Plur	27	amod	_	_
-29-32	במקומם	_	_	_	_	_	_	_	_
+29-32	במקומם	_	_	_	_	_	_	_	SpaceAfter=No
 29	ב	ב	ADP	ADP	_	30	case	_	_
 30	מקום_	מקום	NOUN	NOUN	Definite=Def|Gender=Masc|Number=Sing	26	nmod	_	_
 31	_של_	של	ADP	ADP	_	32	case:gen	_	_
@@ -721,8 +721,8 @@
 33	.	_	PUNCT	PUNCT	_	5	punct	_	_
 
 # sent_id = 20
-# text = " לאחר פעילות נמרצת בשבועות האחרונים , צומצם מספר העובדים הזרים בענף האחיות ב50 % .
-1	"	_	PUNCT	PUNCT	_	11	punct	_	_
+# text = "לאחר פעילות נמרצת בשבועות האחרונים, צומצם מספר העובדים הזרים בענף האחיות ב50%.
+1	"	_	PUNCT	PUNCT	_	11	punct	_	SpaceAfter=No
 2	לאחר	לאחר	ADP	ADP	_	3	case	_	_
 3	פעילות	פעילות	NOUN	NOUN	Gender=Fem|Number=Sing	11	obl	_	_
 4	נמרצת	נמרץ	ADJ	ADJ	Gender=Fem|Number=Sing	3	amod	_	_
@@ -730,7 +730,7 @@
 5	ב	ב	ADP	ADP	_	7	case	_	_
 6	ה_	ה	DET	DET	PronType=Art	7	det:def	_	_
 7	שבועות	שבוע	NOUN	NOUN	Gender=Masc|Number=Plur	3	nmod	_	_
-8-9	האחרונים	_	_	_	_	_	_	_	_
+8-9	האחרונים	_	_	_	_	_	_	_	SpaceAfter=No
 8	ה	ה	DET	DET	PronType=Art	9	det:def	_	_
 9	אחרונים	אחרון	ADJ	ADJ	Gender=Masc|Number=Plur	7	amod	_	_
 10	,	_	PUNCT	PUNCT	_	11	punct	_	_
@@ -748,14 +748,14 @@
 19-20	האחיות	_	_	_	_	_	_	_	_
 19	ה	ה	DET	DET	PronType=Art	20	det:def	_	_
 20	אחיות	אח	NOUN	NOUN	Gender=Fem|Number=Plur	18	compound:smixut	_	_
-21-22	ב50	_	_	_	_	_	_	_	_
+21-22	ב50	_	_	_	_	_	_	_	SpaceAfter=No
 21	ב	ב	ADP	ADP	_	23	case	_	_
 22	50	_	NUM	NUM	_	23	nummod	_	_
-23	%	%	NOUN	NOUN	Gender=Masc|Number=Plur,Sing	11	obl	_	_
+23	%	%	NOUN	NOUN	Gender=Masc|Number=Plur,Sing	11	obl	_	SpaceAfter=No
 24	.	_	PUNCT	PUNCT	_	11	punct	_	_
 
 # sent_id = 21
-# text = עד סוף השנה לא תועסק בארץ אף אחות כעובדת זרה " .
+# text = עד סוף השנה לא תועסק בארץ אף אחות כעובדת זרה".
 1	עד	עד	ADP	ADP	_	2	case	_	_
 2	סוף	סוף	NOUN	NOUN	Definite=Cons|Gender=Masc|Number=Sing	6	obl	_	_
 3-4	השנה	_	_	_	_	_	_	_	_
@@ -772,12 +772,12 @@
 12-13	כעובדת	_	_	_	_	_	_	_	_
 12	כ	כ	ADP	ADP	_	13	case	_	_
 13	עובדת	עובד	NOUN	NOUN	Gender=Fem|Number=Sing	6	obl	_	_
-14	זרה	זר	ADJ	ADJ	Gender=Fem|Number=Sing	13	amod	_	_
-15	"	_	PUNCT	PUNCT	_	6	punct	_	_
+14	זרה	זר	ADJ	ADJ	Gender=Fem|Number=Sing	13	amod	_	SpaceAfter=No
+15	"	_	PUNCT	PUNCT	_	6	punct	_	SpaceAfter=No
 16	.	_	PUNCT	PUNCT	_	6	punct	_	_
 
 # sent_id = 22
-# text = הדוברת אמרה כי השירות קורא לחקלאים לדאוג לעובדים ישראליים , במקום לתאילנדים .
+# text = הדוברת אמרה כי השירות קורא לחקלאים לדאוג לעובדים ישראליים, במקום לתאילנדים.
 1-2	הדוברת	_	_	_	_	_	_	_	_
 1	ה	ה	DET	DET	PronType=Art	2	det:def	_	_
 2	דוברת	דובר	NOUN	NOUN	Gender=Fem|Number=Sing	3	nsubj	_	_
@@ -795,17 +795,17 @@
 12-13	לעובדים	_	_	_	_	_	_	_	_
 12	ל	ל	ADP	ADP	_	13	case	_	_
 13	עובדים	עובד	NOUN	NOUN	Gender=Masc|Number=Plur	11	obl	_	_
-14	ישראליים	ישראלי	ADJ	ADJ	Gender=Masc|Number=Plur	13	amod	_	_
+14	ישראליים	ישראלי	ADJ	ADJ	Gender=Masc|Number=Plur	13	amod	_	SpaceAfter=No
 15	,	_	PUNCT	PUNCT	_	11	punct	_	_
 16	במקום	במקום	ADP	ADP	_	18	case	_	_
-17-18	לתאילנדים	_	_	_	_	_	_	_	_
+17-18	לתאילנדים	_	_	_	_	_	_	_	SpaceAfter=No
 17	ל	ל	ADP	ADP	_	18	case	_	_
 18	תאילנדים	תאילנדי	NOUN	NOUN	Gender=Masc|Number=Plur	11	obl	_	_
 19	.	_	PUNCT	PUNCT	_	3	punct	_	_
 
 # sent_id = 23
-# text = " השירות לא שינה את המדיניות בנושא העסקת תאילנדים בחקלאות , אלא להיפך , הוא הבהיר לתנועת המושבים שכל עובד ישראלי שיסכים לעבוד בענף החקלאות , ישובץ לעבודה לאלתר " .
-1	"	_	PUNCT	PUNCT	_	0	root	_	_
+# text = "השירות לא שינה את המדיניות בנושא העסקת תאילנדים בחקלאות, אלא להיפך, הוא הבהיר לתנועת המושבים שכל עובד ישראלי שיסכים לעבוד בענף החקלאות, ישובץ לעבודה לאלתר".
+1	"	_	PUNCT	PUNCT	_	0	root	_	SpaceAfter=No
 2-3	השירות	_	_	_	_	_	_	_	_
 2	ה	ה	DET	DET	PronType=Art	3	det:def	_	_
 3	שירות	שירות	NOUN	NOUN	Gender=Masc|Number=Sing	5	nsubj	_	_
@@ -820,12 +820,12 @@
 10	נושא	נושא	NOUN	NOUN	Definite=Cons|Gender=Masc|Number=Sing	8	nmod	_	_
 11	העסקת	העסקה	NOUN	NOUN	Definite=Cons|Gender=Fem|Number=Sing	10	compound:smixut	_	_
 12	תאילנדים	תאילנדי	NOUN	NOUN	Gender=Masc|Number=Plur	11	compound:smixut	_	_
-13-14	בחקלאות	_	_	_	_	_	_	_	_
+13-14	בחקלאות	_	_	_	_	_	_	_	SpaceAfter=No
 13	ב	ב	ADP	ADP	_	14	case	_	_
 14	חקלאות	חקלאות	NOUN	NOUN	Gender=Fem|Number=Sing	11	nmod	_	_
 15	,	_	PUNCT	PUNCT	_	5	punct	_	_
 16	אלא	אלא	CCONJ	CCONJ	_	20	cc	_	_
-17	להיפך	להיפך	ADV	ADV	_	20	advmod	_	_
+17	להיפך	להיפך	ADV	ADV	_	20	advmod	_	SpaceAfter=No
 18	,	_	PUNCT	PUNCT	_	20	punct	_	_
 19	הוא	הוא	PRON	PRON	Gender=Masc|Number=Sing|Person=3|PronType=Prs	20	nsubj	_	_
 20	הבהיר	הבהיר	VERB	VERB	Gender=Masc|HebBinyan=HIFIL|Number=Sing|Person=3|Tense=Past|Voice=Act	5	conj	_	_
@@ -847,7 +847,7 @@
 32-33	בענף	_	_	_	_	_	_	_	_
 32	ב	ב	ADP	ADP	_	33	case	_	_
 33	ענף	ענף	NOUN	NOUN	Definite=Cons|Gender=Masc|Number=Sing	31	obl	_	_
-34-35	החקלאות	_	_	_	_	_	_	_	_
+34-35	החקלאות	_	_	_	_	_	_	_	SpaceAfter=No
 34	ה	ה	DET	DET	PronType=Art	35	det:def	_	_
 35	חקלאות	חקלאות	NOUN	NOUN	Gender=Fem|Number=Sing	33	compound:smixut	_	_
 36	,	_	PUNCT	PUNCT	_	37	punct	_	_
@@ -856,21 +856,21 @@
 38	ל	ל	ADP	ADP	_	40	case	_	_
 39	ה_	ה	DET	DET	PronType=Art	40	det:def	_	_
 40	עבודה	עבודה	NOUN	NOUN	Gender=Fem|Number=Sing	37	obl	_	_
-41	לאלתר	לאלתר	ADV	ADV	_	37	advmod	_	_
-42	"	_	PUNCT	PUNCT	_	1	punct	_	_
+41	לאלתר	לאלתר	ADV	ADV	_	37	advmod	_	SpaceAfter=No
+42	"	_	PUNCT	PUNCT	_	1	punct	_	SpaceAfter=No
 43	.	_	PUNCT	PUNCT	_	1	punct	_	_
 
 # sent_id = 24
-# text = מאמרו של תום שגב , " הקרב על סן סימון היה או לא היה " ( " הארץ " 105 ) , הגיע לידי רק בימים אלה .
+# text = מאמרו של תום שגב, "הקרב על סן סימון היה או לא היה" ("הארץ" 105), הגיע לידי רק בימים אלה.
 1-3	מאמרו	_	_	_	_	_	_	_	_
 1	מאמר_	מאמר	NOUN	NOUN	Definite=Def|Gender=Masc|Number=Sing	27	nsubj	_	_
 2	_של_	של	ADP	ADP	_	3	case:gen	_	_
 3	_הוא	הוא	PRON	PRON	Case=Gen|Gender=Masc|Number=Sing|Person=3|PronType=Prs	1	nmod:poss	_	_
 4	של	של	PART	PART	Case=Gen	5	case:gen	_	_
 5	תום	תום	PROPN	PROPN	_	1	nmod:poss	_	_
-6	שגב	שגב	PROPN	PROPN	_	5	flat:name	_	_
+6	שגב	שגב	PROPN	PROPN	_	5	flat:name	_	SpaceAfter=No
 7	,	_	PUNCT	PUNCT	_	1	punct	_	_
-8	"	_	PUNCT	PUNCT	_	14	punct	_	_
+8	"	_	PUNCT	PUNCT	_	14	punct	_	SpaceAfter=No
 9-10	הקרב	_	_	_	_	_	_	_	_
 9	ה	ה	DET	DET	PronType=Art	10	det:def	_	_
 10	קרב	קרב	NOUN	NOUN	Gender=Masc|Number=Sing	14	nsubj	_	_
@@ -880,16 +880,16 @@
 14	היה	היה	VERB	VERB	Gender=Masc|Number=Sing|Person=3|Polarity=Pos|Tense=Past|VerbType=Cop	1	appos	_	_
 15	או	או	CCONJ	CCONJ	_	17	cc	_	_
 16	לא	לא	ADV	ADV	Polarity=Neg	17	advmod	_	_
-17	היה	היה	VERB	VERB	Gender=Masc|Number=Sing|Person=3|Polarity=Pos|Tense=Past|VerbType=Cop	14	conj	_	_
+17	היה	היה	VERB	VERB	Gender=Masc|Number=Sing|Person=3|Polarity=Pos|Tense=Past|VerbType=Cop	14	conj	_	SpaceAfter=No
 18	"	_	PUNCT	PUNCT	_	14	punct	_	_
-19	(	_	PUNCT	PUNCT	_	22	punct	_	_
-20	"	_	PUNCT	PUNCT	_	22	punct	_	_
-21-22	הארץ	_	_	_	_	_	_	_	_
+19	(	_	PUNCT	PUNCT	_	22	punct	_	SpaceAfter=No
+20	"	_	PUNCT	PUNCT	_	22	punct	_	SpaceAfter=No
+21-22	הארץ	_	_	_	_	_	_	_	SpaceAfter=No
 21	ה	ה	DET	DET	PronType=Art	22	det:def	_	_
 22	ארץ	ארץ	NOUN	NOUN	Gender=Fem|Number=Sing	1	appos	_	_
 23	"	_	PUNCT	PUNCT	_	22	punct	_	_
-24	105	_	NUM	NUM	_	22	nummod	_	_
-25	)	_	PUNCT	PUNCT	_	22	punct	_	_
+24	105	_	NUM	NUM	_	22	nummod	_	SpaceAfter=No
+25	)	_	PUNCT	PUNCT	_	22	punct	_	SpaceAfter=No
 26	,	_	PUNCT	PUNCT	_	27	punct	_	_
 27	הגיע	הגיע	VERB	VERB	Gender=Masc|HebBinyan=HIFIL|Number=Sing|Person=3|Tense=Past|Voice=Act	0	root	_	_
 28-31	לידי	_	_	_	_	_	_	_	_
@@ -901,18 +901,18 @@
 33-34	בימים	_	_	_	_	_	_	_	_
 33	ב	ב	ADP	ADP	_	34	case	_	_
 34	ימים	יום	NOUN	NOUN	Gender=Masc|Number=Plur	27	obl	_	_
-35	אלה	אלה	PRON	PRON	Gender=Masc|Number=Plur|Person=3|PronType=Dem	34	amod	_	_
+35	אלה	אלה	PRON	PRON	Gender=Masc|Number=Plur|Person=3|PronType=Dem	34	amod	_	SpaceAfter=No
 36	.	_	PUNCT	PUNCT	_	27	punct	_	_
 
 # sent_id = 25
-# text = למרות שחלפו מאז 24 שנה , ולמרות שאירועי ימים אלה אולי מאפילים על כל דבר אחר , אני מרגיש חובה בשמם של החללים , הפצועים ולוחמי הקרב הזה , כאחד שהיה שם , להתייחס למאמר .
+# text = למרות שחלפו מאז 24 שנה, ולמרות שאירועי ימים אלה אולי מאפילים על כל דבר אחר, אני מרגיש חובה בשמם של החללים, הפצועים ולוחמי הקרב הזה, כאחד שהיה שם, להתייחס למאמר.
 1	למרות	למרות	ADP	ADP	_	3	case	_	_
 2-3	שחלפו	_	_	_	_	_	_	_	_
 2	ש	ש	SCONJ	SCONJ	_	3	mark	_	_
 3	חלפו	חלף	VERB	VERB	Gender=Fem,Masc|HebBinyan=PAAL|Number=Plur|Person=3|Tense=Past|Voice=Act	22	obl	_	_
 4	מאז	מאז	ADV	ADV	_	3	advmod	_	_
 5	24	_	NUM	NUM	_	6	nummod	_	_
-6	שנה	שנה	NOUN	NOUN	Gender=Fem|Number=Sing	3	nsubj	_	_
+6	שנה	שנה	NOUN	NOUN	Gender=Fem|Number=Sing	3	nsubj	_	SpaceAfter=No
 7	,	_	PUNCT	PUNCT	_	3	punct	_	_
 8-9	ולמרות	_	_	_	_	_	_	_	_
 8	ו	ו	CCONJ	CCONJ	_	15	cc	_	_
@@ -927,7 +927,7 @@
 16	על	על	ADP	ADP	_	18	case	_	_
 17	כל	כול	DET	DET	Definite=Cons	18	det	_	_
 18	דבר	דבר	NOUN	NOUN	Gender=Masc|Number=Sing	15	iobj	_	_
-19	אחר	אחר	ADJ	ADJ	Gender=Masc|Number=Sing	18	amod	_	_
+19	אחר	אחר	ADJ	ADJ	Gender=Masc|Number=Sing	18	amod	_	SpaceAfter=No
 20	,	_	PUNCT	PUNCT	_	22	punct	_	_
 21	אני	הוא	PRON	PRON	Gender=Fem,Masc|Number=Sing|Person=1|PronType=Prs	22	nsubj	_	_
 22	מרגיש	הרגיש	VERB	VERB	Gender=Masc|HebBinyan=HIFIL|Number=Sing|Person=1,2,3|VerbForm=Part|Voice=Act	0	root	_	_
@@ -938,7 +938,7 @@
 26	_של_	של	ADP	ADP	_	27	case:gen	_	_
 27	_הם	הוא	PRON	PRON	Case=Gen|Gender=Masc|Number=Plur|Person=3|PronType=Prs	25	nmod:poss	_	_
 28	של	של	PART	PART	Case=Gen	30	case:gen	_	_
-29-30	החללים	_	_	_	_	_	_	_	_
+29-30	החללים	_	_	_	_	_	_	_	SpaceAfter=No
 29	ה	ה	DET	DET	PronType=Art	30	det:def	_	_
 30	חללים	חלל	NOUN	NOUN	Gender=Masc|Number=Plur	25	nmod:poss	_	_
 31	,	_	PUNCT	PUNCT	_	30	punct	_	_
@@ -951,7 +951,7 @@
 36-37	הקרב	_	_	_	_	_	_	_	_
 36	ה	ה	DET	DET	PronType=Art	37	det:def	_	_
 37	קרב	קרב	NOUN	NOUN	Gender=Masc|Number=Sing	35	compound:smixut	_	_
-38-39	הזה	_	_	_	_	_	_	_	_
+38-39	הזה	_	_	_	_	_	_	_	SpaceAfter=No
 38	ה	ה	DET	DET	PronType=Art	39	det:def	_	_
 39	זה	זה	PRON	PRON	Gender=Masc|Number=Sing|Person=3|PronType=Dem	37	amod	_	_
 40	,	_	PUNCT	PUNCT	_	42	punct	_	_
@@ -961,17 +961,17 @@
 43-44	שהיה	_	_	_	_	_	_	_	_
 43	ש	ש	SCONJ	SCONJ	_	44	mark	_	_
 44	היה	היה	VERB	VERB	Gender=Masc|Number=Sing|Person=3|Polarity=Pos|Tense=Past|VerbType=Cop	42	acl:relcl	_	_
-45	שם	שם	ADV	ADV	_	44	advmod	_	_
+45	שם	שם	ADV	ADV	_	44	advmod	_	SpaceAfter=No
 46	,	_	PUNCT	PUNCT	_	42	punct	_	_
 47	להתייחס	התייחס	VERB	VERB	HebBinyan=HITPAEL|VerbForm=Inf	23	acl:inf	_	_
-48-50	למאמר	_	_	_	_	_	_	_	_
+48-50	למאמר	_	_	_	_	_	_	_	SpaceAfter=No
 48	ל	ל	ADP	ADP	_	50	case	_	_
 49	ה_	ה	DET	DET	PronType=Art	50	det:def	_	_
 50	מאמר	מאמר	NOUN	NOUN	Gender=Masc|Number=Sing	47	iobj	_	_
 51	.	_	PUNCT	PUNCT	_	22	punct	_	_
 
 # sent_id = 26
-# text = קטעי המאמר העוסקים בקרב עצמו , ושרק אליהם אתייחס , מאופיינים בחוסר היגיון ובסילוף עובדות , ומעידים על הכותב כי הוא משולל הבנה טקטית מינימלית וניסיון קרבי משמעותי .
+# text = קטעי המאמר העוסקים בקרב עצמו, ושרק אליהם אתייחס, מאופיינים בחוסר היגיון ובסילוף עובדות, ומעידים על הכותב כי הוא משולל הבנה טקטית מינימלית וניסיון קרבי משמעותי.
 1	קטעי	קטע	NOUN	NOUN	Definite=Cons|Gender=Masc|Number=Plur	18	nsubj	_	_
 2-3	המאמר	_	_	_	_	_	_	_	_
 2	ה	ה	DET	DET	PronType=Art	3	det:def	_	_
@@ -983,7 +983,7 @@
 6	ב	ב	ADP	ADP	_	8	case	_	_
 7	ה_	ה	DET	DET	PronType=Art	8	det:def	_	_
 8	קרב	קרב	NOUN	NOUN	Gender=Masc|Number=Sing	5	iobj	_	_
-9	עצמו	עצמו	PRON	PRON	Gender=Masc|Number=Sing|Person=3|PronType=Prs|Reflex=Yes	8	advmod	_	_
+9	עצמו	עצמו	PRON	PRON	Gender=Masc|Number=Sing|Person=3|PronType=Prs|Reflex=Yes	8	advmod	_	SpaceAfter=No
 10	,	_	PUNCT	PUNCT	_	5	punct	_	_
 11-13	ושרק	_	_	_	_	_	_	_	_
 11	ו	ו	CCONJ	CCONJ	_	16	cc	_	_
@@ -992,7 +992,7 @@
 14-15	אליהם	_	_	_	_	_	_	_	_
 14	אליהם	אל	ADP	ADP	_	15	case	_	_
 15	_הם	הוא	PRON	PRON	Gender=Masc|Number=Plur|Person=3|PronType=Prs	16	iobj	_	_
-16	אתייחס	התייחס	VERB	VERB	Gender=Fem,Masc|HebBinyan=HITPAEL|Number=Sing|Person=1|Tense=Fut	5	conj	_	_
+16	אתייחס	התייחס	VERB	VERB	Gender=Fem,Masc|HebBinyan=HITPAEL|Number=Sing|Person=1|Tense=Fut	5	conj	_	SpaceAfter=No
 17	,	_	PUNCT	PUNCT	_	18	punct	_	_
 18	מאופיינים	אופיין	VERB	VERB	Gender=Masc|HebBinyan=PUAL|Number=Plur|Person=1,2,3|VerbForm=Part|Voice=Pass	0	root	_	_
 19-20	בחוסר	_	_	_	_	_	_	_	_
@@ -1003,7 +1003,7 @@
 22	ו	ו	CCONJ	CCONJ	_	24	cc	_	_
 23	ב	ב	ADP	ADP	_	24	case	_	_
 24	סילוף	סילוף	NOUN	NOUN	Definite=Cons|Gender=Masc|Number=Sing	20	conj	_	_
-25	עובדות	עובדה	NOUN	NOUN	Gender=Fem|Number=Plur	24	compound:smixut	_	_
+25	עובדות	עובדה	NOUN	NOUN	Gender=Fem|Number=Plur	24	compound:smixut	_	SpaceAfter=No
 26	,	_	PUNCT	PUNCT	_	18	punct	_	_
 27-28	ומעידים	_	_	_	_	_	_	_	_
 27	ו	ו	CCONJ	CCONJ	_	28	cc	_	_
@@ -1022,11 +1022,11 @@
 38	ו	ו	CCONJ	CCONJ	_	39	cc	_	_
 39	ניסיון	ניסיון	NOUN	NOUN	Gender=Masc|Number=Sing	35	conj	_	_
 40	קרבי	קרבי	ADJ	ADJ	Gender=Masc|Number=Sing	39	amod	_	_
-41	משמעותי	משמעותי	ADJ	ADJ	Gender=Masc|Number=Sing	39	amod	_	_
+41	משמעותי	משמעותי	ADJ	ADJ	Gender=Masc|Number=Sing	39	amod	_	SpaceAfter=No
 42	.	_	PUNCT	PUNCT	_	18	punct	_	_
 
 # sent_id = 27
-# text = וכעת לעובדות המצוטטות : כותרת המאמר , " הקרב על סן סימון : היה לא היה " , מרמזת כי ייתכן שבמנזר כלל לא התנהל קרב .
+# text = וכעת לעובדות המצוטטות: כותרת המאמר, "הקרב על סן סימון: היה לא היה", מרמזת כי ייתכן שבמנזר כלל לא התנהל קרב.
 1-2	וכעת	_	_	_	_	_	_	_	_
 1	ו	ו	CCONJ	CCONJ	_	2	cc	_	_
 2	כעת	כעת	ADV	ADV	_	0	root	_	_
@@ -1034,27 +1034,27 @@
 3	ל	ל	ADP	ADP	_	5	case	_	_
 4	ה_	ה	DET	DET	PronType=Art	5	det:def	_	_
 5	עובדות	עובדה	NOUN	NOUN	Gender=Fem|HebSource=ConvUncertainHead|Number=Plur	2	dep	_	_
-6-7	המצוטטות	_	_	_	_	_	_	_	_
+6-7	המצוטטות	_	_	_	_	_	_	_	SpaceAfter=No
 6	ה	ה	DET	DET	PronType=Art	7	det:def	_	_
 7	מצוטטות	מצוטט	ADJ	ADJ	Gender=Fem|Number=Plur	5	amod	_	_
 8	:	_	PUNCT	PUNCT	_	2	punct	_	_
 9	כותרת	כותרת	NOUN	NOUN	Definite=Cons|Gender=Fem|Number=Sing	25	nsubj	_	_
-10-11	המאמר	_	_	_	_	_	_	_	_
+10-11	המאמר	_	_	_	_	_	_	_	SpaceAfter=No
 10	ה	ה	DET	DET	PronType=Art	11	det:def	_	_
 11	מאמר	מאמר	NOUN	NOUN	Gender=Masc|Number=Sing	9	compound:smixut	_	_
 12	,	_	PUNCT	PUNCT	_	9	punct	_	_
-13	"	_	PUNCT	PUNCT	_	20	punct	_	_
+13	"	_	PUNCT	PUNCT	_	20	punct	_	SpaceAfter=No
 14-15	הקרב	_	_	_	_	_	_	_	_
 14	ה	ה	DET	DET	PronType=Art	15	det:def	_	_
 15	קרב	קרב	NOUN	NOUN	Gender=Masc|Number=Sing	20	dep	_	_
 16	על	על	ADP	ADP	_	17	case	_	_
 17	סן	סן	PROPN	PROPN	_	15	nmod	_	_
-18	סימון	סימון	PROPN	PROPN	_	17	flat:name	_	_
+18	סימון	סימון	PROPN	PROPN	_	17	flat:name	_	SpaceAfter=No
 19	:	_	PUNCT	PUNCT	_	20	punct	_	_
 20	היה	היה	VERB	VERB	Gender=Masc|Number=Sing|Person=3|Polarity=Pos|Tense=Past|VerbType=Cop	9	appos	_	_
 21	לא	לא	ADV	ADV	Polarity=Neg	22	advmod	_	_
-22	היה	היה	VERB	VERB	Gender=Masc|Number=Sing|Person=3|Polarity=Pos|Tense=Past|VerbType=Cop	20	conj:discourse	_	_
-23	"	_	PUNCT	PUNCT	_	20	punct	_	_
+22	היה	היה	VERB	VERB	Gender=Masc|Number=Sing|Person=3|Polarity=Pos|Tense=Past|VerbType=Cop	20	conj:discourse	_	SpaceAfter=No
+23	"	_	PUNCT	PUNCT	_	20	punct	_	SpaceAfter=No
 24	,	_	PUNCT	PUNCT	_	25	punct	_	_
 25	מרמזת	רימז	VERB	VERB	Gender=Fem|HebBinyan=PIEL|HebSource=ConvUncertainHead|Number=Sing|Person=1,2,3|VerbForm=Part|Voice=Act	2	dep	_	_
 26	כי	כי	SCONJ	SCONJ	_	27	mark	_	_
@@ -1067,11 +1067,11 @@
 32	כלל	כלל	ADV	ADV	_	33	advmod	_	_
 33	לא	לא	ADV	ADV	Polarity=Neg	34	advmod:phrase	_	_
 34	התנהל	התנהל	VERB	VERB	Gender=Masc|HebBinyan=HITPAEL|Number=Sing|Person=3|Tense=Past	27	advcl	_	_
-35	קרב	קרב	NOUN	NOUN	Gender=Masc|Number=Sing	34	nsubj	_	_
+35	קרב	קרב	NOUN	NOUN	Gender=Masc|Number=Sing	34	nsubj	_	SpaceAfter=No
 36	.	_	PUNCT	PUNCT	_	2	punct	_	_
 
 # sent_id = 28
-# text = לכל אלה המתרשמים ומסתפקים בקריאת הכותרת בלבד , אני יכול להבטיח שאכן התנהל שם קרב , והוא היה אחד הקשים והמפוארים בכל קרבות ישראל .
+# text = לכל אלה המתרשמים ומסתפקים בקריאת הכותרת בלבד, אני יכול להבטיח שאכן התנהל שם קרב, והוא היה אחד הקשים והמפוארים בכל קרבות ישראל.
 1-2	לכל	_	_	_	_	_	_	_	_
 1	ל	ל	ADP	ADP	_	3	case	_	_
 2	כל	כול	DET	DET	Definite=Cons	3	det	_	_
@@ -1088,7 +1088,7 @@
 10-11	הכותרת	_	_	_	_	_	_	_	_
 10	ה	ה	DET	DET	PronType=Art	11	det:def	_	_
 11	כותרת	כותרת	NOUN	NOUN	Gender=Fem|Number=Sing	9	compound:smixut	_	_
-12	בלבד	בלבד	ADV	ADV	_	9	advmod	_	_
+12	בלבד	בלבד	ADV	ADV	_	9	advmod	_	SpaceAfter=No
 13	,	_	PUNCT	PUNCT	_	15	punct	_	_
 14	אני	הוא	PRON	PRON	Gender=Fem,Masc|Number=Sing|Person=1|PronType=Prs	15	nsubj	_	_
 15	יכול	_	AUX	AUX	Gender=Masc|Number=Sing|Person=1,2,3|VerbForm=Part|VerbType=Mod	0	root	_	_
@@ -1098,7 +1098,7 @@
 18	אכן	אכן	ADV	ADV	_	19	advmod	_	_
 19	התנהל	התנהל	VERB	VERB	Gender=Masc|HebBinyan=HITPAEL|Number=Sing|Person=3|Tense=Past	16	ccomp	_	_
 20	שם	שם	ADV	ADV	_	19	advmod	_	_
-21	קרב	קרב	NOUN	NOUN	Gender=Masc|Number=Sing	19	nsubj	_	_
+21	קרב	קרב	NOUN	NOUN	Gender=Masc|Number=Sing	19	nsubj	_	SpaceAfter=No
 22	,	_	PUNCT	PUNCT	_	19	punct	_	_
 23-24	והוא	_	_	_	_	_	_	_	_
 23	ו	ו	CCONJ	CCONJ	_	28	cc	_	_
@@ -1116,17 +1116,17 @@
 32	ב	ב	ADP	ADP	_	34	case	_	_
 33	כל	כול	DET	DET	Definite=Cons	34	det	_	_
 34	קרבות	קרב	NOUN	NOUN	Definite=Cons|Gender=Masc|HebSource=ConvUncertainHead|Number=Plur	28	dep	_	_
-35	ישראל	ישראל	PROPN	PROPN	_	34	compound:smixut	_	_
+35	ישראל	ישראל	PROPN	PROPN	_	34	compound:smixut	_	SpaceAfter=No
 36	.	_	PUNCT	PUNCT	_	15	punct	_	_
 
 # sent_id = 29
-# text = ועל כך תעיד ההיסטוריה , ויעידו עשרות הלוחמים שנשארו בחיים והצליחו לבצע את משימתם על אף האבדות הכבדות .
+# text = ועל כך תעיד ההיסטוריה, ויעידו עשרות הלוחמים שנשארו בחיים והצליחו לבצע את משימתם על אף האבדות הכבדות.
 1-2	ועל	_	_	_	_	_	_	_	_
 1	ו	ו	CCONJ	CCONJ	_	8	cc	_	_
 2	על	על	ADP	ADP	_	3	case	_	_
 3	כך	כך	PRON	PRON	Person=3|PronType=Dem	4	iobj	_	_
 4	תעיד	העיד	VERB	VERB	Gender=Fem|HebBinyan=HIFIL|Number=Sing|Person=3|Tense=Fut|Voice=Act	0	root	_	_
-5-6	ההיסטוריה	_	_	_	_	_	_	_	_
+5-6	ההיסטוריה	_	_	_	_	_	_	_	SpaceAfter=No
 5	ה	ה	DET	DET	PronType=Art	6	det:def	_	_
 6	היסטוריה	היסטוריה	NOUN	NOUN	Gender=Fem|Number=Sing	4	nsubj	_	_
 7	,	_	PUNCT	PUNCT	_	4	punct	_	_
@@ -1158,17 +1158,17 @@
 27-28	האבדות	_	_	_	_	_	_	_	_
 27	ה	ה	DET	DET	PronType=Art	28	det:def	_	_
 28	אבדות	אבדה	NOUN	NOUN	Gender=Fem|Number=Plur	19	obl	_	_
-29-30	הכבדות	_	_	_	_	_	_	_	_
+29-30	הכבדות	_	_	_	_	_	_	_	SpaceAfter=No
 29	ה	ה	DET	DET	PronType=Art	30	det:def	_	_
 30	כבדות	כבד	ADJ	ADJ	Gender=Fem|Number=Plur	28	amod	_	_
 31	.	_	PUNCT	PUNCT	_	4	punct	_	_
 
 # sent_id = 30
-# text = במלחמת העצמאות , בקרב על ירושלים , נשארה שכונת קטמון תקועה בלב ירושלים המערבית ושימשה כמרכז כוח ערבי רב ומאורגן .
+# text = במלחמת העצמאות, בקרב על ירושלים, נשארה שכונת קטמון תקועה בלב ירושלים המערבית ושימשה כמרכז כוח ערבי רב ומאורגן.
 1-2	במלחמת	_	_	_	_	_	_	_	_
 1	ב	ב	ADP	ADP	_	2	case	_	_
 2	מלחמת	מלחמה	NOUN	NOUN	Definite=Cons|Gender=Fem|Number=Sing	12	obl	_	_
-3-4	העצמאות	_	_	_	_	_	_	_	_
+3-4	העצמאות	_	_	_	_	_	_	_	SpaceAfter=No
 3	ה	ה	DET	DET	PronType=Art	4	det:def	_	_
 4	עצמאות	עצמאות	NOUN	NOUN	Gender=Fem|Number=Sing	2	compound:smixut	_	_
 5	,	_	PUNCT	PUNCT	_	12	punct	_	_
@@ -1177,7 +1177,7 @@
 7	ה_	ה	DET	DET	PronType=Art	8	det:def	_	_
 8	קרב	קרב	NOUN	NOUN	Gender=Masc|Number=Sing	12	obl	_	_
 9	על	על	ADP	ADP	_	10	case	_	_
-10	ירושלים	ירושלים	PROPN	PROPN	_	8	nmod	_	_
+10	ירושלים	ירושלים	PROPN	PROPN	_	8	nmod	_	SpaceAfter=No
 11	,	_	PUNCT	PUNCT	_	12	punct	_	_
 12	נשארה	נשאר	VERB	VERB	Gender=Fem|HebBinyan=NIFAL|Number=Sing|Person=3|Tense=Past|Voice=Mid	0	root	_	_
 13	שכונת	שכונה	NOUN	NOUN	Definite=Cons|Gender=Fem|Number=Sing	12	nsubj	_	_
@@ -1199,13 +1199,13 @@
 25	כוח	כוח	NOUN	NOUN	Gender=Masc|Number=Sing	24	compound:smixut	_	_
 26	ערבי	ערבי	ADJ	ADJ	Gender=Masc|Number=Sing	24	amod	_	_
 27	רב	רב	ADJ	ADJ	Gender=Masc|Number=Sing	24	amod	_	_
-28-29	ומאורגן	_	_	_	_	_	_	_	_
+28-29	ומאורגן	_	_	_	_	_	_	_	SpaceAfter=No
 28	ו	ו	CCONJ	CCONJ	_	29	cc	_	_
 29	מאורגן	מאורגן	ADJ	ADJ	Gender=Masc|Number=Sing	27	conj	_	_
 30	.	_	PUNCT	PUNCT	_	12	punct	_	_
 
 # sent_id = 31
-# text = השטח החיוני של קטמון לשליטה באזור מסוים או לניצחון בקרב היה מנזר סן סימון , ולכן היה עלינו להשתלט עליו .
+# text = השטח החיוני של קטמון לשליטה באזור מסוים או לניצחון בקרב היה מנזר סן סימון, ולכן היה עלינו להשתלט עליו.
 1-2	השטח	_	_	_	_	_	_	_	_
 1	ה	ה	DET	DET	PronType=Art	2	det:def	_	_
 2	שטח	שטח	NOUN	NOUN	Gender=Masc|Number=Sing	19	nsubj	_	_
@@ -1232,7 +1232,7 @@
 18	היה	היה	VERB	VERB	Gender=Masc|Number=Sing|Person=3|Polarity=Pos|Tense=Past|VerbType=Cop	19	aux	_	_
 19	מנזר	מנזר	NOUN	NOUN	Definite=Cons|Gender=Masc|Number=Sing	0	root	_	_
 20	סן	סן	PROPN	PROPN	_	19	compound:smixut	_	_
-21	סימון	סימון	PROPN	PROPN	_	20	flat:name	_	_
+21	סימון	סימון	PROPN	PROPN	_	20	flat:name	_	SpaceAfter=No
 22	,	_	PUNCT	PUNCT	_	19	punct	_	_
 23-24	ולכן	_	_	_	_	_	_	_	_
 23	ו	ו	CCONJ	CCONJ	_	24	cc	_	_
@@ -1242,16 +1242,16 @@
 26	עלינו	על	ADP	ADP	_	27	case	_	_
 27	_אנחנו	הוא	PRON	PRON	Gender=Fem,Masc|Number=Plur|Person=1|PronType=Prs	19	conj	_	_
 28	להשתלט	השתלט	VERB	VERB	HebBinyan=HITPAEL|VerbForm=Inf	27	xcomp	_	_
-29-30	עליו	_	_	_	_	_	_	_	_
+29-30	עליו	_	_	_	_	_	_	_	SpaceAfter=No
 29	עליו	על	ADP	ADP	_	30	case	_	_
 30	_הוא	הוא	PRON	PRON	Gender=Masc|Number=Sing|Person=3|PronType=Prs	28	obl	_	_
 31	.	_	PUNCT	PUNCT	_	19	punct	_	_
 
 # sent_id = 32
-# text = כתוב : " בחוכמה עשה לך מלחמה " .
-1	כתוב	כתב	VERB	VERB	Gender=Masc|HebBinyan=PAAL|Number=Sing|Person=1,2,3|VerbForm=Part|Voice=Act	0	root	_	_
+# text = כתוב: "בחוכמה עשה לך מלחמה".
+1	כתוב	כתב	VERB	VERB	Gender=Masc|HebBinyan=PAAL|Number=Sing|Person=1,2,3|VerbForm=Part|Voice=Act	0	root	_	SpaceAfter=No
 2	:	_	PUNCT	PUNCT	_	6	punct	_	_
-3	"	_	PUNCT	PUNCT	_	6	punct	_	_
+3	"	_	PUNCT	PUNCT	_	6	punct	_	SpaceAfter=No
 4-5	בחוכמה	_	_	_	_	_	_	_	_
 4	ב	ב	ADP	ADP	_	5	case	_	_
 5	חוכמה	חוכמה	NOUN	NOUN	Gender=Fem|Number=Sing	6	obl	_	_
@@ -1259,24 +1259,24 @@
 7-8	לך	_	_	_	_	_	_	_	_
 7	לך	ל	ADP	ADP	_	8	case	_	_
 8	_אתה	הוא	PRON	PRON	Gender=Masc|Number=Sing|Person=2|PronType=Prs	6	obl	_	_
-9	מלחמה	מלחמה	NOUN	NOUN	Gender=Fem|Number=Sing	6	obj	_	_
-10	"	_	PUNCT	PUNCT	_	6	punct	_	_
+9	מלחמה	מלחמה	NOUN	NOUN	Gender=Fem|Number=Sing	6	obj	_	SpaceAfter=No
+10	"	_	PUNCT	PUNCT	_	6	punct	_	SpaceAfter=No
 11	.	_	PUNCT	PUNCT	_	1	punct	_	_
 
 # sent_id = 33
-# text = אכן , כך עשתה חטיבת " הראל " .
-1	אכן	אכן	ADV	ADV	_	4	advmod	_	_
+# text = אכן, כך עשתה חטיבת "הראל".
+1	אכן	אכן	ADV	ADV	_	4	advmod	_	SpaceAfter=No
 2	,	_	PUNCT	PUNCT	_	4	punct	_	_
 3	כך	כך	ADV	ADV	_	4	advmod	_	_
 4	עשתה	עשה	VERB	VERB	Gender=Fem|HebBinyan=PAAL|Number=Sing|Person=3|Tense=Past|Voice=Act	0	root	_	_
 5	חטיבת	חטיבה	NOUN	NOUN	Definite=Cons|Gender=Fem|Number=Sing	4	nsubj	_	_
-6	"	_	PUNCT	PUNCT	_	7	punct	_	_
-7	הראל	הראל	PROPN	PROPN	_	5	flat:name	_	_
-8	"	_	PUNCT	PUNCT	_	7	punct	_	_
+6	"	_	PUNCT	PUNCT	_	7	punct	_	SpaceAfter=No
+7	הראל	הראל	PROPN	PROPN	_	5	flat:name	_	SpaceAfter=No
+8	"	_	PUNCT	PUNCT	_	7	punct	_	SpaceAfter=No
 9	.	_	PUNCT	PUNCT	_	4	punct	_	_
 
 # sent_id = 34
-# text = היא כבשה תחילה את המנזר ואת התנגדות האויב שברה לאחר מכן , בקרב מגננה שהתנהל בתוך המנזר ( קרב מגננה מיועד לשבירת כוחות חזקים ממך ) .
+# text = היא כבשה תחילה את המנזר ואת התנגדות האויב שברה לאחר מכן, בקרב מגננה שהתנהל בתוך המנזר (קרב מגננה מיועד לשבירת כוחות חזקים ממך).
 1	היא	הוא	PRON	PRON	Gender=Fem|Number=Sing|Person=3|PronType=Prs	2	nsubj	_	_
 2	כבשה	כבש	VERB	VERB	Gender=Fem|HebBinyan=PAAL|Number=Sing|Person=3|Tense=Past|Voice=Act	0	root	_	_
 3	תחילה	תחילה	ADV	ADV	_	2	advmod	_	_
@@ -1293,7 +1293,7 @@
 11	אויב	אויב	NOUN	NOUN	Gender=Masc|Number=Sing	9	compound:smixut	_	_
 12	שברה	שבר	VERB	VERB	Gender=Fem|Number=Sing|Person=3|Tense=Past	2	conj	_	_
 13	לאחר	לאחר	ADP	ADP	_	15	case	_	_
-14-15	מכן	_	_	_	_	_	_	_	_
+14-15	מכן	_	_	_	_	_	_	_	SpaceAfter=No
 14	מ	מן	ADP	ADP	_	15	case	_	_
 15	כן	כן	ADV	ADV	_	12	advmod	_	_
 16	,	_	PUNCT	PUNCT	_	12	punct	_	_
@@ -1308,7 +1308,7 @@
 23-24	המנזר	_	_	_	_	_	_	_	_
 23	ה	ה	DET	DET	PronType=Art	24	det:def	_	_
 24	מנזר	מנזר	NOUN	NOUN	Gender=Masc|Number=Sing	21	obl	_	_
-25	(	_	PUNCT	PUNCT	_	28	punct	_	_
+25	(	_	PUNCT	PUNCT	_	28	punct	_	SpaceAfter=No
 26	קרב	קרב	NOUN	NOUN	Definite=Cons|Gender=Masc|Number=Sing	28	nsubj	_	_
 27	מגננה	מגננה	NOUN	NOUN	Gender=Fem|Number=Sing	26	compound:smixut	_	_
 28	מיועד	יועד	VERB	VERB	Gender=Masc|HebBinyan=PUAL|Number=Sing|Person=1,2,3|VerbForm=Part|Voice=Pass	18	appos	_	_
@@ -1317,19 +1317,19 @@
 30	שבירת	שבירה	NOUN	NOUN	Definite=Cons|Gender=Fem|Number=Sing	28	iobj	_	_
 31	כוחות	כוח	NOUN	NOUN	Gender=Masc|Number=Plur	30	compound:smixut	_	_
 32	חזקים	חזק	ADJ	ADJ	Gender=Masc|Number=Plur	31	amod	_	_
-33-34	ממך	_	_	_	_	_	_	_	_
+33-34	ממך	_	_	_	_	_	_	_	SpaceAfter=No
 33	ממך	מן	ADP	ADP	_	34	case	_	_
 34	_אתה	הוא	PRON	PRON	Gender=Masc|Number=Sing|Person=2|PronType=Prs	32	advmod	_	_
-35	)	_	PUNCT	PUNCT	_	28	punct	_	_
+35	)	_	PUNCT	PUNCT	_	28	punct	_	SpaceAfter=No
 36	.	_	PUNCT	PUNCT	_	2	punct	_	_
 
 # sent_id = 35
-# text = האויב אמנם נשבר ; קרב המגננה הפך לניצחון מוחץ ; קטמון נפלה וירושלים המערבית אוחדה .
+# text = האויב אמנם נשבר; קרב המגננה הפך לניצחון מוחץ; קטמון נפלה וירושלים המערבית אוחדה.
 1-2	האויב	_	_	_	_	_	_	_	_
 1	ה	ה	DET	DET	PronType=Art	2	det:def	_	_
 2	אויב	אויב	NOUN	NOUN	Gender=Masc|Number=Sing	4	nsubj	_	_
 3	אמנם	אמנם	ADV	ADV	_	4	advmod	_	_
-4	נשבר	נשבר	VERB	VERB	Gender=Masc|HebBinyan=NIFAL|Number=Sing|Person=3|Tense=Past|Voice=Mid	0	root	_	_
+4	נשבר	נשבר	VERB	VERB	Gender=Masc|HebBinyan=NIFAL|Number=Sing|Person=3|Tense=Past|Voice=Mid	0	root	_	SpaceAfter=No
 5	;	_	PUNCT	PUNCT	_	11	cc	_	_
 6	קרב	קרב	NOUN	NOUN	Definite=Cons|Gender=Masc|Number=Sing	11	nsubj	_	_
 7-8	המגננה	_	_	_	_	_	_	_	_
@@ -1339,7 +1339,7 @@
 10-11	לניצחון	_	_	_	_	_	_	_	_
 10	ל	ל	ADP	ADP	_	11	case	_	_
 11	ניצחון	ניצחון	NOUN	NOUN	Gender=Masc|Number=Sing	4	conj	_	_
-12	מוחץ	מוחץ	ADJ	ADJ	Gender=Masc|Number=Sing	11	amod	_	_
+12	מוחץ	מוחץ	ADJ	ADJ	Gender=Masc|Number=Sing	11	amod	_	SpaceAfter=No
 13	;	_	PUNCT	PUNCT	_	15	cc	_	_
 14	קטמון	קטמון	PROPN	PROPN	_	15	nsubj	_	_
 15	נפלה	נפל	VERB	VERB	Gender=Fem|HebBinyan=PAAL|Number=Sing|Person=3|Tense=Past|Voice=Act	4	conj	_	_
@@ -1349,12 +1349,12 @@
 18-19	המערבית	_	_	_	_	_	_	_	_
 18	ה	ה	DET	DET	PronType=Art	19	det:def	_	_
 19	מערבית	מערבי	ADJ	ADJ	Gender=Fem|Number=Sing	17	amod	_	_
-20	אוחדה	אוחד	VERB	VERB	Gender=Fem|HebBinyan=PUAL|Number=Sing|Person=3|Tense=Past|Voice=Pass	4	conj	_	_
+20	אוחדה	אוחד	VERB	VERB	Gender=Fem|HebBinyan=PUAL|Number=Sing|Person=3|Tense=Past|Voice=Pass	4	conj	_	SpaceAfter=No
 21	.	_	PUNCT	PUNCT	_	4	punct	_	_
 
 # sent_id = 36
-# text = המאמר , המצטט ממחקרו של אורי מילשטיין : " מלכתחילה לא היה צריך לכבוש את המנזר ... " , מצביע על חוסר הבנה אסטרטגית וטקטית בסוגיה זו .
-1-2	המאמר	_	_	_	_	_	_	_	_
+# text = המאמר, המצטט ממחקרו של אורי מילשטיין: "מלכתחילה לא היה צריך לכבוש את המנזר...", מצביע על חוסר הבנה אסטרטגית וטקטית בסוגיה זו.
+1-2	המאמר	_	_	_	_	_	_	_	SpaceAfter=No
 1	ה	ה	DET	DET	PronType=Art	2	det:def	_	_
 2	מאמר	מאמר	NOUN	NOUN	Gender=Masc|Number=Sing	26	nsubj	_	_
 3	,	_	PUNCT	PUNCT	_	2	punct	_	_
@@ -1368,20 +1368,20 @@
 9	_הוא	הוא	PRON	PRON	Case=Gen|Gender=Masc|Number=Sing|Person=3|PronType=Prs	7	nmod:poss	_	_
 10	של	של	PART	PART	Case=Gen	11	case:gen	_	_
 11	אורי	אורי	PROPN	PROPN	_	7	nmod:poss	_	_
-12	מילשטיין	מילשטיין	PROPN	PROPN	_	11	flat:name	_	_
+12	מילשטיין	מילשטיין	PROPN	PROPN	_	11	flat:name	_	SpaceAfter=No
 13	:	_	PUNCT	PUNCT	_	18	punct	_	_
-14	"	_	PUNCT	PUNCT	_	18	punct	_	_
+14	"	_	PUNCT	PUNCT	_	18	punct	_	SpaceAfter=No
 15	מלכתחילה	מלכתחילה	ADV	ADV	_	18	advmod	_	_
 16	לא	לא	ADV	ADV	Polarity=Neg	18	advmod	_	_
 17	היה	היה	VERB	VERB	Gender=Masc|Number=Sing|Person=3|Polarity=Pos|Tense=Past|VerbType=Cop	18	aux	_	_
 18	צריך	צריך	AUX	AUX	Gender=Masc|Number=Sing|Person=1,2,3|VerbType=Mod	7	appos	_	_
 19	לכבוש	כבש	VERB	VERB	HebBinyan=PAAL|VerbForm=Inf|Voice=Act	18	xcomp	_	_
 20	את	את	PART	PART	Case=Acc	22	case:acc	_	_
-21-22	המנזר	_	_	_	_	_	_	_	_
+21-22	המנזר	_	_	_	_	_	_	_	SpaceAfter=No
 21	ה	ה	DET	DET	PronType=Art	22	det:def	_	_
 22	מנזר	מנזר	NOUN	NOUN	Gender=Masc|Number=Sing	19	obj	_	_
-23	...	_	PUNCT	PUNCT	_	18	punct	_	_
-24	"	_	PUNCT	PUNCT	_	18	punct	_	_
+23	...	_	PUNCT	PUNCT	_	18	punct	_	SpaceAfter=No
+24	"	_	PUNCT	PUNCT	_	18	punct	_	SpaceAfter=No
 25	,	_	PUNCT	PUNCT	_	26	punct	_	_
 26	מצביע	הצביע	VERB	VERB	Gender=Masc|HebBinyan=HIFIL|Number=Sing|Person=1,2,3|VerbForm=Part|Voice=Act	0	root	_	_
 27	על	על	ADP	ADP	_	28	case	_	_
@@ -1394,11 +1394,11 @@
 33-34	בסוגיה	_	_	_	_	_	_	_	_
 33	ב	ב	ADP	ADP	_	34	case	_	_
 34	סוגיה	סוגיה	NOUN	NOUN	Gender=Fem|Number=Sing	29	nmod	_	_
-35	זו	זו	PRON	PRON	Gender=Fem|Number=Sing|Person=3|PronType=Dem	34	amod	_	_
+35	זו	זו	PRON	PRON	Gender=Fem|Number=Sing|Person=3|PronType=Dem	34	amod	_	SpaceAfter=No
 36	.	_	PUNCT	PUNCT	_	26	punct	_	_
 
 # sent_id = 37
-# text = מורשת הקרב שצה"ל אימץ כתוצאה מהקרב על מנזר סן סימון איננה מיתוס .
+# text = מורשת הקרב שצה"ל אימץ כתוצאה מהקרב על מנזר סן סימון איננה מיתוס.
 1	מורשת	מורשת	NOUN	NOUN	Definite=Cons|Gender=Fem|Number=Sing	17	nsubj	_	_
 2-3	הקרב	_	_	_	_	_	_	_	_
 2	ה	ה	DET	DET	PronType=Art	3	det:def	_	_
@@ -1419,11 +1419,11 @@
 14	סן	סן	PROPN	PROPN	_	13	compound:smixut	_	_
 15	סימון	סימון	PROPN	PROPN	_	14	flat:name	_	_
 16	איננה	אינו	VERB	VERB	Gender=Fem|Number=Sing|Person=3|Polarity=Neg|VerbForm=Part|VerbType=Cop	17	advmod	_	_
-17	מיתוס	מיתוס	NOUN	NOUN	Gender=Masc|Number=Sing	0	root	_	_
+17	מיתוס	מיתוס	NOUN	NOUN	Gender=Masc|Number=Sing	0	root	_	SpaceAfter=No
 18	.	_	PUNCT	PUNCT	_	17	punct	_	_
 
 # sent_id = 38
-# text = היא מבוססת על אותו קרב המגננה שבו אירעו מעשי גבורה עילאיים , ועל קבלת החלטות קשות בתנאי קרב .
+# text = היא מבוססת על אותו קרב המגננה שבו אירעו מעשי גבורה עילאיים, ועל קבלת החלטות קשות בתנאי קרב.
 1	היא	הוא	PRON	PRON	Gender=Fem|Number=Sing|Person=3|PronType=Prs	2	nsubj	_	_
 2	מבוססת	_	VERB	VERB	Gender=Fem|Number=Sing|Person=1,2,3|VerbForm=Part	0	root	_	_
 3	על	על	ADP	ADP	_	5	case	_	_
@@ -1439,7 +1439,7 @@
 11	אירעו	אירע	VERB	VERB	Gender=Fem,Masc|HebBinyan=PIEL|Number=Plur|Person=3|Tense=Past|Voice=Act	5	acl:relcl	_	_
 12	מעשי	מעשה	NOUN	NOUN	Definite=Cons|Gender=Masc|Number=Plur	11	nsubj	_	_
 13	גבורה	גבורה	NOUN	NOUN	Gender=Fem|Number=Sing	12	compound:smixut	_	_
-14	עילאיים	עילאי	ADJ	ADJ	Gender=Masc|Number=Plur	12	amod	_	_
+14	עילאיים	עילאי	ADJ	ADJ	Gender=Masc|Number=Plur	12	amod	_	SpaceAfter=No
 15	,	_	PUNCT	PUNCT	_	5	punct	_	_
 16-17	ועל	_	_	_	_	_	_	_	_
 16	ו	ו	CCONJ	CCONJ	_	18	cc	_	_
@@ -1450,11 +1450,11 @@
 21-22	בתנאי	_	_	_	_	_	_	_	_
 21	ב	ב	ADP	ADP	_	22	case	_	_
 22	תנאי	תנאי	NOUN	NOUN	Definite=Cons|Gender=Masc|Number=Plur	18	nmod	_	_
-23	קרב	קרב	NOUN	NOUN	Gender=Masc|Number=Sing	22	compound:smixut	_	_
+23	קרב	קרב	NOUN	NOUN	Gender=Masc|Number=Sing	22	compound:smixut	_	SpaceAfter=No
 24	.	_	PUNCT	PUNCT	_	2	punct	_	_
 
 # sent_id = 39
-# text = חוסר ניסיון ועלילה זדונית באים לביטוי בקטע המאמר הדן בנושא " רצח הנזירות " .
+# text = חוסר ניסיון ועלילה זדונית באים לביטוי בקטע המאמר הדן בנושא "רצח הנזירות".
 1	חוסר	חוסר	NOUN	NOUN	Definite=Cons|Gender=Masc|Number=Sing	6	nsubj	_	_
 2	ניסיון	ניסיון	NOUN	NOUN	Gender=Masc|Number=Sing	1	compound:smixut	_	_
 3-4	ועלילה	_	_	_	_	_	_	_	_
@@ -1477,16 +1477,16 @@
 15-16	בנושא	_	_	_	_	_	_	_	_
 15	ב	ב	ADP	ADP	_	16	case	_	_
 16	נושא	נושא	NOUN	NOUN	Definite=Cons|Gender=Masc|Number=Sing	14	iobj	_	_
-17	"	_	PUNCT	PUNCT	_	18	punct	_	_
+17	"	_	PUNCT	PUNCT	_	18	punct	_	SpaceAfter=No
 18	רצח	רצח	NOUN	NOUN	Definite=Cons|Gender=Masc|Number=Sing	16	compound:smixut	_	_
-19-20	הנזירות	_	_	_	_	_	_	_	_
+19-20	הנזירות	_	_	_	_	_	_	_	SpaceAfter=No
 19	ה	ה	DET	DET	PronType=Art	20	det:def	_	_
 20	נזירות	נזירה	NOUN	NOUN	Gender=Fem|Number=Plur	18	compound:smixut	_	_
-21	"	_	PUNCT	PUNCT	_	18	punct	_	_
+21	"	_	PUNCT	PUNCT	_	18	punct	_	SpaceAfter=No
 22	.	_	PUNCT	PUNCT	_	6	punct	_	_
 
 # sent_id = 40
-# text = כל ישראלי המנוסה בקרב לילה בשטח בנוי ( כמנזר סן סימון ) יודע , כי תוך כדי פריצה בחשכה קודם כל יורים בכל דבר שנע ממולך .
+# text = כל ישראלי המנוסה בקרב לילה בשטח בנוי (כמנזר סן סימון) יודע, כי תוך כדי פריצה בחשכה קודם כל יורים בכל דבר שנע ממולך.
 1	כל	כול	DET	DET	Definite=Cons	2	det	_	_
 2	ישראלי	ישראלי	NOUN	NOUN	Gender=Masc|Number=Sing	17	nsubj	_	_
 3-4	המנוסה	_	_	_	_	_	_	_	_
@@ -1500,14 +1500,14 @@
 8	ב	ב	ADP	ADP	_	9	case	_	_
 9	שטח	שטח	NOUN	NOUN	Gender=Masc|Number=Sing	6	nmod	_	_
 10	בנוי	בנוי	ADJ	ADJ	Gender=Masc|Number=Sing	9	amod	_	_
-11	(	_	PUNCT	PUNCT	_	13	punct	_	_
+11	(	_	PUNCT	PUNCT	_	13	punct	_	SpaceAfter=No
 12-13	כמנזר	_	_	_	_	_	_	_	_
 12	כ	כ	ADP	ADP	_	13	case	_	_
 13	מנזר	מנזר	NOUN	NOUN	Definite=Cons|Gender=Masc|Number=Sing	6	appos	_	_
 14	סן	סן	PROPN	PROPN	_	13	compound:smixut	_	_
-15	סימון	סימון	PROPN	PROPN	_	14	flat:name	_	_
+15	סימון	סימון	PROPN	PROPN	_	14	flat:name	_	SpaceAfter=No
 16	)	_	PUNCT	PUNCT	_	13	punct	_	_
-17	יודע	ידע	VERB	VERB	Gender=Masc|HebBinyan=PAAL|Number=Sing|Person=1,2,3|VerbForm=Part|Voice=Act	0	root	_	_
+17	יודע	ידע	VERB	VERB	Gender=Masc|HebBinyan=PAAL|Number=Sing|Person=1,2,3|VerbForm=Part|Voice=Act	0	root	_	SpaceAfter=No
 18	,	_	PUNCT	PUNCT	_	17	punct	_	_
 19	כי	כי	SCONJ	SCONJ	_	28	mark	_	_
 20	תוך	תוך	ADP	ADP	_	22	case	_	_
@@ -1527,15 +1527,15 @@
 32-33	שנע	_	_	_	_	_	_	_	_
 32	ש	ש	SCONJ	SCONJ	_	33	mark	_	_
 33	נע	נע	VERB	VERB	Gender=Masc|HebBinyan=PAAL|Number=Sing|Person=1,2,3|VerbForm=Part|Voice=Act	31	acl:relcl	_	_
-34-36	ממולך	_	_	_	_	_	_	_	_
+34-36	ממולך	_	_	_	_	_	_	_	SpaceAfter=No
 34	מ	מ	ADP	ADP	_	36	case	_	_
 35	מולך	מול	ADP	ADP	_	36	case	_	_
 36	_אתה	הוא	PRON	PRON	Gender=Masc|Number=Sing|Person=2|PronType=Prs	33	obl	_	_
 37	.	_	PUNCT	PUNCT	_	17	punct	_	_
 
 # sent_id = 41
-# text = ואכן , כך קרה בפריצה למנזר החשוך לחלוטין .
-1-2	ואכן	_	_	_	_	_	_	_	_
+# text = ואכן, כך קרה בפריצה למנזר החשוך לחלוטין.
+1-2	ואכן	_	_	_	_	_	_	_	SpaceAfter=No
 1	ו	ו	CCONJ	CCONJ	_	5	cc	_	_
 2	אכן	אכן	ADV	ADV	_	5	advmod	_	_
 3	,	_	PUNCT	PUNCT	_	5	punct	_	_
@@ -1552,62 +1552,62 @@
 12-13	החשוך	_	_	_	_	_	_	_	_
 12	ה	ה	DET	DET	PronType=Art	13	det:def	_	_
 13	חשוך	חשוך	ADJ	ADJ	Gender=Masc|Number=Sing	11	amod	_	_
-14	לחלוטין	לחלוטין	ADV	ADV	_	13	advmod	_	_
+14	לחלוטין	לחלוטין	ADV	ADV	_	13	advmod	_	SpaceAfter=No
 15	.	_	PUNCT	PUNCT	_	5	punct	_	_
 
 # sent_id = 42
-# text = לא נהרגו " נזירות " , אלא נשים ערביות , כנראה משרתות במנזר .
+# text = לא נהרגו "נזירות", אלא נשים ערביות, כנראה משרתות במנזר.
 1	לא	לא	ADV	ADV	Polarity=Neg	2	advmod	_	_
 2	נהרגו	נהרג	VERB	VERB	Gender=Fem,Masc|HebBinyan=NIFAL|Number=Plur|Person=3|Tense=Past|Voice=Mid	0	root	_	_
-3	"	_	PUNCT	PUNCT	_	4	punct	_	_
-4	נזירות	נזירה	NOUN	NOUN	Gender=Fem|Number=Plur	2	nsubj	_	_
-5	"	_	PUNCT	PUNCT	_	4	punct	_	_
+3	"	_	PUNCT	PUNCT	_	4	punct	_	SpaceAfter=No
+4	נזירות	נזירה	NOUN	NOUN	Gender=Fem|Number=Plur	2	nsubj	_	SpaceAfter=No
+5	"	_	PUNCT	PUNCT	_	4	punct	_	SpaceAfter=No
 6	,	_	PUNCT	PUNCT	_	4	punct	_	_
 7	אלא	אלא	CCONJ	CCONJ	_	8	cc	_	_
 8	נשים	איש	NOUN	NOUN	Gender=Fem|Number=Plur	4	conj	_	_
-9	ערביות	ערבי	ADJ	ADJ	Gender=Fem|Number=Plur	8	amod	_	_
+9	ערביות	ערבי	ADJ	ADJ	Gender=Fem|Number=Plur	8	amod	_	SpaceAfter=No
 10	,	_	PUNCT	PUNCT	_	8	punct	_	_
 11	כנראה	כנראה	ADV	ADV	_	12	det	_	_
 12	משרתות	משרת	NOUN	NOUN	Gender=Fem|Number=Plur	8	appos	_	_
-13-15	במנזר	_	_	_	_	_	_	_	_
+13-15	במנזר	_	_	_	_	_	_	_	SpaceAfter=No
 13	ב	ב	ADP	ADP	_	15	case	_	_
 14	ה_	ה	DET	DET	PronType=Art	15	det:def	_	_
 15	מנזר	מנזר	NOUN	NOUN	Gender=Masc|Number=Sing	12	nmod	_	_
 16	.	_	PUNCT	PUNCT	_	2	punct	_	_
 
 # sent_id = 43
-# text = חבל .
-1	חבל	חבל	ADV	ADV	_	0	root	_	_
+# text = חבל.
+1	חבל	חבל	ADV	ADV	_	0	root	_	SpaceAfter=No
 2	.	_	PUNCT	PUNCT	_	1	punct	_	_
 
 # sent_id = 44
-# text = איש לא התכוון לכך .
+# text = איש לא התכוון לכך.
 1	איש	איש	NOUN	NOUN	Gender=Masc|Number=Sing	3	nsubj	_	_
 2	לא	לא	ADV	ADV	Polarity=Neg	3	advmod	_	_
 3	התכוון	התכוון	VERB	VERB	Gender=Masc|HebBinyan=HITPAEL|Number=Sing|Person=3|Tense=Past	0	root	_	_
-4-5	לכך	_	_	_	_	_	_	_	_
+4-5	לכך	_	_	_	_	_	_	_	SpaceAfter=No
 4	ל	ל	ADP	ADP	_	5	case	_	_
 5	כך	כך	PRON	PRON	Person=3|PronType=Dem	3	iobj	_	_
 6	.	_	PUNCT	PUNCT	_	3	punct	_	_
 
 # sent_id = 45
-# text = ציטוט מהמאמר : " בעת שנורתה , ( הנזירה ) עסקה בטיפול בפצועים " .
+# text = ציטוט מהמאמר: "בעת שנורתה, (הנזירה) עסקה בטיפול בפצועים".
 1	ציטוט	ציטוט	NOUN	NOUN	Gender=Masc|Number=Sing	0	root	_	_
-2-4	מהמאמר	_	_	_	_	_	_	_	_
+2-4	מהמאמר	_	_	_	_	_	_	_	SpaceAfter=No
 2	מ	מ	ADP	ADP	_	4	case	_	_
 3	ה	ה	DET	DET	PronType=Art	4	det:def	_	_
 4	מאמר	מאמר	NOUN	NOUN	Gender=Masc|Number=Sing	1	nmod	_	_
 5	:	_	PUNCT	PUNCT	_	16	punct	_	_
-6	"	_	PUNCT	PUNCT	_	16	punct	_	_
+6	"	_	PUNCT	PUNCT	_	16	punct	_	SpaceAfter=No
 7-8	בעת	_	_	_	_	_	_	_	_
 7	ב	ב	ADP	ADP	_	8	case	_	_
 8	עת	עת	NOUN	NOUN	Gender=Fem|Number=Sing	16	obl	_	_
-9-10	שנורתה	_	_	_	_	_	_	_	_
+9-10	שנורתה	_	_	_	_	_	_	_	SpaceAfter=No
 9	ש	ש	SCONJ	SCONJ	_	10	mark	_	_
 10	נורתה	נורה	VERB	VERB	Gender=Fem|HebBinyan=NIFAL|Number=Sing|Person=3|Tense=Past|Voice=Mid	8	acl:relcl	_	_
 11	,	_	PUNCT	PUNCT	_	16	punct	_	_
-12	(	_	PUNCT	PUNCT	_	14	punct	_	_
-13-14	הנזירה	_	_	_	_	_	_	_	_
+12	(	_	PUNCT	PUNCT	_	14	punct	_	SpaceAfter=No
+13-14	הנזירה	_	_	_	_	_	_	_	SpaceAfter=No
 13	ה	ה	DET	DET	PronType=Art	14	det:def	_	_
 14	נזירה	נזירה	NOUN	NOUN	Gender=Fem|Number=Sing	16	nsubj	_	_
 15	)	_	PUNCT	PUNCT	_	14	punct	_	_
@@ -1615,30 +1615,30 @@
 17-18	בטיפול	_	_	_	_	_	_	_	_
 17	ב	ב	ADP	ADP	_	18	case	_	_
 18	טיפול	טיפול	NOUN	NOUN	Gender=Masc|Number=Sing	16	iobj	_	_
-19-20	בפצועים	_	_	_	_	_	_	_	_
+19-20	בפצועים	_	_	_	_	_	_	_	SpaceAfter=No
 19	ב	ב	ADP	ADP	_	20	case	_	_
 20	פצועים	פצוע	NOUN	NOUN	Gender=Masc|Number=Plur	18	nmod	_	_
-21	"	_	PUNCT	PUNCT	_	16	punct	_	_
+21	"	_	PUNCT	PUNCT	_	16	punct	_	SpaceAfter=No
 22	.	_	PUNCT	PUNCT	_	1	punct	_	_
 
 # sent_id = 46
-# text = איזה פצועים ?
+# text = איזה פצועים?
 1	איזה	איזה	DET	DET	Definite=Cons	2	det	_	_
-2	פצועים	פצוע	NOUN	NOUN	Gender=Masc|Number=Plur	0	root	_	_
+2	פצועים	פצוע	NOUN	NOUN	Gender=Masc|Number=Plur	0	root	_	SpaceAfter=No
 3	?	_	PUNCT	PUNCT	_	2	punct	_	_
 
 # sent_id = 47
-# text = הרי כותב המאמר קובע , פסקה קודם לכן , כי המנזר היה ריק ממגינים .
+# text = הרי כותב המאמר קובע, פסקה קודם לכן, כי המנזר היה ריק ממגינים.
 1	הרי	הרי	CCONJ	CCONJ	_	5	advmod	_	_
 2	כותב	כותב	NOUN	NOUN	Definite=Cons|Gender=Masc|Number=Sing	5	nsubj	_	_
 3-4	המאמר	_	_	_	_	_	_	_	_
 3	ה	ה	DET	DET	PronType=Art	4	det:def	_	_
 4	מאמר	מאמר	NOUN	NOUN	Gender=Masc|Number=Sing	2	compound:smixut	_	_
-5	קובע	קבע	VERB	VERB	Gender=Masc|HebBinyan=PAAL|Number=Sing|Person=1,2,3|VerbForm=Part|Voice=Act	0	root	_	_
+5	קובע	קבע	VERB	VERB	Gender=Masc|HebBinyan=PAAL|Number=Sing|Person=1,2,3|VerbForm=Part|Voice=Act	0	root	_	SpaceAfter=No
 6	,	_	PUNCT	PUNCT	_	5	punct	_	_
 7	פסקה	פסק	NOUN	NOUN	_	5	dep	_	_
 8	קודם	קודם	ADV	ADV	_	7	advmod	_	_
-9-11	לכן	_	_	_	_	_	_	_	_
+9-11	לכן	_	_	_	_	_	_	_	SpaceAfter=No
 9	ל	ל	ADP	ADP	_	8	fixed	_	_
 10	ה_	ה	DET	DET	PronType=Art	8	fixed	_	_
 11	כן	_	PRON	PRON	Person=3|PronType=Dem	8	fixed	_	_
@@ -1649,16 +1649,16 @@
 15	מנזר	מנזר	NOUN	NOUN	Gender=Masc|Number=Sing	17	nsubj	_	_
 16	היה	היה	VERB	VERB	Gender=Masc|Number=Sing|Person=3|Polarity=Pos|Tense=Past|VerbType=Cop	17	aux	_	_
 17	ריק	ריק	ADJ	ADJ	Gender=Masc|Number=Sing	5	ccomp	_	_
-18-19	ממגינים	_	_	_	_	_	_	_	_
+18-19	ממגינים	_	_	_	_	_	_	_	SpaceAfter=No
 18	מ	מ	ADP	ADP	_	19	case	_	_
 19	מגינים	מגן	NOUN	NOUN	Gender=Masc|Number=Plur	17	advmod	_	_
 20	.	_	PUNCT	PUNCT	_	5	punct	_	_
 
 # sent_id = 48
-# text = אני הייתי שם , וכל תיאור הגווייה ( " זה היה מראה איום של דם ובשר ואיברי מין " ) הוא שקר וכזב .
+# text = אני הייתי שם, וכל תיאור הגווייה ("זה היה מראה איום של דם ובשר ואיברי מין") הוא שקר וכזב.
 1	אני	הוא	PRON	PRON	Gender=Fem,Masc|Number=Sing|Person=1|PronType=Prs	2	nsubj	_	_
 2	הייתי	היה	VERB	VERB	Gender=Fem,Masc|Number=Sing|Person=1|Polarity=Pos|Tense=Past|VerbType=Cop	0	root	_	_
-3	שם	שם	ADV	ADV	_	2	advmod	_	_
+3	שם	שם	ADV	ADV	_	2	advmod	_	SpaceAfter=No
 4	,	_	PUNCT	PUNCT	_	2	punct	_	_
 5-6	וכל	_	_	_	_	_	_	_	_
 5	ו	ו	CCONJ	CCONJ	_	26	cc	_	_
@@ -1667,8 +1667,8 @@
 8-9	הגווייה	_	_	_	_	_	_	_	_
 8	ה	ה	DET	DET	PronType=Art	9	det:def	_	_
 9	גווייה	גווייה	NOUN	NOUN	Gender=Fem|Number=Sing	7	compound:smixut	_	_
-10	(	_	PUNCT	PUNCT	_	14	punct	_	_
-11	"	_	PUNCT	PUNCT	_	14	punct	_	_
+10	(	_	PUNCT	PUNCT	_	14	punct	_	SpaceAfter=No
+11	"	_	PUNCT	PUNCT	_	14	punct	_	SpaceAfter=No
 12	זה	זה	PRON	PRON	Gender=Masc|Number=Sing|Person=3	14	nsubj	_	_
 13	היה	היה	VERB	VERB	Gender=Masc|Number=Sing|Person=3|Polarity=Pos|Tense=Past|VerbType=Cop	14	aux	_	_
 14	מראה	מראה	NOUN	NOUN	Gender=Masc|Number=Sing	7	appos	_	_
@@ -1681,23 +1681,23 @@
 20-21	ואיברי	_	_	_	_	_	_	_	_
 20	ו	ו	CCONJ	CCONJ	_	21	cc	_	_
 21	איברי	איבר	NOUN	NOUN	Definite=Cons|Gender=Masc|Number=Plur	17	conj	_	_
-22	מין	מין	NOUN	NOUN	Gender=Masc|Number=Sing	21	compound:smixut	_	_
-23	"	_	PUNCT	PUNCT	_	14	punct	_	_
+22	מין	מין	NOUN	NOUN	Gender=Masc|Number=Sing	21	compound:smixut	_	SpaceAfter=No
+23	"	_	PUNCT	PUNCT	_	14	punct	_	SpaceAfter=No
 24	)	_	PUNCT	PUNCT	_	14	punct	_	_
 25	הוא	הוא	VERB	VERB	Gender=Masc|Number=Sing|Person=3|Polarity=Pos|VerbForm=Part|VerbType=Cop	26	cop	_	_
 26	שקר	שקר	NOUN	NOUN	Gender=Masc|Number=Sing	2	conj	_	_
-27-28	וכזב	_	_	_	_	_	_	_	_
+27-28	וכזב	_	_	_	_	_	_	_	SpaceAfter=No
 27	ו	ו	CCONJ	CCONJ	_	28	cc	_	_
 28	כזב	כזב	NOUN	NOUN	Gender=Masc|Number=Sing	26	conj	_	_
 29	.	_	PUNCT	PUNCT	_	2	punct	_	_
 
 # sent_id = 49
-# text = לא היה כאן רצח נזירות , אלא ניסיון לרצח טוהר הנשק של הפלמ"ח בטוהר עט הסופרים של הכותב .
+# text = לא היה כאן רצח נזירות, אלא ניסיון לרצח טוהר הנשק של הפלמ"ח בטוהר עט הסופרים של הכותב.
 1	לא	לא	ADV	ADV	Polarity=Neg	2	advmod	_	_
 2	היה	היה	VERB	VERB	Gender=Masc|Number=Sing|Person=3|Polarity=Pos|Tense=Past|VerbType=Cop	0	root	_	_
 3	כאן	כאן	ADV	ADV	_	2	advmod	_	_
 4	רצח	רצח	NOUN	NOUN	Definite=Cons|Gender=Masc|Number=Sing	2	nsubj	_	_
-5	נזירות	נזירה	NOUN	NOUN	Gender=Fem|Number=Plur	4	compound:smixut	_	_
+5	נזירות	נזירה	NOUN	NOUN	Gender=Fem|Number=Plur	4	compound:smixut	_	SpaceAfter=No
 6	,	_	PUNCT	PUNCT	_	4	punct	_	_
 7	אלא	אלא	CCONJ	CCONJ	_	8	cc	_	_
 8	ניסיון	ניסיון	NOUN	NOUN	Gender=Masc|Number=Sing	4	conj	_	_
@@ -1720,13 +1720,13 @@
 20	ה	ה	DET	DET	PronType=Art	21	det:def	_	_
 21	סופרים	סופר	NOUN	NOUN	Gender=Masc|Number=Plur	19	compound:smixut	_	_
 22	של	של	PART	PART	Case=Gen	24	case:gen	_	_
-23-24	הכותב	_	_	_	_	_	_	_	_
+23-24	הכותב	_	_	_	_	_	_	_	SpaceAfter=No
 23	ה	ה	DET	DET	PronType=Art	24	det:def	_	_
 24	כותב	כותב	NOUN	NOUN	Gender=Masc|Number=Sing	19	nmod:poss	_	_
 25	.	_	PUNCT	PUNCT	_	2	punct	_	_
 
 # sent_id = 50
-# text = הידיעה שפורסמה תחת הכותרת : " הורים בבית הספר בנווה - מונוסון נגד טיול לירושלים ; טוענים : הפגנה פוליטית " ; ( " הארץ " , 0192 ) , הטרידה אותי מאוד .
+# text = הידיעה שפורסמה תחת הכותרת: "הורים בבית הספר בנווה-מונוסון נגד טיול לירושלים; טוענים: הפגנה פוליטית"; ("הארץ", 0192), הטרידה אותי מאוד.
 1-2	הידיעה	_	_	_	_	_	_	_	_
 1	ה	ה	DET	DET	PronType=Art	2	det:def	_	_
 2	ידיעה	ידיעה	NOUN	NOUN	Gender=Fem|Number=Sing	39	nsubj	_	_
@@ -1734,11 +1734,11 @@
 3	ש	ש	SCONJ	SCONJ	_	4	mark	_	_
 4	פורסמה	פורסם	VERB	VERB	Gender=Fem|HebBinyan=PUAL|Number=Sing|Person=3|Tense=Past|Voice=Pass	2	acl:relcl	_	_
 5	תחת	תחת	ADP	ADP	_	7	case	_	_
-6-7	הכותרת	_	_	_	_	_	_	_	_
+6-7	הכותרת	_	_	_	_	_	_	_	SpaceAfter=No
 6	ה	ה	DET	DET	PronType=Art	7	det:def	_	_
 7	כותרת	כותרת	NOUN	NOUN	Gender=Fem|Number=Sing	4	obl	_	_
 8	:	_	PUNCT	PUNCT	_	7	punct	_	_
-9	"	_	PUNCT	PUNCT	_	24	punct	_	_
+9	"	_	PUNCT	PUNCT	_	24	punct	_	SpaceAfter=No
 10	הורים	הורה	NOUN	NOUN	Gender=Masc|Number=Plur	24	nsubj	_	_
 11-12	בבית	_	_	_	_	_	_	_	_
 11	ב	ב	ADP	ADP	_	12	case	_	_
@@ -1746,44 +1746,44 @@
 13-14	הספר	_	_	_	_	_	_	_	_
 13	ה	ה	DET	DET	PronType=Art	14	det:def	_	_
 14	ספר	ספר	NOUN	NOUN	Gender=Masc|Number=Sing	12	compound:smixut	_	_
-15-16	בנווה	_	_	_	_	_	_	_	_
+15-16	בנווה	_	_	_	_	_	_	_	SpaceAfter=No
 15	ב	ב	ADP	ADP	_	16	case	_	_
 16	נווה	נווה	PROPN	PROPN	_	12	nmod	_	_
-17	-	_	PUNCT	PUNCT	_	16	flat:name	_	_
+17	-	_	PUNCT	PUNCT	_	16	flat:name	_	SpaceAfter=No
 18	מונוסון	מונוסון	PROPN	PROPN	_	16	flat:name	_	_
 19	נגד	נגד	ADP	ADP	_	20	case	_	_
 20	טיול	טיול	NOUN	NOUN	Gender=Masc|Number=Sing	10	nmod	_	_
-21-22	לירושלים	_	_	_	_	_	_	_	_
+21-22	לירושלים	_	_	_	_	_	_	_	SpaceAfter=No
 21	ל	ל	ADP	ADP	_	22	case	_	_
 22	ירושלים	ירושלים	PROPN	PROPN	_	20	nmod	_	_
 23	;	_	PUNCT	PUNCT	_	24	punct	_	_
-24	טוענים	טען	VERB	VERB	Gender=Masc|HebBinyan=PAAL|Number=Plur|Person=1,2,3|VerbForm=Part|Voice=Act	7	appos	_	_
+24	טוענים	טען	VERB	VERB	Gender=Masc|HebBinyan=PAAL|Number=Plur|Person=1,2,3|VerbForm=Part|Voice=Act	7	appos	_	SpaceAfter=No
 25	:	_	PUNCT	PUNCT	_	24	punct	_	_
 26	הפגנה	הפגנה	NOUN	NOUN	Gender=Fem|Number=Sing	24	obj	_	_
-27	פוליטית	פוליטי	ADJ	ADJ	Gender=Fem|Number=Sing	26	amod	_	_
-28	"	_	PUNCT	PUNCT	_	24	punct	_	_
+27	פוליטית	פוליטי	ADJ	ADJ	Gender=Fem|Number=Sing	26	amod	_	SpaceAfter=No
+28	"	_	PUNCT	PUNCT	_	24	punct	_	SpaceAfter=No
 29	;	_	PUNCT	PUNCT	_	7	punct	_	_
-30	(	_	PUNCT	PUNCT	_	33	punct	_	_
-31	"	_	PUNCT	PUNCT	_	33	punct	_	_
-32-33	הארץ	_	_	_	_	_	_	_	_
+30	(	_	PUNCT	PUNCT	_	33	punct	_	SpaceAfter=No
+31	"	_	PUNCT	PUNCT	_	33	punct	_	SpaceAfter=No
+32-33	הארץ	_	_	_	_	_	_	_	SpaceAfter=No
 32	ה	ה	DET	DET	PronType=Art	33	det:def	_	_
 33	ארץ	ארץ	NOUN	NOUN	Gender=Fem|Number=Sing	7	appos	_	_
-34	"	_	PUNCT	PUNCT	_	33	punct	_	_
+34	"	_	PUNCT	PUNCT	_	33	punct	_	SpaceAfter=No
 35	,	_	PUNCT	PUNCT	_	33	punct	_	_
-36	0192	_	NUM	NUM	_	33	nummod	_	_
-37	)	_	PUNCT	PUNCT	_	33	punct	_	_
+36	0192	_	NUM	NUM	_	33	nummod	_	SpaceAfter=No
+37	)	_	PUNCT	PUNCT	_	33	punct	_	SpaceAfter=No
 38	,	_	PUNCT	PUNCT	_	39	punct	_	_
 39	הטרידה	הטריד	VERB	VERB	Gender=Fem|HebBinyan=HIFIL|Number=Sing|Person=3|Tense=Past|Voice=Act	0	root	_	_
 40-41	אותי	_	_	_	_	_	_	_	_
 40	את_	את	PART	PART	Case=Acc	41	case:acc	_	_
 41	_אני	הוא	PRON	PRON	Gender=Fem,Masc|Number=Sing|Person=1|PronType=Prs	39	obj	_	_
-42	מאוד	מאוד	ADV	ADV	_	39	advmod	_	_
+42	מאוד	מאוד	ADV	ADV	_	39	advmod	_	SpaceAfter=No
 43	.	_	PUNCT	PUNCT	_	39	punct	_	_
 
 # sent_id = 51
-# text = נילי מנדלר , שמסרה את הידיעה מפי הורים ( אין יודעים אם מדובר בהורה בודד , או בקבוצת הורים מסוימת ) , כתבה כי " אחד ההורים , שהחזיר למנהלת את הספח החוזר שבו הביע התנגדות להשתתפות ילדו בטיול , טען כי " זהו חינוך פוליטי כאשר ילדינו משמשים אמצעי חי להפגנות " .
+# text = נילי מנדלר, שמסרה את הידיעה מפי הורים (אין יודעים אם מדובר בהורה בודד, או בקבוצת הורים מסוימת), כתבה כי "אחד ההורים, שהחזיר למנהלת את הספח החוזר שבו הביע התנגדות להשתתפות ילדו בטיול, טען כי "זהו חינוך פוליטי כאשר ילדינו משמשים אמצעי חי להפגנות".
 1	נילי	נילי	PROPN	PROPN	_	28	nsubj	_	_
-2	מנדלר	מנדלר	PROPN	PROPN	_	1	flat:name	_	_
+2	מנדלר	מנדלר	PROPN	PROPN	_	1	flat:name	_	SpaceAfter=No
 3	,	_	PUNCT	PUNCT	_	1	punct	_	_
 4-5	שמסרה	_	_	_	_	_	_	_	_
 4	ש	ש	SCONJ	SCONJ	_	5	mark	_	_
@@ -1796,7 +1796,7 @@
 9	מ	מ	ADP	ADP	_	11	case	_	_
 10	פי	פה	NOUN	NOUN	Definite=Cons|Gender=Masc|Number=Sing	9	fixed	_	_
 11	הורים	הורה	NOUN	NOUN	Gender=Masc|Number=Plur	8	nmod	_	_
-12	(	_	PUNCT	PUNCT	_	14	punct	_	_
+12	(	_	PUNCT	PUNCT	_	14	punct	_	SpaceAfter=No
 13	אין	_	ADV	ADV	Polarity=Neg	14	advmod	_	_
 14	יודעים	ידע	VERB	VERB	Gender=Masc|HebBinyan=PAAL|Number=Plur|Person=1,2,3|VerbForm=Part|Voice=Act	8	appos	_	_
 15	אם	אם	SCONJ	SCONJ	_	16	mark	_	_
@@ -1804,21 +1804,21 @@
 17-18	בהורה	_	_	_	_	_	_	_	_
 17	ב	ב	ADP	ADP	_	18	case	_	_
 18	הורה	הורה	NOUN	NOUN	Gender=Masc|Number=Sing	16	iobj	_	_
-19	בודד	בודד	ADJ	ADJ	Gender=Masc|Number=Sing	18	amod	_	_
+19	בודד	בודד	ADJ	ADJ	Gender=Masc|Number=Sing	18	amod	_	SpaceAfter=No
 20	,	_	PUNCT	PUNCT	_	18	punct	_	_
 21	או	או	CCONJ	CCONJ	_	23	cc	_	_
 22-23	בקבוצת	_	_	_	_	_	_	_	_
 22	ב	ב	ADP	ADP	_	23	case	_	_
 23	קבוצת	קבוצה	NOUN	NOUN	Definite=Cons|Gender=Fem|Number=Sing	18	conj	_	_
 24	הורים	הורה	NOUN	NOUN	Gender=Masc|Number=Plur	23	compound:smixut	_	_
-25	מסוימת	מסוים	ADJ	ADJ	Gender=Fem|Number=Sing	23	amod	_	_
-26	)	_	PUNCT	PUNCT	_	14	punct	_	_
+25	מסוימת	מסוים	ADJ	ADJ	Gender=Fem|Number=Sing	23	amod	_	SpaceAfter=No
+26	)	_	PUNCT	PUNCT	_	14	punct	_	SpaceAfter=No
 27	,	_	PUNCT	PUNCT	_	28	punct	_	_
 28	כתבה	כתב	VERB	VERB	Gender=Fem|HebBinyan=PAAL|Number=Sing|Person=3|Tense=Past|Voice=Act	0	root	_	_
 29	כי	כי	SCONJ	SCONJ	_	59	mark	_	_
-30	"	_	PUNCT	PUNCT	_	59	punct	_	_
+30	"	_	PUNCT	PUNCT	_	59	punct	_	SpaceAfter=No
 31	אחד	אחד	NUM	NUM	Definite=Cons|Gender=Masc|Number=Sing	33	nummod	_	_
-32-33	ההורים	_	_	_	_	_	_	_	_
+32-33	ההורים	_	_	_	_	_	_	_	SpaceAfter=No
 32	ה	ה	DET	DET	PronType=Art	33	det:def	_	_
 33	הורים	הורה	NOUN	NOUN	Gender=Masc|Number=Plur	59	nsubj	_	_
 34	,	_	PUNCT	PUNCT	_	33	punct	_	_
@@ -1849,14 +1849,14 @@
 52	ילד_	ילד	NOUN	NOUN	Definite=Def|Gender=Masc|Number=Sing	51	compound:smixut	_	_
 53	_של_	של	ADP	ADP	_	54	case:gen	_	_
 54	_הוא	הוא	PRON	PRON	Case=Gen|Gender=Masc|Number=Sing|Person=3|PronType=Prs	52	nmod:poss	_	_
-55-57	בטיול	_	_	_	_	_	_	_	_
+55-57	בטיול	_	_	_	_	_	_	_	SpaceAfter=No
 55	ב	ב	ADP	ADP	_	57	case	_	_
 56	ה_	ה	DET	DET	PronType=Art	57	det:def	_	_
 57	טיול	טיול	NOUN	NOUN	Gender=Masc|Number=Sing	51	nmod	_	_
 58	,	_	PUNCT	PUNCT	_	59	punct	_	_
 59	טען	טען	VERB	VERB	Gender=Masc|HebBinyan=PAAL|Number=Sing|Person=3|Tense=Past|Voice=Act	28	ccomp	_	_
 60	כי	כי	SCONJ	SCONJ	_	63	mark	_	_
-61	"	_	PUNCT	PUNCT	_	63	punct	_	_
+61	"	_	PUNCT	PUNCT	_	63	punct	_	SpaceAfter=No
 62	זהו	זהו	PRON	PRON	Gender=Masc|Number=Sing|Person=3|PronType=Dem	63	nsubj	_	_
 63	חינוך	חינוך	NOUN	NOUN	Gender=Masc|Number=Sing	59	ccomp	_	_
 64	פוליטי	פוליטי	ADJ	ADJ	Gender=Masc|Number=Sing	63	amod	_	_
@@ -1868,17 +1868,17 @@
 69	משמשים	שימש	VERB	VERB	Gender=Masc|HebBinyan=PIEL|Number=Plur|Person=1,2,3|VerbForm=Part|Voice=Act	63	advcl	_	_
 70	אמצעי	אמצעי	NOUN	NOUN	Gender=Masc|Number=Sing	69	obj	_	_
 71	חי	חי	ADJ	ADJ	Gender=Masc|Number=Sing	70	amod	_	_
-72-73	להפגנות	_	_	_	_	_	_	_	_
+72-73	להפגנות	_	_	_	_	_	_	_	SpaceAfter=No
 72	ל	ל	ADP	ADP	_	73	case	_	_
 73	הפגנות	הפגנה	NOUN	NOUN	Gender=Fem|Number=Plur	70	nmod	_	_
-74	"	_	PUNCT	PUNCT	_	59	punct	_	_
+74	"	_	PUNCT	PUNCT	_	59	punct	_	SpaceAfter=No
 75	.	_	PUNCT	PUNCT	_	28	punct	_	_
 
 # sent_id = 52
-# text = לשם איזון הנושא , עלי לציין כי אני נמנה על ההורים שהביעו את הסכמתם לקיום הטיול .
+# text = לשם איזון הנושא, עלי לציין כי אני נמנה על ההורים שהביעו את הסכמתם לקיום הטיול.
 1	לשם	לשם	ADP	ADP	_	2	case	_	_
 2	איזון	איזון	NOUN	NOUN	Definite=Cons|Gender=Masc|Number=Sing	7	nmod	_	_
-3-4	הנושא	_	_	_	_	_	_	_	_
+3-4	הנושא	_	_	_	_	_	_	_	SpaceAfter=No
 3	ה	ה	DET	DET	PronType=Art	4	det:def	_	_
 4	נושא	נושא	NOUN	NOUN	Gender=Masc|Number=Sing	2	compound:smixut	_	_
 5	,	_	PUNCT	PUNCT	_	7	punct	_	_
@@ -1904,13 +1904,13 @@
 21-22	לקיום	_	_	_	_	_	_	_	_
 21	ל	ל	ADP	ADP	_	22	case	_	_
 22	קיום	קיום	NOUN	NOUN	Definite=Cons|Gender=Masc|Number=Sing	18	nmod	_	_
-23-24	הטיול	_	_	_	_	_	_	_	_
+23-24	הטיול	_	_	_	_	_	_	_	SpaceAfter=No
 23	ה	ה	DET	DET	PronType=Art	24	det:def	_	_
 24	טיול	טיול	NOUN	NOUN	Gender=Masc|Number=Sing	22	compound:smixut	_	_
 25	.	_	PUNCT	PUNCT	_	7	punct	_	_
 
 # sent_id = 53
-# text = לא רק שאין זה עניין פוליטי אלא זה נושא חינוכי - לאומי ממדרגה ראשונה .
+# text = לא רק שאין זה עניין פוליטי אלא זה נושא חינוכי - לאומי ממדרגה ראשונה.
 1	לא	לא	ADV	ADV	Polarity=Neg	2	advmod	_	_
 2	רק	רק	ADV	ADV	_	6	advmod	_	_
 3-4	שאין	_	_	_	_	_	_	_	_
@@ -1928,11 +1928,11 @@
 14-15	ממדרגה	_	_	_	_	_	_	_	_
 14	מ	מ	ADP	ADP	_	15	case	_	_
 15	מדרגה	מדרגה	NOUN	NOUN	Gender=Fem|Number=Sing	10	nmod	_	_
-16	ראשונה	_	ADJ	ADJ	Gender=Fem|Number=Sing	15	amod	_	_
+16	ראשונה	_	ADJ	ADJ	Gender=Fem|Number=Sing	15	amod	_	SpaceAfter=No
 17	.	_	PUNCT	PUNCT	_	6	punct	_	_
 
 # sent_id = 54
-# text = אני גם מוכן להסתכן ולשער כי ההורה , או קבוצת ההורים שהתנגדה לטיול , מסתתרים תחת המעטה של טיעון פוליטי נבוב ולמעשה הם פוחדים לשלוח את ילדיהם שמא איזה ערבי ינעץ בהם סכין בגב .
+# text = אני גם מוכן להסתכן ולשער כי ההורה, או קבוצת ההורים שהתנגדה לטיול, מסתתרים תחת המעטה של טיעון פוליטי נבוב ולמעשה הם פוחדים לשלוח את ילדיהם שמא איזה ערבי ינעץ בהם סכין בגב.
 1	אני	הוא	PRON	PRON	Gender=Fem,Masc|Number=Sing|Person=1|PronType=Prs	3	nsubj	_	_
 2	גם	גם	ADV	ADV	_	3	advmod	_	_
 3	מוכן	מוכן	AUX	AUX	Gender=Masc|Number=Sing|Person=1,2,3|VerbType=Mod	0	root	_	_
@@ -1941,7 +1941,7 @@
 5	ו	ו	CCONJ	CCONJ	_	6	cc	_	_
 6	לשער	שיער	VERB	VERB	HebBinyan=PIEL|VerbForm=Inf|Voice=Act	4	conj	_	_
 7	כי	כי	SCONJ	SCONJ	_	21	mark	_	_
-8-9	ההורה	_	_	_	_	_	_	_	_
+8-9	ההורה	_	_	_	_	_	_	_	SpaceAfter=No
 8	ה	ה	DET	DET	PronType=Art	9	det:def	_	_
 9	הורה	הורה	NOUN	NOUN	Gender=Masc|Number=Sing	21	nsubj	_	_
 10	,	_	PUNCT	PUNCT	_	9	punct	_	_
@@ -1953,7 +1953,7 @@
 15-16	שהתנגדה	_	_	_	_	_	_	_	_
 15	ש	ש	SCONJ	SCONJ	_	16	mark	_	_
 16	התנגדה	התנגד	VERB	VERB	Gender=Fem|HebBinyan=HITPAEL|Number=Sing|Person=3|Tense=Past	12	acl:relcl	_	_
-17-19	לטיול	_	_	_	_	_	_	_	_
+17-19	לטיול	_	_	_	_	_	_	_	SpaceAfter=No
 17	ל	ל	ADP	ADP	_	19	case	_	_
 18	ה_	ה	DET	DET	PronType=Art	19	det:def	_	_
 19	טיול	טיול	NOUN	NOUN	Gender=Masc|Number=Sing	16	iobj	_	_
@@ -1986,18 +1986,18 @@
 42	בהם	ב	ADP	ADP	_	43	case	_	_
 43	_הם	הוא	PRON	PRON	Gender=Masc|Number=Plur|Person=3|PronType=Prs	41	obl	_	_
 44	סכין	סכין	NOUN	NOUN	Gender=Fem,Masc|Number=Sing	41	obj	_	_
-45-47	בגב	_	_	_	_	_	_	_	_
+45-47	בגב	_	_	_	_	_	_	_	SpaceAfter=No
 45	ב	ב	ADP	ADP	_	47	case	_	_
 46	ה_	ה	DET	DET	PronType=Art	47	det:def	_	_
 47	גב	גב	NOUN	NOUN	Gender=Masc|Number=Sing	41	obl	_	_
 48	.	_	PUNCT	PUNCT	_	3	punct	_	_
 
 # sent_id = 55
-# text = אני מוכן , ורוצה , לשלוח את הילד שלי לירושלים עם זר פרחים ועם קופסת ממתקים , כדי להביע הוקרה ועידוד לנכד של אבא קובנר , שחטף סכין בראש מידי אותו מרצח שפל שדקר למוות שלושה יהודים בשכונת בקעה .
+# text = אני מוכן, ורוצה, לשלוח את הילד שלי לירושלים עם זר פרחים ועם קופסת ממתקים, כדי להביע הוקרה ועידוד לנכד של אבא קובנר, שחטף סכין בראש מידי אותו מרצח שפל שדקר למוות שלושה יהודים בשכונת בקעה.
 1	אני	הוא	PRON	PRON	Gender=Fem,Masc|Number=Sing|Person=1|PronType=Prs	2	nsubj	_	_
-2	מוכן	מוכן	AUX	AUX	Gender=Masc|Number=Sing|Person=1,2,3|VerbType=Mod	0	root	_	_
+2	מוכן	מוכן	AUX	AUX	Gender=Masc|Number=Sing|Person=1,2,3|VerbType=Mod	0	root	_	SpaceAfter=No
 3	,	_	PUNCT	PUNCT	_	2	punct	_	_
-4-5	ורוצה	_	_	_	_	_	_	_	_
+4-5	ורוצה	_	_	_	_	_	_	_	SpaceAfter=No
 4	ו	ו	CCONJ	CCONJ	_	5	cc	_	_
 5	רוצה	רצה	VERB	VERB	Gender=Masc|HebBinyan=PAAL|Number=Sing|Person=1,2,3|VerbForm=Part|Voice=Act	2	conj	_	_
 6	,	_	PUNCT	PUNCT	_	2	punct	_	_
@@ -2019,7 +2019,7 @@
 18	ו	ו	CCONJ	CCONJ	_	20	cc	_	_
 19	עם	עם	ADP	ADP	_	20	case	_	_
 20	קופסת	קופסה	NOUN	NOUN	Definite=Cons|Gender=Fem|Number=Sing	16	conj	_	_
-21	ממתקים	ממתק	NOUN	NOUN	Gender=Masc|Number=Plur	20	compound:smixut	_	_
+21	ממתקים	ממתק	NOUN	NOUN	Gender=Masc|Number=Plur	20	compound:smixut	_	SpaceAfter=No
 22	,	_	PUNCT	PUNCT	_	7	punct	_	_
 23	כדי	_	ADP	ADP	_	24	case	_	_
 24	להביע	הביע	VERB	VERB	HebBinyan=HIFIL|VerbForm=Inf|Voice=Act	7	advcl	_	_
@@ -2033,7 +2033,7 @@
 30	נכד	נכד	NOUN	NOUN	Gender=Masc|Number=Sing	24	obl	_	_
 31	של	של	PART	PART	Case=Gen	32	case:gen	_	_
 32	אבא	אבא	PROPN	PROPN	_	30	nmod:poss	_	_
-33	קובנר	קובנר	PROPN	PROPN	_	32	flat:name	_	_
+33	קובנר	קובנר	PROPN	PROPN	_	32	flat:name	_	SpaceAfter=No
 34	,	_	PUNCT	PUNCT	_	30	punct	_	_
 35-36	שחטף	_	_	_	_	_	_	_	_
 35	ש	ש	SCONJ	SCONJ	_	36	mark	_	_
@@ -2059,11 +2059,11 @@
 52-53	בשכונת	_	_	_	_	_	_	_	_
 52	ב	ב	ADP	ADP	_	53	case	_	_
 53	שכונת	שכונה	NOUN	NOUN	Definite=Cons|Gender=Fem|Number=Sing	46	obl	_	_
-54	בקעה	בקעה	NOUN	NOUN	Gender=Fem|Number=Sing	53	compound:smixut	_	_
+54	בקעה	בקעה	NOUN	NOUN	Gender=Fem|Number=Sing	53	compound:smixut	_	SpaceAfter=No
 55	.	_	PUNCT	PUNCT	_	2	punct	_	_
 
 # sent_id = 56
-# text = אני רוצה שהילד שלי יסתכל בעיניים של הילד הפגוע ויגיד לו : " אתה לא לבדך בירושלים , כי גם אנחנו הגרים בנווה - מונסון , אתך בלב איתן ביחד " .
+# text = אני רוצה שהילד שלי יסתכל בעיניים של הילד הפגוע ויגיד לו: "אתה לא לבדך בירושלים, כי גם אנחנו הגרים בנווה - מונסון, אתך בלב איתן ביחד".
 1	אני	הוא	PRON	PRON	Gender=Fem,Masc|Number=Sing|Person=1|PronType=Prs	2	dep	_	_
 2	רוצה	רצה	VERB	VERB	Gender=Masc|HebBinyan=PAAL|Number=Sing|Person=1,2,3|VerbForm=Part|Voice=Act	0	root	_	_
 3-5	שהילד	_	_	_	_	_	_	_	_
@@ -2088,15 +2088,15 @@
 17-18	ויגיד	_	_	_	_	_	_	_	_
 17	ו	ו	CCONJ	CCONJ	_	18	cc	_	_
 18	יגיד	הגיד	VERB	VERB	Gender=Masc|HebBinyan=HIFIL|Number=Sing|Person=3|Tense=Fut|Voice=Act	8	conj	_	_
-19-20	לו	_	_	_	_	_	_	_	_
+19-20	לו	_	_	_	_	_	_	_	SpaceAfter=No
 19	לו	ל	ADP	ADP	_	20	case	_	_
 20	_הוא	הוא	PRON	PRON	Gender=Masc|Number=Sing|Person=3|PronType=Prs	18	obl	_	_
 21	:	_	PUNCT	PUNCT	_	25	punct	_	_
-22	"	_	PUNCT	PUNCT	_	25	punct	_	_
+22	"	_	PUNCT	PUNCT	_	25	punct	_	SpaceAfter=No
 23	אתה	הוא	PRON	PRON	Gender=Masc|Number=Sing|Person=2|PronType=Prs	25	nsubj	_	_
 24	לא	לא	ADV	ADV	Polarity=Neg	25	advmod	_	_
 25	לבדך	_	ADJ	ADJ	_	18	ccomp	_	_
-26-27	בירושלים	_	_	_	_	_	_	_	_
+26-27	בירושלים	_	_	_	_	_	_	_	SpaceAfter=No
 26	ב	ב	ADP	ADP	_	27	case	_	_
 27	ירושלים	ירושלים	PROPN	PROPN	_	25	advmod	_	_
 28	,	_	PUNCT	PUNCT	_	25	punct	_	_
@@ -2110,7 +2110,7 @@
 34	ב	ב	ADP	ADP	_	35	case	_	_
 35	נווה	נווה	PROPN	PROPN	_	33	obl	_	_
 36	-	_	PUNCT	PUNCT	_	35	flat:name	_	_
-37	מונסון	מונסון	NOUN	NOUN	Gender=Masc|Number=Sing	35	flat:name	_	_
+37	מונסון	מונסון	NOUN	NOUN	Gender=Masc|Number=Sing	35	flat:name	_	SpaceAfter=No
 38	,	_	PUNCT	PUNCT	_	40	punct	_	_
 39-40	אתך	_	_	_	_	_	_	_	_
 39	אתך	את	ADP	ADP	_	40	case	_	_
@@ -2119,12 +2119,12 @@
 41	ב	ב	ADP	ADP	_	42	case	_	_
 42	לב	לב	NOUN	NOUN	Gender=Masc|HebSource=ConvUncertainHead|Number=Sing	40	dep	_	_
 43	איתן	איתן	ADJ	ADJ	Gender=Masc|Number=Sing	42	amod	_	_
-44	ביחד	ביחד	ADV	ADV	HebSource=ConvUncertainHead	40	dep	_	_
-45	"	_	PUNCT	PUNCT	_	25	punct	_	_
+44	ביחד	ביחד	ADV	ADV	HebSource=ConvUncertainHead	40	dep	_	SpaceAfter=No
+45	"	_	PUNCT	PUNCT	_	25	punct	_	SpaceAfter=No
 46	.	_	PUNCT	PUNCT	_	2	punct	_	_
 
 # sent_id = 57
-# text = אני מוכן להעיד כי גם אבי ז"ל , שלקח אותי באוטובוס לירושלים בשנת תרצ"ח כאשר הערבים ירו על כביש באב אל - ואד , אמר לי : " אלי ! אם תשמע יריות תתכופף , אבל אל תפחד " .
+# text = אני מוכן להעיד כי גם אבי ז"ל, שלקח אותי באוטובוס לירושלים בשנת תרצ"ח כאשר הערבים ירו על כביש באב אל-ואד, אמר לי: "אלי! אם תשמע יריות תתכופף, אבל אל תפחד".
 1	אני	הוא	PRON	PRON	Gender=Fem,Masc|Number=Sing|Person=1|PronType=Prs	2	nsubj	_	_
 2	מוכן	מוכן	AUX	AUX	Gender=Masc|Number=Sing|Person=1,2,3|VerbType=Mod	0	root	_	_
 3	להעיד	העיד	VERB	VERB	HebBinyan=HIFIL|VerbForm=Inf|Voice=Act	2	xcomp	_	_
@@ -2134,7 +2134,7 @@
 6	אב_	אב	NOUN	NOUN	Definite=Def|Gender=Masc|Number=Sing	33	nsubj	_	_
 7	_של_	של	ADP	ADP	_	8	case:gen	_	_
 8	_אני	הוא	PRON	PRON	Case=Gen|Gender=Fem,Masc|Number=Sing|Person=1|PronType=Prs	6	nmod:poss	_	_
-9	ז"ל	ז"ל	ADJ	ADJ	Abbr=Yes|Gender=Masc|HebSource=ConvUncertainLabel|Number=Sing	6	nmod	_	_
+9	ז"ל	ז"ל	ADJ	ADJ	Abbr=Yes|Gender=Masc|HebSource=ConvUncertainLabel|Number=Sing	6	nmod	_	SpaceAfter=No
 10	,	_	PUNCT	PUNCT	_	6	punct	_	_
 11-12	שלקח	_	_	_	_	_	_	_	_
 11	ש	ש	SCONJ	SCONJ	_	12	mark	_	_
@@ -2160,31 +2160,31 @@
 26	על	על	ADP	ADP	_	27	case	_	_
 27	כביש	כביש	NOUN	NOUN	Definite=Cons|Gender=Masc|Number=Sing	25	obl	_	_
 28	באב	באב	PROPN	PROPN	_	27	compound:smixut	_	_
-29	אל	אל	PROPN	PROPN	_	28	flat:name	_	_
-30	-	_	PUNCT	PUNCT	_	28	flat:name	_	_
-31	ואד	ואד	PROPN	PROPN	_	28	flat:name	_	_
+29	אל	אל	PROPN	PROPN	_	28	flat:name	_	SpaceAfter=No
+30	-	_	PUNCT	PUNCT	_	28	flat:name	_	SpaceAfter=No
+31	ואד	ואד	PROPN	PROPN	_	28	flat:name	_	SpaceAfter=No
 32	,	_	PUNCT	PUNCT	_	33	punct	_	_
 33	אמר	אמר	VERB	VERB	Gender=Masc|HebBinyan=PAAL|Number=Sing|Person=3|Tense=Past|Voice=Act	3	ccomp	_	_
-34-35	לי	_	_	_	_	_	_	_	_
+34-35	לי	_	_	_	_	_	_	_	SpaceAfter=No
 34	לי	ל	ADP	ADP	_	35	case	_	_
 35	_אני	הוא	PRON	PRON	Gender=Fem,Masc|Number=Sing|Person=1|PronType=Prs	33	obl	_	_
 36	:	_	PUNCT	PUNCT	_	43	punct	_	_
-37	"	_	PUNCT	PUNCT	_	43	punct	_	_
-38	אלי	אלי	PROPN	PROPN	_	43	obl	_	_
+37	"	_	PUNCT	PUNCT	_	43	punct	_	SpaceAfter=No
+38	אלי	אלי	PROPN	PROPN	_	43	obl	_	SpaceAfter=No
 39	!	_	PUNCT	PUNCT	_	43	punct	_	_
 40	אם	אם	SCONJ	SCONJ	_	41	mark	_	_
 41	תשמע	שמע	VERB	VERB	Gender=Masc|HebBinyan=PAAL|Number=Sing|Person=2|Tense=Fut|Voice=Act	43	advcl	_	_
 42	יריות	ירייה	NOUN	NOUN	Gender=Fem|Number=Plur	41	obj	_	_
-43	תתכופף	התכופף	VERB	VERB	Gender=Masc|HebBinyan=HITPAEL|Number=Sing|Person=2|Tense=Fut	33	ccomp	_	_
+43	תתכופף	התכופף	VERB	VERB	Gender=Masc|HebBinyan=HITPAEL|Number=Sing|Person=2|Tense=Fut	33	ccomp	_	SpaceAfter=No
 44	,	_	PUNCT	PUNCT	_	43	punct	_	_
 45	אבל	אבל	CCONJ	CCONJ	_	47	cc	_	_
 46	אל	_	ADV	ADV	_	47	advmod	_	_
-47	תפחד	פחד	VERB	VERB	Gender=Masc|Number=Sing|Person=2|Tense=Fut	43	conj	_	_
-48	"	_	PUNCT	PUNCT	_	43	punct	_	_
+47	תפחד	פחד	VERB	VERB	Gender=Masc|Number=Sing|Person=2|Tense=Fut	43	conj	_	SpaceAfter=No
+48	"	_	PUNCT	PUNCT	_	43	punct	_	SpaceAfter=No
 49	.	_	PUNCT	PUNCT	_	2	punct	_	_
 
 # sent_id = 58
-# text = ולכן אני אומר לכל ילדי ישראל : אל תפחדו ! סעו לירושלים , אפילו אם יורים או אם מתעופפים שם סכינים .
+# text = ולכן אני אומר לכל ילדי ישראל: אל תפחדו! סעו לירושלים, אפילו אם יורים או אם מתעופפים שם סכינים.
 1-2	ולכן	_	_	_	_	_	_	_	_
 1	ו	ו	CCONJ	CCONJ	_	0	root	_	_
 2	לכן	לכן	CCONJ	CCONJ	_	4	cc	_	_
@@ -2194,13 +2194,13 @@
 5	ל	ל	ADP	ADP	_	7	case	_	_
 6	כל	כול	DET	DET	Definite=Cons	7	det	_	_
 7	ילדי	ילד	NOUN	NOUN	Definite=Cons|Gender=Masc|Number=Plur	4	iobj	_	_
-8	ישראל	ישראל	PROPN	PROPN	_	7	compound:smixut	_	_
+8	ישראל	ישראל	PROPN	PROPN	_	7	compound:smixut	_	SpaceAfter=No
 9	:	_	PUNCT	PUNCT	_	11	punct	_	_
 10	אל	_	ADV	ADV	_	11	advmod	_	_
-11	תפחדו	פחד	VERB	VERB	Gender=Fem,Masc|Number=Plur|Person=2|Tense=Fut	4	ccomp	_	_
+11	תפחדו	פחד	VERB	VERB	Gender=Fem,Masc|Number=Plur|Person=2|Tense=Fut	4	ccomp	_	SpaceAfter=No
 12	!	_	PUNCT	PUNCT	_	11	punct	_	_
 13	סעו	נסע	VERB	VERB	Gender=Fem,Masc|HebBinyan=PAAL|Mood=Imp|Number=Plur|Person=2|Voice=Act	11	conj:discourse	_	_
-14-15	לירושלים	_	_	_	_	_	_	_	_
+14-15	לירושלים	_	_	_	_	_	_	_	SpaceAfter=No
 14	ל	ל	ADP	ADP	_	15	case	_	_
 15	ירושלים	ירושלים	PROPN	PROPN	HebSource=ConvUncertainHead	13	dep	_	_
 16	,	_	PUNCT	PUNCT	HebSource=ConvUncertainHead	13	dep	_	_
@@ -2211,11 +2211,11 @@
 21	אם	אם	SCONJ	SCONJ	_	22	mark	_	_
 22	מתעופפים	התעופף	VERB	VERB	Gender=Masc|HebBinyan=HITPAEL|Number=Plur|Person=1,2,3|VerbForm=Part	19	conj	_	_
 23	שם	שם	ADV	ADV	_	22	advmod	_	_
-24	סכינים	סכין	NOUN	NOUN	Gender=Fem,Masc|Number=Plur	22	nsubj	_	_
+24	סכינים	סכין	NOUN	NOUN	Gender=Fem,Masc|Number=Plur	22	nsubj	_	SpaceAfter=No
 25	.	_	PUNCT	PUNCT	_	1	punct	_	_
 
 # sent_id = 59
-# text = הפטיש הכבד שהנחית הפועל הערבי על ראשיהם של מעסיקו וחברו , הסכין שידו של איש המרכול תקעה באחד הספקים , ורצח המסעדן בעין כרם זה לא מכבר על - ידי אחד מעובדיו , אף הוא ערבי , מעלה מנבכי הזיכרון את הפתגם : " המגדל נחש שפיפון בביתו , אל יופתע אם ימצא עצמו מוכש " .
+# text = הפטיש הכבד שהנחית הפועל הערבי על ראשיהם של מעסיקו וחברו, הסכין שידו של איש המרכול תקעה באחד הספקים, ורצח המסעדן בעין כרם זה לא מכבר על-ידי אחד מעובדיו, אף הוא ערבי, מעלה מנבכי הזיכרון את הפתגם: "המגדל נחש שפיפון בביתו, אל יופתע אם ימצא עצמו מוכש".
 1-2	הפטיש	_	_	_	_	_	_	_	_
 1	ה	ה	DET	DET	PronType=Art	2	det:def	_	_
 2	פטיש	פטיש	NOUN	NOUN	Gender=Masc|Number=Sing	64	nsubj	_	_
@@ -2241,7 +2241,7 @@
 16	מעסיק_	מעסיק	NOUN	NOUN	Definite=Def|Gender=Masc|Number=Sing	12	nmod:poss	_	_
 17	_של_	של	ADP	ADP	_	18	case:gen	_	_
 18	_הוא	הוא	PRON	PRON	Case=Gen|Gender=Masc|Number=Sing|Person=3|PronType=Prs	16	nmod:poss	_	_
-19-22	וחברו	_	_	_	_	_	_	_	_
+19-22	וחברו	_	_	_	_	_	_	_	SpaceAfter=No
 19	ו	ו	CCONJ	CCONJ	_	20	cc	_	_
 20	חבר_	חבר	NOUN	NOUN	Definite=Def|Gender=Masc|Number=Sing	16	conj	_	_
 21	_של_	של	ADP	ADP	_	22	case:gen	_	_
@@ -2264,7 +2264,7 @@
 35-36	באחד	_	_	_	_	_	_	_	_
 35	ב	ב	ADP	ADP	_	38	case	_	_
 36	אחד	אחד	NUM	NUM	Definite=Cons|Gender=Masc|Number=Sing	38	nummod	_	_
-37-38	הספקים	_	_	_	_	_	_	_	_
+37-38	הספקים	_	_	_	_	_	_	_	SpaceAfter=No
 37	ה	ה	DET	DET	PronType=Art	38	det:def	_	_
 38	ספקים	ספק	NOUN	NOUN	Gender=Masc|Number=Plur	34	iobj	_	_
 39	,	_	PUNCT	PUNCT	_	2	punct	_	_
@@ -2283,11 +2283,11 @@
 49-50	מכבר	_	_	_	_	_	_	_	_
 49	מ	מ	ADP	ADP	_	47	fixed	_	_
 50	כבר	כבר	ADV	ADV	_	47	fixed	_	_
-51	על	על	ADP	ADP	_	56	case	_	_
-52	-	_	PUNCT	PUNCT	_	51	fixed	_	_
+51	על	על	ADP	ADP	_	56	case	_	SpaceAfter=No
+52	-	_	PUNCT	PUNCT	_	51	fixed	_	SpaceAfter=No
 53	ידי	יד	NOUN	NOUN	Definite=Cons|Gender=Fem|Number=Plur	51	fixed	_	_
 54	אחד	אחד	NUM	NUM	Gender=Masc|Number=Sing	56	det	_	_
-55-58	מעובדיו	_	_	_	_	_	_	_	_
+55-58	מעובדיו	_	_	_	_	_	_	_	SpaceAfter=No
 55	מ	מ	ADP	ADP	_	56	case	_	_
 56	עובד_	עובד	NOUN	NOUN	Definite=Def|Gender=Masc|Number=Plur	41	nmod	_	_
 57	_של_	של	ADP	ADP	_	58	case:gen	_	_
@@ -2295,7 +2295,7 @@
 59	,	_	PUNCT	PUNCT	_	62	punct	_	_
 60	אף	אף	CCONJ	CCONJ	_	61	det	_	_
 61	הוא	הוא	PRON	PRON	Gender=Masc|Number=Sing|Person=3|PronType=Prs	62	nsubj	_	_
-62	ערבי	ערבי	NOUN	NOUN	Gender=Masc|Number=Sing	56	appos	_	_
+62	ערבי	ערבי	NOUN	NOUN	Gender=Masc|Number=Sing	56	appos	_	SpaceAfter=No
 63	,	_	PUNCT	PUNCT	_	62	punct	_	_
 64	מעלה	העלה	VERB	VERB	Gender=Masc|HebBinyan=HIFIL|Number=Sing|Person=1,2,3|VerbForm=Part|Voice=Act	0	root	_	_
 65-66	מנבכי	_	_	_	_	_	_	_	_
@@ -2305,17 +2305,17 @@
 67	ה	ה	DET	DET	PronType=Art	68	det:def	_	_
 68	זיכרון	זיכרון	NOUN	NOUN	Gender=Masc|Number=Sing	66	compound:smixut	_	_
 69	את	את	PART	PART	Case=Acc	71	case:acc	_	_
-70-71	הפתגם	_	_	_	_	_	_	_	_
+70-71	הפתגם	_	_	_	_	_	_	_	SpaceAfter=No
 70	ה	ה	DET	DET	PronType=Art	71	det:def	_	_
 71	פתגם	פתגם	NOUN	NOUN	Gender=Masc|Number=Sing	64	obj	_	_
 72	:	_	PUNCT	PUNCT	_	84	punct	_	_
-73	"	_	PUNCT	PUNCT	_	84	punct	_	_
+73	"	_	PUNCT	PUNCT	_	84	punct	_	SpaceAfter=No
 74-75	המגדל	_	_	_	_	_	_	_	_
 74	ה	ה	SCONJ	SCONJ	_	75	mark	_	_
 75	מגדל	גידל	VERB	VERB	Gender=Masc|HebBinyan=PIEL|Number=Sing|Person=1,2,3|VerbForm=Part|Voice=Act	84	csubj	_	_
 76	נחש	נחש	NOUN	NOUN	Definite=Cons|Gender=Masc|Number=Sing	75	obj	_	_
 77	שפיפון	שפיפון	NOUN	NOUN	Gender=Masc|Number=Sing	76	compound:smixut	_	_
-78-81	בביתו	_	_	_	_	_	_	_	_
+78-81	בביתו	_	_	_	_	_	_	_	SpaceAfter=No
 78	ב	ב	ADP	ADP	_	79	case	_	_
 79	בית_	בית	NOUN	NOUN	Definite=Def|Gender=Masc|Number=Sing	75	obl	_	_
 80	_של_	של	ADP	ADP	_	81	case:gen	_	_
@@ -2326,12 +2326,12 @@
 85	אם	אם	SCONJ	SCONJ	_	86	mark	_	_
 86	ימצא	מצא	VERB	VERB	Gender=Masc|HebBinyan=PAAL|Number=Sing|Person=3|Tense=Fut|Voice=Act	84	advcl	_	_
 87	עצמו	עצמו	PRON	PRON	Gender=Masc|Number=Sing|Person=3|PronType=Prs|Reflex=Yes	86	obj	_	_
-88	מוכש	הוכש	VERB	VERB	Gender=Masc|HebBinyan=HUFAL|Number=Sing|Person=1,2,3|VerbForm=Part|Voice=Pass	86	advmod	_	_
-89	"	_	PUNCT	PUNCT	_	84	punct	_	_
+88	מוכש	הוכש	VERB	VERB	Gender=Masc|HebBinyan=HUFAL|Number=Sing|Person=1,2,3|VerbForm=Part|Voice=Pass	86	advmod	_	SpaceAfter=No
+89	"	_	PUNCT	PUNCT	_	84	punct	_	SpaceAfter=No
 90	.	_	PUNCT	PUNCT	_	64	punct	_	_
 
 # sent_id = 60
-# text = אני כותב זאת בצער וברגשי אשם ; פעם חשבתי אחרת ( על הערבים , לא על הנחשים ) .
+# text = אני כותב זאת בצער וברגשי אשם; פעם חשבתי אחרת (על הערבים, לא על הנחשים).
 1	אני	הוא	PRON	PRON	Gender=Fem,Masc|Number=Sing|Person=1|PronType=Prs	2	nsubj	_	_
 2	כותב	כתב	VERB	VERB	Gender=Masc|HebBinyan=PAAL|Number=Sing|Person=1,2,3|VerbForm=Part|Voice=Act	0	root	_	_
 3	זאת	זאת	PRON	PRON	Gender=Fem|Number=Sing|Person=3|PronType=Dem	2	obj	_	_
@@ -2342,36 +2342,36 @@
 6	ו	ו	CCONJ	CCONJ	_	8	cc	_	_
 7	ב	ב	ADP	ADP	_	8	case	_	_
 8	רגשי	_	NOUN	NOUN	Definite=Cons	5	conj	_	_
-9	אשם	אשם	NOUN	NOUN	Gender=Masc|Number=Sing	8	compound:smixut	_	_
+9	אשם	אשם	NOUN	NOUN	Gender=Masc|Number=Sing	8	compound:smixut	_	SpaceAfter=No
 10	;	_	PUNCT	PUNCT	_	12	cc	_	_
 11	פעם	פעם	ADV	ADV	_	12	advmod	_	_
 12	חשבתי	חשב	VERB	VERB	Gender=Fem,Masc|Number=Sing|Person=1|Tense=Past	2	conj	_	_
 13	אחרת	אחרת	ADV	ADV	_	12	advmod	_	_
-14	(	_	PUNCT	PUNCT	_	17	punct	_	_
+14	(	_	PUNCT	PUNCT	_	17	punct	_	SpaceAfter=No
 15	על	על	ADP	ADP	_	17	case	_	_
-16-17	הערבים	_	_	_	_	_	_	_	_
+16-17	הערבים	_	_	_	_	_	_	_	SpaceAfter=No
 16	ה	ה	DET	DET	PronType=Art	17	det:def	_	_
 17	ערבים	ערבי	NOUN	NOUN	Gender=Masc|Number=Plur	12	parataxis	_	_
 18	,	_	PUNCT	PUNCT	_	17	punct	_	_
 19	לא	לא	ADV	ADV	Polarity=Neg	20	advmod	_	_
 20	על	על	ADP	ADP	_	22	case	_	_
-21-22	הנחשים	_	_	_	_	_	_	_	_
+21-22	הנחשים	_	_	_	_	_	_	_	SpaceAfter=No
 21	ה	ה	DET	DET	PronType=Art	22	det:def	_	_
 22	נחשים	נחש	NOUN	NOUN	Gender=Masc|HebSource=ConvUncertainHead|Number=Plur	17	dep	_	_
-23	)	_	PUNCT	PUNCT	_	17	punct	_	_
+23	)	_	PUNCT	PUNCT	_	17	punct	_	SpaceAfter=No
 24	.	_	PUNCT	PUNCT	_	2	punct	_	_
 
 # sent_id = 61
-# text = מסתבר שהייתי תמים .
+# text = מסתבר שהייתי תמים.
 1	מסתבר	הסתבר	VERB	VERB	Gender=Masc|HebBinyan=HITPAEL|Number=Sing|Person=1,2,3|VerbForm=Part	0	root	_	_
 2-3	שהייתי	_	_	_	_	_	_	_	_
 2	ש	ש	SCONJ	SCONJ	_	4	mark	_	_
 3	הייתי	היה	VERB	VERB	Gender=Fem,Masc|Number=Sing|Person=1|Polarity=Pos|Tense=Past|VerbType=Cop	4	aux	_	_
-4	תמים	תמים	ADJ	ADJ	Gender=Masc|Number=Sing	1	advcl	_	_
+4	תמים	תמים	ADJ	ADJ	Gender=Masc|Number=Sing	1	advcl	_	SpaceAfter=No
 5	.	_	PUNCT	PUNCT	_	1	punct	_	_
 
 # sent_id = 62
-# text = מאמר המערכת שהתפרסם תחת הכותרת " יחדל נא מילוא להתלבט " ( " הארץ " , 111 ) , תובע למצות את הדין עם המפכ"ל וקציני המשטרה הבכירים בגלל מחדליהם באירועי הר הבית .
+# text = מאמר המערכת שהתפרסם תחת הכותרת "יחדל נא מילוא להתלבט" ("הארץ", 111), תובע למצות את הדין עם המפכ"ל וקציני המשטרה הבכירים בגלל מחדליהם באירועי הר הבית.
 1	מאמר	מאמר	NOUN	NOUN	Definite=Cons|Gender=Masc|Number=Sing	24	nsubj	_	_
 2-3	המערכת	_	_	_	_	_	_	_	_
 2	ה	ה	DET	DET	PronType=Art	3	det:def	_	_
@@ -2383,21 +2383,21 @@
 7-8	הכותרת	_	_	_	_	_	_	_	_
 7	ה	ה	DET	DET	PronType=Art	8	det:def	_	_
 8	כותרת	כותרת	NOUN	NOUN	Gender=Fem|Number=Sing	5	obl	_	_
-9	"	_	PUNCT	PUNCT	_	10	punct	_	_
+9	"	_	PUNCT	PUNCT	_	10	punct	_	SpaceAfter=No
 10	יחדל	חדל	VERB	VERB	Gender=Masc|HebBinyan=PAAL|Number=Sing|Person=3|Tense=Fut|Voice=Act	8	appos	_	_
 11	נא	נא	INTJ	INTJ	_	10	advmod	_	_
 12	מילוא	מילוא	NOUN	NOUN	Gender=Masc|Number=Sing	10	nsubj	_	_
-13	להתלבט	התלבט	VERB	VERB	HebBinyan=HITPAEL|VerbForm=Inf	10	xcomp	_	_
+13	להתלבט	התלבט	VERB	VERB	HebBinyan=HITPAEL|VerbForm=Inf	10	xcomp	_	SpaceAfter=No
 14	"	_	PUNCT	PUNCT	_	10	punct	_	_
-15	(	_	PUNCT	PUNCT	_	18	punct	_	_
-16	"	_	PUNCT	PUNCT	_	18	punct	_	_
-17-18	הארץ	_	_	_	_	_	_	_	_
+15	(	_	PUNCT	PUNCT	_	18	punct	_	SpaceAfter=No
+16	"	_	PUNCT	PUNCT	_	18	punct	_	SpaceAfter=No
+17-18	הארץ	_	_	_	_	_	_	_	SpaceAfter=No
 17	ה	ה	DET	DET	PronType=Art	18	det:def	_	_
 18	ארץ	ארץ	NOUN	NOUN	Gender=Fem|Number=Sing	1	appos	_	_
-19	"	_	PUNCT	PUNCT	_	18	punct	_	_
+19	"	_	PUNCT	PUNCT	_	18	punct	_	SpaceAfter=No
 20	,	_	PUNCT	PUNCT	_	18	punct	_	_
-21	111	_	NUM	NUM	_	18	nummod	_	_
-22	)	_	PUNCT	PUNCT	_	18	punct	_	_
+21	111	_	NUM	NUM	_	18	nummod	_	SpaceAfter=No
+22	)	_	PUNCT	PUNCT	_	18	punct	_	SpaceAfter=No
 23	,	_	PUNCT	PUNCT	_	24	punct	_	_
 24	תובע	תבע	VERB	VERB	Gender=Masc|HebBinyan=PAAL|Number=Sing|Person=1,2,3|VerbForm=Part|Voice=Act	0	root	_	_
 25	למצות	מיצה	VERB	VERB	HebBinyan=PIEL|VerbForm=Inf|Voice=Act	24	xcomp	_	_
@@ -2427,13 +2427,13 @@
 42	ב	ב	ADP	ADP	_	43	case	_	_
 43	אירועי	אירוע	NOUN	NOUN	Definite=Cons|Gender=Masc|Number=Plur	39	nmod	_	_
 44	הר	הר	NOUN	NOUN	Definite=Cons|Gender=Masc|Number=Sing	43	compound:smixut	_	_
-45-46	הבית	_	_	_	_	_	_	_	_
+45-46	הבית	_	_	_	_	_	_	_	SpaceAfter=No
 45	ה	ה	DET	DET	PronType=Art	46	det:def	_	_
 46	בית	בית	NOUN	NOUN	Gender=Masc|Number=Sing	44	compound:smixut	_	_
 47	.	_	PUNCT	PUNCT	_	24	punct	_	_
 
 # sent_id = 63
-# text = זהו כישלונו היחיד עד כה של המפכ"ל , שנגרם רק בגלל העובדה שהוא סמך יותר מדי על קציניו הבכירים .
+# text = זהו כישלונו היחיד עד כה של המפכ"ל, שנגרם רק בגלל העובדה שהוא סמך יותר מדי על קציניו הבכירים.
 1	זהו	זהו	PRON	PRON	Gender=Masc|Number=Sing|Person=3|PronType=Dem	2	nsubj	_	_
 2-4	כישלונו	_	_	_	_	_	_	_	_
 2	כישלון_	כישלון	NOUN	NOUN	Definite=Def|Gender=Masc|Number=Sing	0	root	_	_
@@ -2445,7 +2445,7 @@
 7	עד	עד	ADP	ADP	_	8	case	_	_
 8	כה	כה	ADV	ADV	_	2	nmod	_	_
 9	של	של	PART	PART	Case=Gen	11	case:gen	_	_
-10-11	המפכ"ל	_	_	_	_	_	_	_	_
+10-11	המפכ"ל	_	_	_	_	_	_	_	SpaceAfter=No
 10	ה	ה	DET	DET	PronType=Art	11	det:def	_	_
 11	מפכ"ל	מפכ"ל	NOUN	NOUN	Abbr=Yes|Gender=Masc|Number=Sing	2	nmod	_	_
 12	,	_	PUNCT	PUNCT	_	2	punct	_	_
@@ -2468,13 +2468,13 @@
 25	קצין_	קצין	NOUN	NOUN	Definite=Def|Gender=Masc|Number=Plur	21	iobj	_	_
 26	_של_	של	ADP	ADP	_	27	case:gen	_	_
 27	_הוא	הוא	PRON	PRON	Case=Gen|Gender=Masc|Number=Sing|Person=3|PronType=Prs	25	nmod:poss	_	_
-28-29	הבכירים	_	_	_	_	_	_	_	_
+28-29	הבכירים	_	_	_	_	_	_	_	SpaceAfter=No
 28	ה	ה	DET	DET	PronType=Art	29	det:def	_	_
 29	בכירים	בכיר	ADJ	ADJ	Gender=Masc|Number=Plur	25	amod	_	_
 30	.	_	PUNCT	PUNCT	_	2	punct	_	_
 
 # sent_id = 64
-# text = אם כל נושא משרה יפוטר מיד עם השגיאה הראשונה , תסבול המדינה מסבב בלתי פוסק של בעלי תפקידים בכירים , חסרי ניסיון וחסרי ביטחון .
+# text = אם כל נושא משרה יפוטר מיד עם השגיאה הראשונה, תסבול המדינה מסבב בלתי פוסק של בעלי תפקידים בכירים, חסרי ניסיון וחסרי ביטחון.
 1	אם	אם	SCONJ	SCONJ	_	5	mark	_	_
 2	כל	כול	DET	DET	Definite=Cons	3	det	_	_
 3	נושא	נושא	NOUN	NOUN	Definite=Cons|Gender=Masc|Number=Sing	5	nsubj	_	_
@@ -2485,7 +2485,7 @@
 8-9	השגיאה	_	_	_	_	_	_	_	_
 8	ה	ה	DET	DET	PronType=Art	9	det:def	_	_
 9	שגיאה	שגיאה	NOUN	NOUN	Gender=Fem|Number=Sing	5	obl	_	_
-10-11	הראשונה	_	_	_	_	_	_	_	_
+10-11	הראשונה	_	_	_	_	_	_	_	SpaceAfter=No
 10	ה	ה	DET	DET	PronType=Art	11	det:def	_	_
 11	ראשונה	_	ADJ	ADJ	Gender=Fem|Number=Sing	9	amod	_	_
 12	,	_	PUNCT	PUNCT	_	13	punct	_	_
@@ -2501,18 +2501,18 @@
 20	של	של	PART	PART	Case=Gen	21	case:gen	_	_
 21	בעלי	בעל	NOUN	NOUN	Definite=Cons|Gender=Masc|Number=Plur	17	nmod	_	_
 22	תפקידים	תפקיד	NOUN	NOUN	Gender=Masc|Number=Plur	21	compound:smixut	_	_
-23	בכירים	בכיר	ADJ	ADJ	Gender=Masc|Number=Plur	22	amod	_	_
+23	בכירים	בכיר	ADJ	ADJ	Gender=Masc|Number=Plur	22	amod	_	SpaceAfter=No
 24	,	_	PUNCT	PUNCT	_	21	punct	_	_
 25	חסרי	חסר	ADJ	ADJ	Definite=Cons|Gender=Masc|Number=Plur	21	amod	_	_
 26	ניסיון	ניסיון	NOUN	NOUN	Gender=Masc|Number=Sing	25	compound:smixut	_	_
 27-28	וחסרי	_	_	_	_	_	_	_	_
 27	ו	ו	CCONJ	CCONJ	_	28	cc	_	_
 28	חסרי	חסר	ADJ	ADJ	Definite=Cons|Gender=Masc|Number=Plur	25	conj	_	_
-29	ביטחון	ביטחון	NOUN	NOUN	Gender=Masc|Number=Sing	28	compound:smixut	_	_
+29	ביטחון	ביטחון	NOUN	NOUN	Gender=Masc|Number=Sing	28	compound:smixut	_	SpaceAfter=No
 30	.	_	PUNCT	PUNCT	_	13	punct	_	_
 
 # sent_id = 65
-# text = מתקבל הרושם שהיחידים במדינה הזו שאינם צריכים לחשוש מתוצאות מעשיהם הם הפוליטיקאים .
+# text = מתקבל הרושם שהיחידים במדינה הזו שאינם צריכים לחשוש מתוצאות מעשיהם הם הפוליטיקאים.
 1	מתקבל	התקבל	VERB	VERB	Gender=Masc|HebBinyan=HITPAEL|Number=Sing|Person=1,2,3|VerbForm=Part	0	root	_	_
 2-3	הרושם	_	_	_	_	_	_	_	_
 2	ה	ה	DET	DET	PronType=Art	3	det:def	_	_
@@ -2541,13 +2541,13 @@
 19	_של_	של	ADP	ADP	_	20	case:gen	_	_
 20	_הם	הוא	PRON	PRON	Case=Gen|Gender=Masc|Number=Plur|Person=3|PronType=Prs	18	nmod:poss	_	_
 21	הם	הוא	VERB	VERB	Gender=Masc|Number=Plur|Person=3|Polarity=Pos|VerbForm=Part|VerbType=Cop	23	cop	_	_
-22-23	הפוליטיקאים	_	_	_	_	_	_	_	_
+22-23	הפוליטיקאים	_	_	_	_	_	_	_	SpaceAfter=No
 22	ה	ה	DET	DET	PronType=Art	23	det:def	_	_
 23	פוליטיקאים	פוליטיקאי	NOUN	NOUN	Gender=Masc|Number=Plur	3	acl:relcl	_	_
 24	.	_	PUNCT	PUNCT	_	1	punct	_	_
 
 # sent_id = 66
-# text = אלה לא נופלים כתוצאה משגיאות או ממחדלים , או אפילו מהתנהגות פסולה , אלא רק בשל משחקי כוח פוליטיים .
+# text = אלה לא נופלים כתוצאה משגיאות או ממחדלים, או אפילו מהתנהגות פסולה, אלא רק בשל משחקי כוח פוליטיים.
 1	אלה	אלה	PRON	PRON	Gender=Masc|Number=Plur|Person=3|PronType=Dem	3	nsubj	_	_
 2	לא	לא	ADV	ADV	Polarity=Neg	3	advmod	_	_
 3	נופלים	נפל	VERB	VERB	Gender=Masc|HebBinyan=PAAL|Number=Plur|Person=1,2,3|VerbForm=Part|Voice=Act	0	root	_	_
@@ -2558,7 +2558,7 @@
 6	מ	מ	ADP	ADP	_	7	case	_	_
 7	שגיאות	שגיאה	NOUN	NOUN	Gender=Fem|Number=Plur	5	nmod	_	_
 8	או	או	CCONJ	CCONJ	_	10	cc	_	_
-9-10	ממחדלים	_	_	_	_	_	_	_	_
+9-10	ממחדלים	_	_	_	_	_	_	_	SpaceAfter=No
 9	מ	מ	ADP	ADP	_	10	case	_	_
 10	מחדלים	מחדל	NOUN	NOUN	Gender=Masc|Number=Plur	7	conj	_	_
 11	,	_	PUNCT	PUNCT	_	7	punct	_	_
@@ -2567,18 +2567,18 @@
 14-15	מהתנהגות	_	_	_	_	_	_	_	_
 14	מ	מ	ADP	ADP	_	15	case	_	_
 15	התנהגות	התנהגות	NOUN	NOUN	Gender=Fem|Number=Sing	7	conj	_	_
-16	פסולה	פסול	ADJ	ADJ	Gender=Fem|Number=Sing	15	amod	_	_
+16	פסולה	פסול	ADJ	ADJ	Gender=Fem|Number=Sing	15	amod	_	SpaceAfter=No
 17	,	_	PUNCT	PUNCT	_	5	punct	_	_
 18	אלא	אלא	CCONJ	CCONJ	_	21	cc	_	_
 19	רק	רק	ADV	ADV	_	20	advmod	_	_
 20	בשל	בשל	ADP	ADP	_	21	case	_	_
 21	משחקי	משחק	NOUN	NOUN	Definite=Cons|Gender=Masc|Number=Plur	5	conj	_	_
 22	כוח	כוח	NOUN	NOUN	Gender=Masc|Number=Sing	21	compound:smixut	_	_
-23	פוליטיים	פוליטי	ADJ	ADJ	Gender=Masc|Number=Plur	21	amod	_	_
+23	פוליטיים	פוליטי	ADJ	ADJ	Gender=Masc|Number=Plur	21	amod	_	SpaceAfter=No
 24	.	_	PUNCT	PUNCT	_	3	punct	_	_
 
 # sent_id = 67
-# text = המלצה לפיטורי שר או נושא משרה פוליטית , מצד בית המשפט העליון או מצד ועדת חקירה נופלת תמיד על אוזניים ערלות ; אבל כשאפשר להטיל את האשמה על קצין צבא או משטרה , מוטל גורלם של אלה על כף המאזניים .
+# text = המלצה לפיטורי שר או נושא משרה פוליטית, מצד בית המשפט העליון או מצד ועדת חקירה נופלת תמיד על אוזניים ערלות; אבל כשאפשר להטיל את האשמה על קצין צבא או משטרה, מוטל גורלם של אלה על כף המאזניים.
 1	המלצה	המלצה	NOUN	NOUN	Gender=Fem|Number=Sing	20	nsubj	_	_
 2-3	לפיטורי	_	_	_	_	_	_	_	_
 2	ל	ל	ADP	ADP	_	3	case	_	_
@@ -2587,7 +2587,7 @@
 5	או	או	CCONJ	CCONJ	_	6	cc	_	_
 6	נושא	נושא	NOUN	NOUN	Definite=Cons|Gender=Masc|Number=Sing	4	conj	_	_
 7	משרה	משרה	NOUN	NOUN	Gender=Fem|Number=Sing	6	compound:smixut	_	_
-8	פוליטית	פוליטי	ADJ	ADJ	Gender=Fem|Number=Sing	7	amod	_	_
+8	פוליטית	פוליטי	ADJ	ADJ	Gender=Fem|Number=Sing	7	amod	_	SpaceAfter=No
 9	,	_	PUNCT	PUNCT	_	1	punct	_	_
 10	מצד	מצד	ADP	ADP	_	11	case	_	_
 11	בית	בית	NOUN	NOUN	Definite=Cons|Gender=Masc|Number=Sing	1	nmod	_	_
@@ -2605,7 +2605,7 @@
 21	תמיד	תמיד	ADV	ADV	_	20	advmod	_	_
 22	על	על	ADP	ADP	_	23	case	_	_
 23	אוזניים	אוזן	NOUN	NOUN	Gender=Fem|Number=Plur	20	iobj	_	_
-24	ערלות	ערל	ADJ	ADJ	Gender=Fem|Number=Plur	23	amod	_	_
+24	ערלות	ערל	ADJ	ADJ	Gender=Fem|Number=Plur	23	amod	_	SpaceAfter=No
 25	;	_	PUNCT	PUNCT	_	26	cc	_	_
 26	אבל	אבל	CCONJ	CCONJ	_	39	cc	_	_
 27-28	כשאפשר	_	_	_	_	_	_	_	_
@@ -2620,7 +2620,7 @@
 34	קצין	קצין	NOUN	NOUN	Definite=Cons|Gender=Masc|Number=Sing	29	iobj	_	_
 35	צבא	צבא	NOUN	NOUN	Gender=Masc|Number=Sing	34	compound:smixut	_	_
 36	או	או	CCONJ	CCONJ	_	37	cc	_	_
-37	משטרה	משטרה	NOUN	NOUN	Gender=Fem|Number=Sing	35	conj	_	_
+37	משטרה	משטרה	NOUN	NOUN	Gender=Fem|Number=Sing	35	conj	_	SpaceAfter=No
 38	,	_	PUNCT	PUNCT	_	39	punct	_	_
 39	מוטל	הוטל	VERB	VERB	Gender=Masc|HebBinyan=HUFAL|Number=Sing|Person=1,2,3|VerbForm=Part|Voice=Pass	20	conj	_	_
 40-42	גורלם	_	_	_	_	_	_	_	_
@@ -2631,18 +2631,18 @@
 44	אלה	אלה	PRON	PRON	Gender=Masc|Number=Plur|Person=3|PronType=Dem	40	nmod:poss	_	_
 45	על	על	ADP	ADP	_	46	case	_	_
 46	כף	כף	NOUN	NOUN	Definite=Cons|Gender=Fem|Number=Sing	39	iobj	_	_
-47-48	המאזניים	_	_	_	_	_	_	_	_
+47-48	המאזניים	_	_	_	_	_	_	_	SpaceAfter=No
 47	ה	ה	DET	DET	PronType=Art	48	det:def	_	_
 48	מאזניים	מאזניים	NOUN	NOUN	Gender=Masc|Number=Plur	46	compound:smixut	_	_
 49	.	_	PUNCT	PUNCT	_	20	punct	_	_
 
 # sent_id = 68
-# text = אני תמה על " הארץ " שהזדרז לשחק לידיהם של הפוליטיקאים , המעוניינים להיפטר מהמפכ"ל הנוכחי .
+# text = אני תמה על "הארץ" שהזדרז לשחק לידיהם של הפוליטיקאים, המעוניינים להיפטר מהמפכ"ל הנוכחי.
 1	אני	הוא	PRON	PRON	Gender=Fem,Masc|Number=Sing|Person=1|PronType=Prs	2	dep	_	_
 2	תמה	_	VERB	VERB	VerbForm=Part	0	root	_	_
 3	על	על	ADP	ADP	_	6	case	_	_
-4	"	_	PUNCT	PUNCT	_	6	punct	_	_
-5-6	הארץ	_	_	_	_	_	_	_	_
+4	"	_	PUNCT	PUNCT	_	6	punct	_	SpaceAfter=No
+5-6	הארץ	_	_	_	_	_	_	_	SpaceAfter=No
 5	ה	ה	DET	DET	PronType=Art	6	det:def	_	_
 6	ארץ	ארץ	NOUN	NOUN	Gender=Fem|Number=Sing	2	iobj	_	_
 7	"	_	PUNCT	PUNCT	_	6	punct	_	_
@@ -2656,7 +2656,7 @@
 13	_של_	של	ADP	ADP	_	14	case:gen	_	_
 14	_הם	הוא	PRON	PRON	Case=Gen|Gender=Masc|Number=Plur|Person=3|PronType=Prs	12	nmod:poss	_	_
 15	של	של	PART	PART	Case=Gen	17	case:gen	_	_
-16-17	הפוליטיקאים	_	_	_	_	_	_	_	_
+16-17	הפוליטיקאים	_	_	_	_	_	_	_	SpaceAfter=No
 16	ה	ה	DET	DET	PronType=Art	17	det:def	_	_
 17	פוליטיקאים	פוליטיקאי	NOUN	NOUN	Gender=Masc|Number=Plur	12	nmod:poss	_	_
 18	,	_	PUNCT	PUNCT	_	17	punct	_	_
@@ -2668,13 +2668,13 @@
 22	מ	מ	ADP	ADP	_	24	case	_	_
 23	ה	ה	DET	DET	PronType=Art	24	det:def	_	_
 24	מפכ"ל	מפכ"ל	NOUN	NOUN	Abbr=Yes|Gender=Masc|Number=Sing	21	iobj	_	_
-25-26	הנוכחי	_	_	_	_	_	_	_	_
+25-26	הנוכחי	_	_	_	_	_	_	_	SpaceAfter=No
 25	ה	ה	DET	DET	PronType=Art	26	det:def	_	_
 26	נוכחי	נוכחי	ADJ	ADJ	Gender=Masc|Number=Sing	24	amod	_	_
 27	.	_	PUNCT	PUNCT	_	2	punct	_	_
 
 # sent_id = 69
-# text = בעיתונים רבים פורסם מכתבה של מלי פיליפסבורן , יו"ר ארגון נפגעי המשכנתאות וחסרי הדיור , תחת הכותרת " אל תיגעו במשכנתא " .
+# text = בעיתונים רבים פורסם מכתבה של מלי פיליפסבורן, יו"ר ארגון נפגעי המשכנתאות וחסרי הדיור, תחת הכותרת " אל תיגעו במשכנתא ".
 1-2	בעיתונים	_	_	_	_	_	_	_	_
 1	ב	ב	ADP	ADP	_	2	case	_	_
 2	עיתונים	עיתון	NOUN	NOUN	Gender=Masc|Number=Plur	4	obl	_	_
@@ -2686,7 +2686,7 @@
 7	_היא	הוא	PRON	PRON	Case=Gen|Gender=Fem|Number=Sing|Person=3|PronType=Prs	5	nmod:poss	_	_
 8	של	של	PART	PART	Case=Gen	9	case:gen	_	_
 9	מלי	מלי	PROPN	PROPN	_	5	nmod:poss	_	_
-10	פיליפסבורן	פיליפסבורן	PROPN	PROPN	_	9	flat:name	_	_
+10	פיליפסבורן	פיליפסבורן	PROPN	PROPN	_	9	flat:name	_	SpaceAfter=No
 11	,	_	PUNCT	PUNCT	_	9	punct	_	_
 12	יו"ר	יו"ר	NOUN	NOUN	Abbr=Yes|Definite=Cons|Gender=Masc|Number=Sing	9	appos	_	_
 13	ארגון	ארגון	NOUN	NOUN	Definite=Cons|Gender=Masc|Number=Sing	12	compound:smixut	_	_
@@ -2697,7 +2697,7 @@
 17-18	וחסרי	_	_	_	_	_	_	_	_
 17	ו	ו	CCONJ	CCONJ	_	18	cc	_	_
 18	חסרי	חסר	NOUN	NOUN	Definite=Cons|Gender=Masc|Number=Plur	14	conj	_	_
-19-20	הדיור	_	_	_	_	_	_	_	_
+19-20	הדיור	_	_	_	_	_	_	_	SpaceAfter=No
 19	ה	ה	DET	DET	PronType=Art	20	det:def	_	_
 20	דיור	דיור	NOUN	NOUN	Gender=Masc|Number=Sing	18	compound:smixut	_	_
 21	,	_	PUNCT	PUNCT	_	4	punct	_	_
@@ -2712,11 +2712,11 @@
 28	ב	ב	ADP	ADP	_	30	case	_	_
 29	ה_	ה	DET	DET	PronType=Art	30	det:def	_	_
 30	משכנתא	משכנתא	NOUN	NOUN	Gender=Fem|Number=Sing	27	iobj	_	_
-31	"	_	PUNCT	PUNCT	_	27	punct	_	_
+31	"	_	PUNCT	PUNCT	_	27	punct	_	SpaceAfter=No
 32	.	_	PUNCT	PUNCT	_	4	punct	_	_
 
 # sent_id = 70
-# text = ברצוני להדגיש משפט אחד בדבריה : " אנו , נפגעי המשכנתאות , נקלענו למצבנו הקשה לא בגלל ריבית נמוכה , אלא בגלל האינפלציה וההצמדה " .
+# text = ברצוני להדגיש משפט אחד בדבריה: " אנו, נפגעי המשכנתאות, נקלענו למצבנו הקשה לא בגלל ריבית נמוכה, אלא בגלל האינפלציה וההצמדה ".
 1-4	ברצוני	_	_	_	_	_	_	_	_
 1	ב	ב	ADP	ADP	_	2	case	_	_
 2	רצון_	רצון	NOUN	NOUN	Definite=Def|Gender=Masc|Number=Sing	0	root	_	_
@@ -2725,17 +2725,17 @@
 5	להדגיש	הדגיש	VERB	VERB	HebBinyan=HIFIL|VerbForm=Inf|Voice=Act	2	xcomp	_	_
 6	משפט	משפט	NOUN	NOUN	Gender=Masc|Number=Sing	5	obj	_	_
 7	אחד	אחד	NUM	NUM	Gender=Masc|Number=Sing	6	nummod	_	_
-8-11	בדבריה	_	_	_	_	_	_	_	_
+8-11	בדבריה	_	_	_	_	_	_	_	SpaceAfter=No
 8	ב	ב	ADP	ADP	_	9	case	_	_
 9	דבר_	דבר	NOUN	NOUN	Definite=Def|Gender=Masc|Number=Plur	6	nmod	_	_
 10	_של_	של	ADP	ADP	_	11	case:gen	_	_
 11	_היא	הוא	PRON	PRON	Case=Gen|Gender=Fem|Number=Sing|Person=3|PronType=Prs	9	nmod:poss	_	_
 12	:	_	PUNCT	PUNCT	_	20	punct	_	_
 13	"	_	PUNCT	PUNCT	_	20	punct	_	_
-14	אנו	הוא	PRON	PRON	Gender=Fem,Masc|Number=Plur|Person=1|PronType=Prs	20	nsubj	_	_
+14	אנו	הוא	PRON	PRON	Gender=Fem,Masc|Number=Plur|Person=1|PronType=Prs	20	nsubj	_	SpaceAfter=No
 15	,	_	PUNCT	PUNCT	_	14	punct	_	_
 16	נפגעי	נפגע	NOUN	NOUN	Definite=Cons|Gender=Masc|Number=Plur	14	appos	_	_
-17-18	המשכנתאות	_	_	_	_	_	_	_	_
+17-18	המשכנתאות	_	_	_	_	_	_	_	SpaceAfter=No
 17	ה	ה	DET	DET	PronType=Art	18	det:def	_	_
 18	משכנתאות	משכנתא	NOUN	NOUN	Gender=Fem|Number=Plur	16	compound:smixut	_	_
 19	,	_	PUNCT	PUNCT	_	20	punct	_	_
@@ -2751,7 +2751,7 @@
 27	לא	לא	ADV	ADV	Polarity=Neg	28	advmod	_	_
 28	בגלל	בגלל	ADP	ADP	_	29	case	_	_
 29	ריבית	ריבית	NOUN	NOUN	Gender=Fem|Number=Sing	20	obl	_	_
-30	נמוכה	נמוך	ADJ	ADJ	Gender=Fem|Number=Sing	29	amod	_	_
+30	נמוכה	נמוך	ADJ	ADJ	Gender=Fem|Number=Sing	29	amod	_	SpaceAfter=No
 31	,	_	PUNCT	PUNCT	_	29	punct	_	_
 32	אלא	אלא	CCONJ	CCONJ	_	35	cc	_	_
 33	בגלל	בגלל	ADP	ADP	_	35	case	_	_
@@ -2762,13 +2762,13 @@
 36	ו	ו	CCONJ	CCONJ	_	38	cc	_	_
 37	ה	ה	DET	DET	PronType=Art	38	det:def	_	_
 38	הצמדה	הצמדה	NOUN	NOUN	Gender=Fem|Number=Sing	35	conj	_	_
-39	"	_	PUNCT	PUNCT	_	20	punct	_	_
+39	"	_	PUNCT	PUNCT	_	20	punct	_	SpaceAfter=No
 40	.	_	PUNCT	PUNCT	_	2	punct	_	_
 
 # sent_id = 71
-# text = מלים כדורבנות , התואמות במדויק את מה שהחתום מטה טען במשך שנים רבות .
+# text = מלים כדורבנות, התואמות במדויק את מה שהחתום מטה טען במשך שנים רבות.
 1	מלים	מילה	NOUN	NOUN	Gender=Fem|Number=Plur	0	root	_	_
-2-3	כדורבנות	_	_	_	_	_	_	_	_
+2-3	כדורבנות	_	_	_	_	_	_	_	SpaceAfter=No
 2	כ	כ	ADP	ADP	_	3	case	_	_
 3	דורבנות	דורבן	NOUN	NOUN	Gender=Masc|Number=Plur	1	nmod	_	_
 4	,	_	PUNCT	PUNCT	_	1	punct	_	_
@@ -2786,11 +2786,11 @@
 14	טען	טען	VERB	VERB	Gender=Masc|HebBinyan=PAAL|Number=Sing|Person=3|Tense=Past|Voice=Act	9	acl:relcl	_	_
 15	במשך	במשך	ADP	ADP	_	16	case	_	_
 16	שנים	שנה	NOUN	NOUN	Gender=Fem|Number=Plur	14	obl	_	_
-17	רבות	רב	ADJ	ADJ	Gender=Fem|Number=Plur	16	amod	_	_
+17	רבות	רב	ADJ	ADJ	Gender=Fem|Number=Plur	16	amod	_	SpaceAfter=No
 18	.	_	PUNCT	PUNCT	_	1	punct	_	_
 
 # sent_id = 72
-# text = זו לא הריבית שסיבכה את מקבלי המשכנתאות או לקוחות הבנקים האחרים .
+# text = זו לא הריבית שסיבכה את מקבלי המשכנתאות או לקוחות הבנקים האחרים.
 1	זו	זו	PRON	PRON	Gender=Fem|Number=Sing|Person=3|PronType=Dem	4	nsubj	_	_
 2	לא	לא	ADV	ADV	Polarity=Neg	4	advmod	_	_
 3-4	הריבית	_	_	_	_	_	_	_	_
@@ -2809,18 +2809,18 @@
 13-14	הבנקים	_	_	_	_	_	_	_	_
 13	ה	ה	DET	DET	PronType=Art	14	det:def	_	_
 14	בנקים	בנק	NOUN	NOUN	Gender=Masc|Number=Plur	12	compound:smixut	_	_
-15-16	האחרים	_	_	_	_	_	_	_	_
+15-16	האחרים	_	_	_	_	_	_	_	SpaceAfter=No
 15	ה	ה	DET	DET	PronType=Art	16	det:def	_	_
 16	אחרים	אחר	ADJ	ADJ	Gender=Masc|Number=Plur	12	amod	_	_
 17	.	_	PUNCT	PUNCT	_	4	punct	_	_
 
 # sent_id = 73
-# text = יתר - על - כן , הריבית בישראל במיוחד על משכנתאות היא מהנמוכות ביותר בעולם , אם לא הנמוכה שבהן .
+# text = יתר - על - כן, הריבית בישראל במיוחד על משכנתאות היא מהנמוכות ביותר בעולם, אם לא הנמוכה שבהן.
 1	יתר	יתר	NOUN	NOUN	Gender=Masc|Number=Sing	17	advmod	_	_
 2	-	_	PUNCT	PUNCT	_	1	fixed	_	_
 3	על	על	ADP	ADP	_	1	fixed	_	_
 4	-	_	PUNCT	PUNCT	_	1	fixed	_	_
-5	כן	_	PRON	PRON	Person=3|PronType=Dem	1	fixed	_	_
+5	כן	_	PRON	PRON	Person=3|PronType=Dem	1	fixed	_	SpaceAfter=No
 6	,	_	PUNCT	PUNCT	_	17	punct	_	_
 7-8	הריבית	_	_	_	_	_	_	_	_
 7	ה	ה	DET	DET	PronType=Art	8	det:def	_	_
@@ -2837,7 +2837,7 @@
 16	ה	ה	DET	DET	PronType=Art	17	det:def	_	_
 17	נמוכות	נמוך	ADJ	ADJ	Gender=Fem|Number=Plur	0	root	_	_
 18	ביותר	ביותר	ADV	ADV	_	17	advmod	_	_
-19-21	בעולם	_	_	_	_	_	_	_	_
+19-21	בעולם	_	_	_	_	_	_	_	SpaceAfter=No
 19	ב	ב	ADP	ADP	_	21	case	_	_
 20	ה_	ה	DET	DET	PronType=Art	21	det:def	_	_
 21	עולם	עולם	NOUN	NOUN	Gender=Masc|Number=Sing	17	obl	_	_
@@ -2847,14 +2847,14 @@
 25-26	הנמוכה	_	_	_	_	_	_	_	_
 25	ה	ה	DET	DET	PronType=Art	26	det:def	_	_
 26	נמוכה	נמוך	ADJ	ADJ	Gender=Fem|HebSource=ConvUncertainHead|Number=Sing	17	dep	_	_
-27-29	שבהן	_	_	_	_	_	_	_	_
+27-29	שבהן	_	_	_	_	_	_	_	SpaceAfter=No
 27	ש	ש	SCONJ	SCONJ	_	29	case	_	_
 28	בהן	ב	ADP	ADP	_	29	case	_	_
 29	_הן	הוא	PRON	PRON	Gender=Fem|Number=Plur|Person=3|PronType=Prs	26	obl	_	_
 30	.	_	PUNCT	PUNCT	_	17	punct	_	_
 
 # sent_id = 74
-# text = ובאשר להצמדה ולאינפלציה הכתובת אינה הבנקים .
+# text = ובאשר להצמדה ולאינפלציה הכתובת אינה הבנקים.
 1-2	ובאשר	_	_	_	_	_	_	_	_
 1	ו	ו	CCONJ	CCONJ	_	14	cc	_	_
 2	באשר	באשר	CCONJ	CCONJ	_	5	case	_	_
@@ -2871,13 +2871,13 @@
 10	ה	ה	DET	DET	PronType=Art	11	det:def	_	_
 11	כתובת	כתובת	NOUN	NOUN	Gender=Fem|Number=Sing	14	nsubj	_	_
 12	אינה	אינו	VERB	VERB	Gender=Fem|Number=Sing|Person=3|Polarity=Neg|VerbForm=Part|VerbType=Cop	14	advmod	_	_
-13-14	הבנקים	_	_	_	_	_	_	_	_
+13-14	הבנקים	_	_	_	_	_	_	_	SpaceAfter=No
 13	ה	ה	DET	DET	PronType=Art	14	det:def	_	_
 14	בנקים	בנק	NOUN	NOUN	Gender=Masc|Number=Plur	0	root	_	_
 15	.	_	PUNCT	PUNCT	_	14	punct	_	_
 
 # sent_id = 75
-# text = ב16 באוקטובר הגיע אל העיר דה מוין , במערב התיכון של ארצות הברית , הנשיא גורג בוש .
+# text = ב16 באוקטובר הגיע אל העיר דה מוין, במערב התיכון של ארצות הברית, הנשיא גורג בוש.
 1-3	ב16	_	_	_	_	_	_	_	_
 1	ב	ב	ADP	ADP	_	3	case	_	_
 2	ה_	ה	DET	DET	PronType=Art	3	det:def	_	_
@@ -2891,7 +2891,7 @@
 8	ה	ה	DET	DET	PronType=Art	9	det:def	_	_
 9	עיר	עיר	NOUN	NOUN	Gender=Fem|Number=Sing	6	obl	_	_
 10	דה	דה	PROPN	PROPN	_	9	appos	_	_
-11	מוין	מוין	PROPN	PROPN	_	10	flat:name	_	_
+11	מוין	מוין	PROPN	PROPN	_	10	flat:name	_	SpaceAfter=No
 12	,	_	PUNCT	PUNCT	_	9	punct	_	_
 13-15	במערב	_	_	_	_	_	_	_	_
 13	ב	ב	ADP	ADP	_	15	case	_	_
@@ -2902,7 +2902,7 @@
 17	תיכון	תיכון	ADJ	ADJ	Gender=Masc|Number=Sing	15	amod	_	_
 18	של	של	PART	PART	Case=Gen	19	case:gen	_	_
 19	ארצות	ארץ	NOUN	NOUN	Definite=Cons|Gender=Fem|Number=Plur	15	nmod:poss	_	_
-20-21	הברית	_	_	_	_	_	_	_	_
+20-21	הברית	_	_	_	_	_	_	_	SpaceAfter=No
 20	ה	ה	DET	DET	PronType=Art	21	det:def	_	_
 21	ברית	ברית	NOUN	NOUN	Gender=Fem|Number=Sing	19	compound:smixut	_	_
 22	,	_	PUNCT	PUNCT	_	6	punct	_	_
@@ -2910,11 +2910,11 @@
 23	ה	ה	DET	DET	PronType=Art	24	det:def	_	_
 24	נשיא	נשיא	NOUN	NOUN	Gender=Masc|Number=Sing	6	nsubj	_	_
 25	גורג	גורג	PROPN	PROPN	_	24	appos	_	_
-26	בוש	בוש	PROPN	PROPN	_	25	flat:name	_	_
+26	בוש	בוש	PROPN	PROPN	_	25	flat:name	_	SpaceAfter=No
 27	.	_	PUNCT	PUNCT	_	6	punct	_	_
 
 # sent_id = 76
-# text = כאן הוא גם נתקל בהפגנה הראשונה נגד מלחמה במפרץ הפרסי .
+# text = כאן הוא גם נתקל בהפגנה הראשונה נגד מלחמה במפרץ הפרסי.
 1	כאן	כאן	ADV	ADV	_	4	advmod	_	_
 2	הוא	הוא	PRON	PRON	Gender=Masc|Number=Sing|Person=3|PronType=Prs	4	nsubj	_	_
 3	גם	גם	ADV	ADV	_	4	advmod	_	_
@@ -2932,20 +2932,20 @@
 12	ב	ב	ADP	ADP	_	14	case	_	_
 13	ה_	ה	DET	DET	PronType=Art	14	det:def	_	_
 14	מפרץ	מפרץ	NOUN	NOUN	Gender=Masc|Number=Sing	11	nmod	_	_
-15-16	הפרסי	_	_	_	_	_	_	_	_
+15-16	הפרסי	_	_	_	_	_	_	_	SpaceAfter=No
 15	ה	ה	DET	DET	PronType=Art	16	det:def	_	_
 16	פרסי	פרסי	ADJ	ADJ	Gender=Masc|Number=Sing	14	amod	_	_
 17	.	_	PUNCT	PUNCT	_	4	punct	_	_
 
 # sent_id = 77
-# text = " לא נשפוך דם למען נפט " , קראו לעברו כמה צעירים באסיפת בחירות לטובת מועמד רפובליקאי .
-1	"	_	PUNCT	PUNCT	_	3	punct	_	_
+# text = "לא נשפוך דם למען נפט", קראו לעברו כמה צעירים באסיפת בחירות לטובת מועמד רפובליקאי.
+1	"	_	PUNCT	PUNCT	_	3	punct	_	SpaceAfter=No
 2	לא	לא	ADV	ADV	Polarity=Neg	3	advmod	_	_
 3	נשפוך	שפך	VERB	VERB	Gender=Fem,Masc|HebBinyan=PAAL|Number=Plur|Person=1|Tense=Fut|Voice=Act	9	iobj	_	_
 4	דם	דם	NOUN	NOUN	Gender=Masc|Number=Sing	3	obj	_	_
 5	למען	למען	ADP	ADP	_	6	case	_	_
-6	נפט	נפט	NOUN	NOUN	Gender=Masc|Number=Sing	3	obl	_	_
-7	"	_	PUNCT	PUNCT	_	3	punct	_	_
+6	נפט	נפט	NOUN	NOUN	Gender=Masc|Number=Sing	3	obl	_	SpaceAfter=No
+7	"	_	PUNCT	PUNCT	_	3	punct	_	SpaceAfter=No
 8	,	_	PUNCT	PUNCT	_	9	punct	_	_
 9	קראו	קרא	VERB	VERB	Gender=Fem,Masc|HebBinyan=PAAL|Number=Plur|Person=3|Tense=Past|Voice=Act	0	root	_	_
 10-11	לעברו	_	_	_	_	_	_	_	_
@@ -2961,45 +2961,45 @@
 17	ל	ל	ADP	ADP	_	19	case	_	_
 18	טובת	טובה	NOUN	NOUN	Definite=Cons|Gender=Fem|Number=Sing	17	fixed	_	_
 19	מועמד	מועמד	NOUN	NOUN	Gender=Masc|Number=Sing	15	nmod	_	_
-20	רפובליקאי	רפובליקני	ADJ	ADJ	Gender=Masc|Number=Sing	19	amod	_	_
+20	רפובליקאי	רפובליקני	ADJ	ADJ	Gender=Masc|Number=Sing	19	amod	_	SpaceAfter=No
 21	.	_	PUNCT	PUNCT	_	9	punct	_	_
 
 # sent_id = 78
-# text = " לא נפט " , כעס הנשיא , " מדובר פה בתוקפנות גלויה " .
-1	"	_	PUNCT	PUNCT	_	3	punct	_	_
+# text = "לא נפט", כעס הנשיא, "מדובר פה בתוקפנות גלויה".
+1	"	_	PUNCT	PUNCT	_	3	punct	_	SpaceAfter=No
 2	לא	לא	ADV	ADV	Polarity=Neg	3	det	_	_
-3	נפט	נפט	NOUN	NOUN	Gender=Masc|Number=Sing	0	root	_	_
-4	"	_	PUNCT	PUNCT	_	3	punct	_	_
+3	נפט	נפט	NOUN	NOUN	Gender=Masc|Number=Sing	0	root	_	SpaceAfter=No
+4	"	_	PUNCT	PUNCT	_	3	punct	_	SpaceAfter=No
 5	,	_	PUNCT	PUNCT	_	6	punct	_	_
 6	כעס	כעס	VERB	VERB	Gender=Masc|HebBinyan=PAAL|Number=Sing|Person=3|Tense=Past|Voice=Act	3	parataxis	_	_
-7-8	הנשיא	_	_	_	_	_	_	_	_
+7-8	הנשיא	_	_	_	_	_	_	_	SpaceAfter=No
 7	ה	ה	DET	DET	PronType=Art	8	det:def	_	_
 8	נשיא	נשיא	NOUN	NOUN	Gender=Masc|Number=Sing	6	nsubj	_	_
 9	,	_	PUNCT	PUNCT	_	6	punct	_	_
-10	"	_	PUNCT	PUNCT	_	11	punct	_	_
+10	"	_	PUNCT	PUNCT	_	11	punct	_	SpaceAfter=No
 11	מדובר	דובר	VERB	VERB	Gender=Masc|HebBinyan=PUAL|HebSource=ConvUncertainHead|Number=Sing|Person=1,2,3|VerbForm=Part|Voice=Pass	3	dep	_	_
 12	פה	פה	ADV	ADV	_	11	advmod	_	_
 13-14	בתוקפנות	_	_	_	_	_	_	_	_
 13	ב	ב	ADP	ADP	_	14	case	_	_
 14	תוקפנות	תוקפנות	NOUN	NOUN	Gender=Fem|Number=Sing	11	iobj	_	_
-15	גלויה	גלוי	ADJ	ADJ	Gender=Fem|Number=Sing	14	amod	_	_
-16	"	_	PUNCT	PUNCT	_	11	punct	_	_
+15	גלויה	גלוי	ADJ	ADJ	Gender=Fem|Number=Sing	14	amod	_	SpaceAfter=No
+16	"	_	PUNCT	PUNCT	_	11	punct	_	SpaceAfter=No
 17	.	_	PUNCT	PUNCT	_	3	punct	_	_
 
 # sent_id = 79
-# text = איובה היא מקום לא - שגרתי .
+# text = איובה היא מקום לא - שגרתי.
 1	איובה	איובה	PROPN	PROPN	_	3	nsubj:cop	_	_
 2	היא	הוא	VERB	VERB	Gender=Fem|Number=Sing|Person=3|Polarity=Pos|VerbForm=Part|VerbType=Cop	3	cop	_	_
 3	מקום	מקום	NOUN	NOUN	Gender=Masc|Number=Sing	0	root	_	_
 4	לא	לא	ADV	ADV	Polarity=Neg	6	advmod	_	_
 5	-	_	PUNCT	PUNCT	_	6	punct	_	_
-6	שגרתי	שגרתי	ADJ	ADJ	Gender=Masc|Number=Sing	3	amod	_	_
+6	שגרתי	שגרתי	ADJ	ADJ	Gender=Masc|Number=Sing	3	amod	_	SpaceAfter=No
 7	.	_	PUNCT	PUNCT	_	3	punct	_	_
 
 # sent_id = 80
-# text = אומרים עליה , שיש בה יותר ארגונים פציפיסטיים לקילומטר מרובע מאשר בכל מדינה אחרת של ארה"ב .
+# text = אומרים עליה, שיש בה יותר ארגונים פציפיסטיים לקילומטר מרובע מאשר בכל מדינה אחרת של ארה"ב.
 1	אומרים	אמר	VERB	VERB	Gender=Masc|HebBinyan=PAAL|Number=Plur|Person=1,2,3|VerbForm=Part|Voice=Act	0	root	_	_
-2-3	עליה	_	_	_	_	_	_	_	_
+2-3	עליה	_	_	_	_	_	_	_	SpaceAfter=No
 2	עליה	על	ADP	ADP	_	3	case	_	_
 3	_היא	הוא	PRON	PRON	Gender=Fem|Number=Sing|Person=3|PronType=Prs	1	iobj	_	_
 4	,	_	PUNCT	PUNCT	_	1	punct	_	_
@@ -3023,11 +3023,11 @@
 18	מדינה	מדינה	NOUN	NOUN	Gender=Fem|Number=Sing	10	nmod	_	_
 19	אחרת	אחר	ADJ	ADJ	Gender=Fem|Number=Sing	18	amod	_	_
 20	של	של	PART	PART	Case=Gen	21	case:gen	_	_
-21	ארה"ב	ארה"ב	PROPN	PROPN	Abbr=Yes	18	nmod	_	_
+21	ארה"ב	ארה"ב	PROPN	PROPN	Abbr=Yes	18	nmod	_	SpaceAfter=No
 22	.	_	PUNCT	PUNCT	_	1	punct	_	_
 
 # sent_id = 81
-# text = פציפיזם אינו מוגבל באיובה לסטודנטים רדיקליים , אפשר למצוא אותו גם בין חקלאים ופועלי חרושת .
+# text = פציפיזם אינו מוגבל באיובה לסטודנטים רדיקליים, אפשר למצוא אותו גם בין חקלאים ופועלי חרושת.
 1	פציפיזם	פציפיזם	NOUN	NOUN	Gender=Masc|Number=Sing	3	nsubj	_	_
 2	אינו	אינו	VERB	VERB	Gender=Masc|Number=Sing|Person=3|Polarity=Neg|VerbForm=Part|VerbType=Cop	3	advmod	_	_
 3	מוגבל	הוגבל	VERB	VERB	Gender=Masc|HebBinyan=HUFAL|Number=Sing|Person=1,2,3|VerbForm=Part|Voice=Pass	0	root	_	_
@@ -3037,7 +3037,7 @@
 6-7	לסטודנטים	_	_	_	_	_	_	_	_
 6	ל	ל	ADP	ADP	_	7	case	_	_
 7	סטודנטים	סטודנט	NOUN	NOUN	Gender=Masc|Number=Plur	3	iobj	_	_
-8	רדיקליים	רדיקלי	ADJ	ADJ	Gender=Masc|Number=Plur	7	amod	_	_
+8	רדיקליים	רדיקלי	ADJ	ADJ	Gender=Masc|Number=Plur	7	amod	_	SpaceAfter=No
 9	,	_	PUNCT	PUNCT	_	3	punct	_	_
 10	אפשר	אפשר	AUX	AUX	VerbType=Mod	3	conj:discourse	_	_
 11	למצוא	מצא	VERB	VERB	HebBinyan=PAAL|VerbForm=Inf|Voice=Act	10	xcomp	_	_
@@ -3050,11 +3050,11 @@
 17-18	ופועלי	_	_	_	_	_	_	_	_
 17	ו	ו	CCONJ	CCONJ	_	18	cc	_	_
 18	פועלי	פועל	NOUN	NOUN	Definite=Cons|Gender=Masc|Number=Plur	16	conj	_	_
-19	חרושת	חרושת	NOUN	NOUN	Gender=Fem|Number=Sing	18	compound:smixut	_	_
+19	חרושת	חרושת	NOUN	NOUN	Gender=Fem|Number=Sing	18	compound:smixut	_	SpaceAfter=No
 20	.	_	PUNCT	PUNCT	_	3	punct	_	_
 
 # sent_id = 82
-# text = איובה היא מאסמי הדגנים של ארה"ב , ולפרנסתה היא מייצאת אותם למדינות כברית המועצות .
+# text = איובה היא מאסמי הדגנים של ארה"ב, ולפרנסתה היא מייצאת אותם למדינות כברית המועצות.
 1	איובה	איובה	PROPN	PROPN	_	4	nsubj:cop	_	_
 2	היא	הוא	VERB	VERB	Gender=Fem|Number=Sing|Person=3|Polarity=Pos|VerbForm=Part|VerbType=Cop	4	cop	_	_
 3-4	מאסמי	_	_	_	_	_	_	_	_
@@ -3064,7 +3064,7 @@
 5	ה	ה	DET	DET	PronType=Art	6	det:def	_	_
 6	דגנים	דגן	NOUN	NOUN	Gender=Masc|Number=Plur	4	compound:smixut	_	_
 7	של	של	PART	PART	Case=Gen	8	case:gen	_	_
-8	ארה"ב	ארה"ב	PROPN	PROPN	Abbr=Yes	4	nmod:poss	_	_
+8	ארה"ב	ארה"ב	PROPN	PROPN	Abbr=Yes	4	nmod:poss	_	SpaceAfter=No
 9	,	_	PUNCT	PUNCT	_	4	punct	_	_
 10-14	ולפרנסתה	_	_	_	_	_	_	_	_
 10	ו	ו	CCONJ	CCONJ	_	16	cc	_	_
@@ -3083,18 +3083,18 @@
 21-22	כברית	_	_	_	_	_	_	_	_
 21	כ	כ	ADP	ADP	_	22	case	_	_
 22	ברית	ברית	NOUN	NOUN	Definite=Cons|Gender=Fem|Number=Sing	20	nmod	_	_
-23-24	המועצות	_	_	_	_	_	_	_	_
+23-24	המועצות	_	_	_	_	_	_	_	SpaceAfter=No
 23	ה	ה	DET	DET	PronType=Art	24	det:def	_	_
 24	מועצות	מועצה	NOUN	NOUN	Gender=Fem|Number=Plur	22	compound:smixut	_	_
 25	.	_	PUNCT	PUNCT	_	4	punct	_	_
 
 # sent_id = 83
-# text = ב0891 נקלעה איובה , יחד עם מדינות חקלאיות אחרות במערב התיכון , לסחרור קשה : הנשיא גימי קרטר החליט להטיל חרם דגנים על הסובייטים , בגלל פלישתם לאפגניסטן .
+# text = ב0891 נקלעה איובה, יחד עם מדינות חקלאיות אחרות במערב התיכון, לסחרור קשה: הנשיא גימי קרטר החליט להטיל חרם דגנים על הסובייטים, בגלל פלישתם לאפגניסטן.
 1-2	ב0891	_	_	_	_	_	_	_	_
 1	ב	ב	ADP	ADP	_	2	case	_	_
 2	0891	_	NUM	NUM	_	3	obl	_	_
 3	נקלעה	נקלע	VERB	VERB	Gender=Fem|HebBinyan=NIFAL|Number=Sing|Person=3|Tense=Past|Voice=Mid	0	root	_	_
-4	איובה	איובה	PROPN	PROPN	_	3	nsubj	_	_
+4	איובה	איובה	PROPN	PROPN	_	3	nsubj	_	SpaceAfter=No
 5	,	_	PUNCT	PUNCT	_	3	punct	_	_
 6	יחד	יחד	ADV	ADV	_	8	case	_	_
 7	עם	עם	ADP	ADP	_	6	fixed	_	_
@@ -3105,14 +3105,14 @@
 11	ב	ב	ADP	ADP	_	13	case	_	_
 12	ה_	ה	DET	DET	PronType=Art	13	det:def	_	_
 13	מערב	מערב	NOUN	NOUN	Gender=Masc|Number=Sing	8	nmod	_	_
-14-15	התיכון	_	_	_	_	_	_	_	_
+14-15	התיכון	_	_	_	_	_	_	_	SpaceAfter=No
 14	ה	ה	DET	DET	PronType=Art	15	det:def	_	_
 15	תיכון	תיכון	ADJ	ADJ	Gender=Masc|Number=Sing	13	amod	_	_
 16	,	_	PUNCT	PUNCT	_	3	punct	_	_
 17-18	לסחרור	_	_	_	_	_	_	_	_
 17	ל	ל	ADP	ADP	_	18	case	_	_
 18	סחרור	סחרור	NOUN	NOUN	Gender=Masc|Number=Sing	3	iobj	_	_
-19	קשה	קשה	ADJ	ADJ	Gender=Masc|Number=Sing	18	amod	_	_
+19	קשה	קשה	ADJ	ADJ	Gender=Masc|Number=Sing	18	amod	_	SpaceAfter=No
 20	:	_	PUNCT	PUNCT	_	3	punct	_	_
 21-22	הנשיא	_	_	_	_	_	_	_	_
 21	ה	ה	DET	DET	PronType=Art	22	det:def	_	_
@@ -3124,7 +3124,7 @@
 27	חרם	חרם	NOUN	NOUN	Definite=Cons|Gender=Masc|Number=Sing	26	obj	_	_
 28	דגנים	דגן	NOUN	NOUN	Gender=Masc|Number=Plur	27	compound:smixut	_	_
 29	על	על	ADP	ADP	_	31	case	_	_
-30-31	הסובייטים	_	_	_	_	_	_	_	_
+30-31	הסובייטים	_	_	_	_	_	_	_	SpaceAfter=No
 30	ה	ה	DET	DET	PronType=Art	31	det:def	_	_
 31	סובייטים	סובייט	NOUN	NOUN	Gender=Masc|Number=Plur	26	iobj	_	_
 32	,	_	PUNCT	PUNCT	_	26	punct	_	_
@@ -3133,13 +3133,13 @@
 34	פלישה_	פלישה	NOUN	NOUN	Definite=Def|Gender=Fem|Number=Sing	26	obl	_	_
 35	_של_	של	ADP	ADP	_	36	case:gen	_	_
 36	_הם	הוא	PRON	PRON	Case=Gen|Gender=Masc|Number=Plur|Person=3|PronType=Prs	34	nmod:poss	_	_
-37-38	לאפגניסטן	_	_	_	_	_	_	_	_
+37-38	לאפגניסטן	_	_	_	_	_	_	_	SpaceAfter=No
 37	ל	ל	ADP	ADP	_	38	case	_	_
 38	אפגניסטן	אפגניסטן	PROPN	PROPN	_	34	nmod	_	_
 39	.	_	PUNCT	PUNCT	_	3	punct	_	_
 
 # sent_id = 84
-# text = איובה שילמה את המחיר עד אמצע שנות ה80 .
+# text = איובה שילמה את המחיר עד אמצע שנות ה80.
 1	איובה	איובה	PROPN	PROPN	_	2	nsubj	_	_
 2	שילמה	שילם	VERB	VERB	Gender=Fem|HebBinyan=PIEL|Number=Sing|Person=3|Tense=Past|Voice=Act	0	root	_	_
 3	את	את	PART	PART	Case=Acc	5	case:acc	_	_
@@ -3149,13 +3149,13 @@
 6	עד	עד	ADP	ADP	_	7	case	_	_
 7	אמצע	אמצע	NOUN	NOUN	Definite=Cons|Gender=Masc|Number=Sing	2	obl	_	_
 8	שנות	שנה	NOUN	NOUN	Definite=Cons|Gender=Fem|Number=Plur	7	compound:smixut	_	_
-9-10	ה80	_	_	_	_	_	_	_	_
+9-10	ה80	_	_	_	_	_	_	_	SpaceAfter=No
 9	ה	ה	DET	DET	PronType=Art	10	det:def	_	_
 10	80	_	NUM	NUM	_	8	compound:smixut	_	_
 11	.	_	PUNCT	PUNCT	_	2	punct	_	_
 
 # sent_id = 85
-# text = כלכלתה היתה שקועה במיתון קשה , בשעה שרוב המדינות האחרות בארה"ב נהנו משגשוג חסר תקדים .
+# text = כלכלתה היתה שקועה במיתון קשה, בשעה שרוב המדינות האחרות בארה"ב נהנו משגשוג חסר תקדים.
 1-3	כלכלתה	_	_	_	_	_	_	_	_
 1	כלכלה_	כלכלה	NOUN	NOUN	Definite=Def|Gender=Fem|Number=Sing	5	nsubj	_	_
 2	_של_	של	ADP	ADP	_	3	case:gen	_	_
@@ -3165,7 +3165,7 @@
 6-7	במיתון	_	_	_	_	_	_	_	_
 6	ב	ב	ADP	ADP	_	7	case	_	_
 7	מיתון	מיתון	NOUN	NOUN	Gender=Masc|Number=Sing	5	iobj	_	_
-8	קשה	קשה	ADJ	ADJ	Gender=Masc|Number=Sing	7	amod	_	_
+8	קשה	קשה	ADJ	ADJ	Gender=Masc|Number=Sing	7	amod	_	SpaceAfter=No
 9	,	_	PUNCT	PUNCT	_	5	punct	_	_
 10-11	בשעה	_	_	_	_	_	_	_	_
 10	ב	ב	ADP	ADP	_	11	case	_	_
@@ -3187,11 +3187,11 @@
 21	מ	מ	ADP	ADP	_	22	case	_	_
 22	שגשוג	שגשוג	NOUN	NOUN	Gender=Masc|Number=Sing	20	iobj	_	_
 23	חסר	חסר	ADJ	ADJ	Definite=Cons|Gender=Masc|Number=Sing	22	amod	_	_
-24	תקדים	תקדים	NOUN	NOUN	Gender=Masc|Number=Sing	23	compound:smixut	_	_
+24	תקדים	תקדים	NOUN	NOUN	Gender=Masc|Number=Sing	23	compound:smixut	_	SpaceAfter=No
 25	.	_	PUNCT	PUNCT	_	5	punct	_	_
 
 # sent_id = 86
-# text = לא רק מניעים אלטרואיסטיים מעוררים איפוא באיובה התנגדות למלחמות , אלא גם מניעים תועלתניים .
+# text = לא רק מניעים אלטרואיסטיים מעוררים איפוא באיובה התנגדות למלחמות, אלא גם מניעים תועלתניים.
 1	לא	לא	ADV	ADV	Polarity=Neg	2	advmod	_	_
 2	רק	רק	ADV	ADV	_	3	advmod	_	_
 3	מניעים	מניע	NOUN	NOUN	Gender=Masc|Number=Plur	5	nsubj	_	_
@@ -3202,18 +3202,18 @@
 7	ב	ב	ADP	ADP	_	8	case	_	_
 8	איובה	איובה	PROPN	PROPN	_	5	obl	_	_
 9	התנגדות	התנגדות	NOUN	NOUN	Gender=Fem|Number=Sing	5	obj	_	_
-10-11	למלחמות	_	_	_	_	_	_	_	_
+10-11	למלחמות	_	_	_	_	_	_	_	SpaceAfter=No
 10	ל	ל	ADP	ADP	_	11	case	_	_
 11	מלחמות	מלחמה	NOUN	NOUN	Gender=Fem|Number=Plur	9	nmod	_	_
 12	,	_	PUNCT	PUNCT	_	5	punct	_	_
 13	אלא	אלא	CCONJ	CCONJ	_	15	cc	_	_
 14	גם	גם	ADV	ADV	_	15	det	_	_
 15	מניעים	מניע	NOUN	NOUN	Gender=Masc|Number=Plur	5	conj	_	_
-16	תועלתניים	תועלתניים	ADJ	ADJ	_	15	amod	_	_
+16	תועלתניים	תועלתניים	ADJ	ADJ	_	15	amod	_	SpaceAfter=No
 17	.	_	PUNCT	PUNCT	_	5	punct	_	_
 
 # sent_id = 87
-# text = כאן אין אוהבים ביותר את הרעיון של מלחמה במפרץ הפרסי .
+# text = כאן אין אוהבים ביותר את הרעיון של מלחמה במפרץ הפרסי.
 1	כאן	כאן	ADV	ADV	_	3	advmod	_	_
 2	אין	_	ADV	ADV	Polarity=Neg	3	advmod	_	_
 3	אוהבים	אהב	VERB	VERB	Gender=Masc|HebBinyan=PAAL|Number=Plur|Person=1,2,3|VerbForm=Part|Voice=Act	0	root	_	_
@@ -3228,13 +3228,13 @@
 10	ב	ב	ADP	ADP	_	12	case	_	_
 11	ה_	ה	DET	DET	PronType=Art	12	det:def	_	_
 12	מפרץ	מפרץ	NOUN	NOUN	Gender=Masc|Number=Sing	9	nmod	_	_
-13-14	הפרסי	_	_	_	_	_	_	_	_
+13-14	הפרסי	_	_	_	_	_	_	_	SpaceAfter=No
 13	ה	ה	DET	DET	PronType=Art	14	det:def	_	_
 14	פרסי	פרסי	ADJ	ADJ	Gender=Masc|Number=Sing	12	amod	_	_
 15	.	_	PUNCT	PUNCT	_	3	punct	_	_
 
 # sent_id = 88
-# text = יום אחד בשבוע שעבר מרח העיתון המקומי " דה מוין רגיסטר " כותרת ענקית לרוחב מלוא העמוד הראשון של מוספו היומי .
+# text = יום אחד בשבוע שעבר מרח העיתון המקומי "דה מוין רגיסטר" כותרת ענקית לרוחב מלוא העמוד הראשון של מוספו היומי.
 1	יום	יום	NOUN	NOUN	Gender=Masc|Number=Sing	8	dep	_	_
 2	אחד	אחד	NUM	NUM	Gender=Masc|Number=Sing	1	nummod	_	_
 3-5	בשבוע	_	_	_	_	_	_	_	_
@@ -3251,10 +3251,10 @@
 11-12	המקומי	_	_	_	_	_	_	_	_
 11	ה	ה	DET	DET	PronType=Art	12	det:def	_	_
 12	מקומי	מקומי	ADJ	ADJ	Gender=Masc|Number=Sing	10	amod	_	_
-13	"	_	PUNCT	PUNCT	_	14	punct	_	_
+13	"	_	PUNCT	PUNCT	_	14	punct	_	SpaceAfter=No
 14	דה	דה	PROPN	PROPN	_	10	appos	_	_
 15	מוין	מוין	PROPN	PROPN	_	14	flat:name	_	_
-16	רגיסטר	רגיסטר	PROPN	PROPN	_	14	flat:name	_	_
+16	רגיסטר	רגיסטר	PROPN	PROPN	_	14	flat:name	_	SpaceAfter=No
 17	"	_	PUNCT	PUNCT	_	14	punct	_	_
 18	כותרת	כותרת	NOUN	NOUN	Gender=Fem|Number=Sing	8	obj	_	_
 19	ענקית	ענק	ADJ	ADJ	Gender=Fem|Number=Sing	18	amod	_	_
@@ -3273,31 +3273,31 @@
 28	מוסף_	מוסף	NOUN	NOUN	Definite=Def|Gender=Masc|Number=Sing	24	nmod	_	_
 29	_של_	של	ADP	ADP	_	30	case:gen	_	_
 30	_הוא	הוא	PRON	PRON	Case=Gen|Gender=Masc|Number=Sing|Person=3|PronType=Prs	28	nmod:poss	_	_
-31-32	היומי	_	_	_	_	_	_	_	_
+31-32	היומי	_	_	_	_	_	_	_	SpaceAfter=No
 31	ה	ה	DET	DET	PronType=Art	32	det:def	_	_
 32	יומי	יומי	ADJ	ADJ	Gender=Masc|Number=Sing	28	amod	_	_
 33	.	_	PUNCT	PUNCT	_	8	punct	_	_
 
 # sent_id = 89
-# text = " , אמרה הכותרת באנגלית , " שלום עכשיו " .
-1	"	_	PUNCT	PUNCT	_	3	punct	_	_
+# text = ", אמרה הכותרת באנגלית, "שלום עכשיו".
+1	"	_	PUNCT	PUNCT	_	3	punct	_	SpaceAfter=No
 2	,	_	PUNCT	PUNCT	_	3	punct	_	_
 3	אמרה	אמר	VERB	VERB	Gender=Fem|HebBinyan=PAAL|Number=Sing|Person=3|Tense=Past|Voice=Act	0	root	_	_
 4-5	הכותרת	_	_	_	_	_	_	_	_
 4	ה	ה	DET	DET	PronType=Art	5	det:def	_	_
 5	כותרת	כותרת	NOUN	NOUN	Gender=Fem|Number=Sing	3	nsubj	_	_
-6-7	באנגלית	_	_	_	_	_	_	_	_
+6-7	באנגלית	_	_	_	_	_	_	_	SpaceAfter=No
 6	ב	ב	ADP	ADP	_	7	case	_	_
 7	אנגלית	אנגלית	PROPN	PROPN	_	3	obl	_	_
 8	,	_	PUNCT	PUNCT	_	3	punct	_	_
-9	"	_	PUNCT	PUNCT	_	10	punct	_	_
+9	"	_	PUNCT	PUNCT	_	10	punct	_	SpaceAfter=No
 10	שלום	שלום	NOUN	NOUN	Gender=Masc|Number=Sing	3	obj	_	_
-11	עכשיו	עכשיו	ADV	ADV	_	10	advmod	_	_
-12	"	_	PUNCT	PUNCT	_	10	punct	_	_
+11	עכשיו	עכשיו	ADV	ADV	_	10	advmod	_	SpaceAfter=No
+12	"	_	PUNCT	PUNCT	_	10	punct	_	SpaceAfter=No
 13	.	_	PUNCT	PUNCT	_	3	punct	_	_
 
 # sent_id = 90
-# text = לצד האותיות האדומות הציב העיתון את סמל תנועת ההתנגדות למלחמת וייטנאם .
+# text = לצד האותיות האדומות הציב העיתון את סמל תנועת ההתנגדות למלחמת וייטנאם.
 1	לצד	לצד	ADP	ADP	_	3	case	_	_
 2-3	האותיות	_	_	_	_	_	_	_	_
 2	ה	ה	DET	DET	PronType=Art	3	det:def	_	_
@@ -3318,11 +3318,11 @@
 14-15	למלחמת	_	_	_	_	_	_	_	_
 14	ל	ל	ADP	ADP	_	15	case	_	_
 15	מלחמת	מלחמה	NOUN	NOUN	Definite=Cons|Gender=Fem|Number=Sing	13	nmod	_	_
-16	וייטנאם	וייטנאם	PROPN	PROPN	_	15	flat:name	_	_
+16	וייטנאם	וייטנאם	PROPN	PROPN	_	15	flat:name	_	SpaceAfter=No
 17	.	_	PUNCT	PUNCT	_	6	punct	_	_
 
 # sent_id = 91
-# text = ביום אחר פירסם העיתון בעמוד מאמרי המערכת שלו קריקטורה מקפיאת דם .
+# text = ביום אחר פירסם העיתון בעמוד מאמרי המערכת שלו קריקטורה מקפיאת דם.
 1-2	ביום	_	_	_	_	_	_	_	_
 1	ב	ב	ADP	ADP	_	2	case	_	_
 2	יום	יום	NOUN	NOUN	Gender=Masc|Number=Sing	4	obl	_	_
@@ -3343,11 +3343,11 @@
 13	_הוא	הוא	PRON	PRON	Gender=Masc|Number=Sing|Person=3|PronType=Prs	8	nmod:poss	_	_
 14	קריקטורה	קריקטורה	NOUN	NOUN	Gender=Fem|Number=Sing	4	obj	_	_
 15	מקפיאת	מקפיא	ADJ	ADJ	Definite=Cons|Gender=Fem|Number=Sing	14	amod	_	_
-16	דם	דם	NOUN	NOUN	Gender=Masc|Number=Sing	15	compound:smixut	_	_
+16	דם	דם	NOUN	NOUN	Gender=Masc|Number=Sing	15	compound:smixut	_	SpaceAfter=No
 17	.	_	PUNCT	PUNCT	_	4	punct	_	_
 
 # sent_id = 92
-# text = נראה בה מלאך המוות חבוש כאפייה , ומפיו בוקעות המלים : " קרא את שפתיי , גורג לא תהיה עוד וייטנאם " .
+# text = נראה בה מלאך המוות חבוש כאפייה, ומפיו בוקעות המלים: "קרא את שפתיי, גורג לא תהיה עוד וייטנאם".
 1	נראה	נראה	VERB	VERB	Gender=Masc|HebBinyan=NIFAL|Number=Sing|Person=3|Tense=Past|Voice=Mid	0	root	_	_
 2-3	בה	_	_	_	_	_	_	_	_
 2	בה	ב	ADP	ADP	_	3	case	_	_
@@ -3357,7 +3357,7 @@
 5	ה	ה	DET	DET	PronType=Art	6	det:def	_	_
 6	מוות	מוות	NOUN	NOUN	Gender=Masc|Number=Sing	4	compound:smixut	_	_
 7	חבוש	חבוש	ADJ	ADJ	Definite=Cons|Gender=Masc|Number=Sing	4	amod	_	_
-8	כאפייה	כפייה	NOUN	NOUN	_	7	compound:smixut	_	_
+8	כאפייה	כפייה	NOUN	NOUN	_	7	compound:smixut	_	SpaceAfter=No
 9	,	_	PUNCT	PUNCT	_	1	punct	_	_
 10-14	ומפיו	_	_	_	_	_	_	_	_
 10	ו	ו	CCONJ	CCONJ	_	15	cc	_	_
@@ -3366,41 +3366,41 @@
 13	_של_	של	ADP	ADP	_	14	case:gen	_	_
 14	_הוא	הוא	PRON	PRON	Case=Gen|Gender=Masc|Number=Sing|Person=3|PronType=Prs	12	nmod:poss	_	_
 15	בוקעות	בקע	VERB	VERB	Gender=Fem|HebBinyan=PAAL|Number=Plur|Person=1,2,3|VerbForm=Part|Voice=Act	1	conj	_	_
-16-17	המלים	_	_	_	_	_	_	_	_
+16-17	המלים	_	_	_	_	_	_	_	SpaceAfter=No
 16	ה	ה	DET	DET	PronType=Art	17	det:def	_	_
 17	מלים	מילה	NOUN	NOUN	Gender=Fem|Number=Plur	15	nsubj	_	_
 18	:	_	PUNCT	PUNCT	_	20	punct	_	_
-19	"	_	PUNCT	PUNCT	_	20	punct	_	_
+19	"	_	PUNCT	PUNCT	_	20	punct	_	SpaceAfter=No
 20	קרא	קרא	VERB	VERB	Gender=Masc|HebBinyan=PAAL|Mood=Imp|Number=Sing|Person=2|Voice=Act	17	appos	_	_
 21	את	את	PART	PART	Case=Acc	22	case:acc	_	_
-22	שפתיי	שפתיי	NOUN	NOUN	_	20	obj	_	_
+22	שפתיי	שפתיי	NOUN	NOUN	_	20	obj	_	SpaceAfter=No
 23	,	_	PUNCT	PUNCT	_	20	punct	_	_
 24	גורג	גורג	PROPN	PROPN	_	20	obl	_	_
 25	לא	לא	ADV	ADV	Polarity=Neg	26	advmod	_	_
 26	תהיה	היה	VERB	VERB	Gender=Fem|Number=Sing|Person=3|Polarity=Pos|Tense=Fut|VerbType=Cop	20	conj:discourse	_	_
 27	עוד	עוד	ADV	ADV	_	28	det	_	_
-28	וייטנאם	וייטנאם	PROPN	PROPN	_	26	nsubj	_	_
-29	"	_	PUNCT	PUNCT	_	20	punct	_	_
+28	וייטנאם	וייטנאם	PROPN	PROPN	_	26	nsubj	_	SpaceAfter=No
+29	"	_	PUNCT	PUNCT	_	20	punct	_	SpaceAfter=No
 30	.	_	PUNCT	PUNCT	_	1	punct	_	_
 
 # sent_id = 93
-# text = " גורג " הוא כמובן גורג בוש .
-1	"	_	PUNCT	PUNCT	_	2	punct	_	_
-2	גורג	גורג	PROPN	PROPN	_	6	nsubj:cop	_	_
+# text = "גורג" הוא כמובן גורג בוש.
+1	"	_	PUNCT	PUNCT	_	2	punct	_	SpaceAfter=No
+2	גורג	גורג	PROPN	PROPN	_	6	nsubj:cop	_	SpaceAfter=No
 3	"	_	PUNCT	PUNCT	_	2	punct	_	_
 4	הוא	הוא	VERB	VERB	Gender=Masc|Number=Sing|Person=3|Polarity=Pos|VerbForm=Part|VerbType=Cop	6	cop	_	_
 5	כמובן	כמובן	ADV	ADV	_	6	dep	_	_
 6	גורג	גורג	PROPN	PROPN	_	0	root	_	_
-7	בוש	בוש	PROPN	PROPN	_	6	flat:name	_	_
+7	בוש	בוש	PROPN	PROPN	_	6	flat:name	_	SpaceAfter=No
 8	.	_	PUNCT	PUNCT	_	6	punct	_	_
 
 # sent_id = 94
-# text = " קרא את שפתיי ... " היא פאראפראזה על סיסמת הבחירות הכוזבת של הנשיא מ8891 , " קראו את שפתיי לא יהיו מסים חדשים " .
-1	"	_	PUNCT	PUNCT	_	2	punct	_	_
+# text = "קרא את שפתיי..." היא פאראפראזה על סיסמת הבחירות הכוזבת של הנשיא מ8891, "קראו את שפתיי לא יהיו מסים חדשים".
+1	"	_	PUNCT	PUNCT	_	2	punct	_	SpaceAfter=No
 2	קרא	קרא	VERB	VERB	Gender=Masc|HebBinyan=PAAL|Mood=Imp|Number=Sing|Person=2|Voice=Act	8	nsubj:cop	_	_
 3	את	את	PART	PART	Case=Acc	4	case:acc	_	_
-4	שפתיי	שפתיי	NOUN	NOUN	_	2	obj	_	_
-5	...	_	PUNCT	PUNCT	_	2	punct	_	_
+4	שפתיי	שפתיי	NOUN	NOUN	_	2	obj	_	SpaceAfter=No
+5	...	_	PUNCT	PUNCT	_	2	punct	_	SpaceAfter=No
 6	"	_	PUNCT	PUNCT	_	2	punct	_	_
 7	היא	הוא	VERB	VERB	Gender=Fem|Number=Sing|Person=3|Polarity=Pos|VerbForm=Part|VerbType=Cop	8	cop	_	_
 8	פאראפראזה	פאראפראזה	NOUN	NOUN	_	0	root	_	_
@@ -3416,23 +3416,23 @@
 16-17	הנשיא	_	_	_	_	_	_	_	_
 16	ה	ה	DET	DET	PronType=Art	17	det:def	_	_
 17	נשיא	נשיא	NOUN	NOUN	Gender=Masc|Number=Sing	10	nmod	_	_
-18-19	מ8891	_	_	_	_	_	_	_	_
+18-19	מ8891	_	_	_	_	_	_	_	SpaceAfter=No
 18	מ	מ	ADP	ADP	_	19	case	_	_
 19	8891	_	NUM	NUM	_	10	nmod	_	_
 20	,	_	PUNCT	PUNCT	_	10	punct	_	_
-21	"	_	PUNCT	PUNCT	_	22	punct	_	_
+21	"	_	PUNCT	PUNCT	_	22	punct	_	SpaceAfter=No
 22	קראו	קרא	VERB	VERB	Gender=Fem,Masc|HebBinyan=PAAL|Mood=Imp|Number=Plur|Person=2|Voice=Act	10	appos	_	_
 23	את	את	PART	PART	Case=Acc	24	case:acc	_	_
 24	שפתיי	שפתיי	NOUN	NOUN	_	22	obj	_	_
 25	לא	לא	ADV	ADV	Polarity=Neg	26	advmod	_	_
 26	יהיו	היה	VERB	VERB	Gender=Fem,Masc|Number=Plur|Person=3|Polarity=Pos|Tense=Fut|VerbType=Cop	22	conj:discourse	_	_
 27	מסים	מס	NOUN	NOUN	Gender=Masc|Number=Plur	26	nsubj	_	_
-28	חדשים	חדש	ADJ	ADJ	Gender=Masc|Number=Plur	27	amod	_	_
-29	"	_	PUNCT	PUNCT	_	22	punct	_	_
+28	חדשים	חדש	ADJ	ADJ	Gender=Masc|Number=Plur	27	amod	_	SpaceAfter=No
+29	"	_	PUNCT	PUNCT	_	22	punct	_	SpaceAfter=No
 30	.	_	PUNCT	PUNCT	_	8	punct	_	_
 
 # sent_id = 95
-# text = במהלך נשף התרמה לטום הארקין , הסנאטור הדמוקרטי שהעמיד את עצמו השבוע לבחירה חוזרת , הסביר לי באריכות אחד הנוכחים כיצד יכולה ארה"ב ליישב את סכסוך המפרץ הפרסי , " אם רק תביא את העניין לפני בית המשפט הבין - לאומי " בהאג .
+# text = במהלך נשף התרמה לטום הארקין, הסנאטור הדמוקרטי שהעמיד את עצמו השבוע לבחירה חוזרת, הסביר לי באריכות אחד הנוכחים כיצד יכולה ארה"ב ליישב את סכסוך המפרץ הפרסי, "אם רק תביא את העניין לפני בית המשפט הבין-לאומי" בהאג.
 1-2	במהלך	_	_	_	_	_	_	_	_
 1	ב	ב	ADP	ADP	_	3	case	_	_
 2	מהלך	מהלך	NOUN	NOUN	Gender=Masc|Number=Sing	1	fixed	_	_
@@ -3441,7 +3441,7 @@
 5-6	לטום	_	_	_	_	_	_	_	_
 5	ל	ל	ADP	ADP	_	6	case	_	_
 6	טום	טום	PROPN	PROPN	_	3	nmod	_	_
-7	הארקין	הארקין	PROPN	PROPN	_	6	flat:name	_	_
+7	הארקין	הארקין	PROPN	PROPN	_	6	flat:name	_	SpaceAfter=No
 8	,	_	PUNCT	PUNCT	_	6	punct	_	_
 9-10	הסנאטור	_	_	_	_	_	_	_	_
 9	ה	ה	DET	DET	PronType=Art	10	det:def	_	_
@@ -3458,7 +3458,7 @@
 18-19	לבחירה	_	_	_	_	_	_	_	_
 18	ל	ל	ADP	ADP	_	19	case	_	_
 19	בחירה	בחירה	NOUN	NOUN	Gender=Fem|Number=Sing	14	iobj	_	_
-20	חוזרת	חוזר	ADJ	ADJ	Gender=Fem|Number=Sing	19	amod	_	_
+20	חוזרת	חוזר	ADJ	ADJ	Gender=Fem|Number=Sing	19	amod	_	SpaceAfter=No
 21	,	_	PUNCT	PUNCT	_	22	punct	_	_
 22	הסביר	הסביר	VERB	VERB	Gender=Masc|HebBinyan=HIFIL|Number=Sing|Person=3|Tense=Past|Voice=Act	0	root	_	_
 23-24	לי	_	_	_	_	_	_	_	_
@@ -3480,11 +3480,11 @@
 36-37	המפרץ	_	_	_	_	_	_	_	_
 36	ה	ה	DET	DET	PronType=Art	37	det:def	_	_
 37	מפרץ	מפרץ	NOUN	NOUN	Gender=Masc|Number=Sing	35	compound:smixut	_	_
-38-39	הפרסי	_	_	_	_	_	_	_	_
+38-39	הפרסי	_	_	_	_	_	_	_	SpaceAfter=No
 38	ה	ה	DET	DET	PronType=Art	39	det:def	_	_
 39	פרסי	פרסי	ADJ	ADJ	Gender=Masc|Number=Sing	37	amod	_	_
 40	,	_	PUNCT	PUNCT	_	31	punct	_	_
-41	"	_	PUNCT	PUNCT	_	44	punct	_	_
+41	"	_	PUNCT	PUNCT	_	44	punct	_	SpaceAfter=No
 42	אם	אם	SCONJ	SCONJ	_	44	mark	_	_
 43	רק	רק	ADV	ADV	_	44	advmod	_	_
 44	תביא	הביא	VERB	VERB	Gender=Fem|HebBinyan=HIFIL|Number=Sing|Person=3|Tense=Fut|Voice=Act	31	advcl	_	_
@@ -3497,19 +3497,19 @@
 50-51	המשפט	_	_	_	_	_	_	_	_
 50	ה	ה	DET	DET	PronType=Art	51	det:def	_	_
 51	משפט	משפט	NOUN	NOUN	Gender=Masc|Number=Sing	49	compound:smixut	_	_
-52-53	הבין	_	_	_	_	_	_	_	_
+52-53	הבין	_	_	_	_	_	_	_	SpaceAfter=No
 52	ה	ה	DET	DET	PronType=Art	55	det:def	_	_
 53	בין	בין	ADV	ADV	Prefix=Yes	55	advmod	_	_
-54	-	_	PUNCT	PUNCT	_	55	punct	_	_
-55	לאומי	לאומי	ADJ	ADJ	Gender=Masc|Number=Sing	49	amod	_	_
+54	-	_	PUNCT	PUNCT	_	55	punct	_	SpaceAfter=No
+55	לאומי	לאומי	ADJ	ADJ	Gender=Masc|Number=Sing	49	amod	_	SpaceAfter=No
 56	"	_	PUNCT	PUNCT	_	49	punct	_	_
-57-58	בהאג	_	_	_	_	_	_	_	_
+57-58	בהאג	_	_	_	_	_	_	_	SpaceAfter=No
 57	ב	ב	ADP	ADP	_	58	case	_	_
 58	האג	האג	PROPN	PROPN	_	49	nmod	_	_
 59	.	_	PUNCT	PUNCT	_	22	punct	_	_
 
 # sent_id = 96
-# text = התבוננתי בבן שיחי בהפתעה ניכרת .
+# text = התבוננתי בבן שיחי בהפתעה ניכרת.
 1	התבוננתי	התבונן	VERB	VERB	Gender=Fem,Masc|HebBinyan=HITPAEL|Number=Sing|Person=1|Tense=Past	0	root	_	_
 2-3	בבן	_	_	_	_	_	_	_	_
 2	ב	ב	ADP	ADP	_	3	case	_	_
@@ -3521,13 +3521,13 @@
 7-8	בהפתעה	_	_	_	_	_	_	_	_
 7	ב	ב	ADP	ADP	_	8	case	_	_
 8	הפתעה	הפתעה	NOUN	NOUN	Gender=Fem|Number=Sing	1	obl	_	_
-9	ניכרת	ניכר	ADJ	ADJ	Gender=Fem|Number=Sing	8	amod	_	_
+9	ניכרת	ניכר	ADJ	ADJ	Gender=Fem|Number=Sing	8	amod	_	SpaceAfter=No
 10	.	_	PUNCT	PUNCT	_	1	punct	_	_
 
 # sent_id = 97
-# text = טיעונים כאלה , שפעם היו מקובלים בין ליברלים בארה"ב , לא שמעתי כבר הרבה זמן .
+# text = טיעונים כאלה, שפעם היו מקובלים בין ליברלים בארה"ב, לא שמעתי כבר הרבה זמן.
 1	טיעונים	טיעון	NOUN	NOUN	Gender=Masc|Number=Plur	16	obj	_	_
-2-4	כאלה	_	_	_	_	_	_	_	_
+2-4	כאלה	_	_	_	_	_	_	_	SpaceAfter=No
 2	כ	כ	ADP	ADP	_	4	case	_	_
 3	ה_	ה	DET	DET	PronType=Art	4	det:def	_	_
 4	אלה	אלה	PRON	PRON	Gender=Masc|Number=Plur|Person=3|PronType=Dem	1	nmod	_	_
@@ -3539,7 +3539,7 @@
 9	מקובלים	מקובל	ADJ	ADJ	Gender=Masc|Number=Plur	1	acl:relcl	_	_
 10	בין	בין	ADP	ADP	_	11	case	_	_
 11	ליברלים	ליברל	NOUN	NOUN	Gender=Masc|Number=Plur	9	obl	_	_
-12-13	בארה"ב	_	_	_	_	_	_	_	_
+12-13	בארה"ב	_	_	_	_	_	_	_	SpaceAfter=No
 12	ב	ב	ADP	ADP	_	13	case	_	_
 13	ארה"ב	ארה"ב	PROPN	PROPN	Abbr=Yes	9	obl	_	_
 14	,	_	PUNCT	PUNCT	_	16	punct	_	_
@@ -3547,11 +3547,11 @@
 16	שמעתי	שמע	VERB	VERB	Gender=Fem,Masc|HebBinyan=PAAL|Number=Sing|Person=1|Tense=Past|Voice=Act	0	root	_	_
 17	כבר	כבר	ADV	ADV	_	19	det	_	_
 18	הרבה	הרבה	DET	DET	Definite=Cons	19	det	_	_
-19	זמן	זמן	NOUN	NOUN	Gender=Masc|Number=Sing	16	dep	_	_
+19	זמן	זמן	NOUN	NOUN	Gender=Masc|Number=Sing	16	dep	_	SpaceAfter=No
 20	.	_	PUNCT	PUNCT	_	16	punct	_	_
 
 # sent_id = 98
-# text = במעמקי המערב התיכון של ארה"ב קל להאמין שהעולם נברא בצלם אמריקה , שהוא מלא אנשים הגיוניים ופרגמטיים , ושהאותוריטה המוסרית של מוסד שאיש , כולל ארה"ב , מעולם לא לקח ברצינות תעשה רושם מיידי על סדאם חוסיין .
+# text = במעמקי המערב התיכון של ארה"ב קל להאמין שהעולם נברא בצלם אמריקה, שהוא מלא אנשים הגיוניים ופרגמטיים, ושהאותוריטה המוסרית של מוסד שאיש, כולל ארה"ב, מעולם לא לקח ברצינות תעשה רושם מיידי על סדאם חוסיין.
 1-2	במעמקי	_	_	_	_	_	_	_	_
 1	ב	ב	ADP	ADP	_	2	case	_	_
 2	מעמקי	מעמקים	NOUN	NOUN	Definite=Cons|Gender=Masc|Number=Plur	9	obl	_	_
@@ -3573,7 +3573,7 @@
 15-16	בצלם	_	_	_	_	_	_	_	_
 15	ב	ב	ADP	ADP	_	16	case	_	_
 16	צלם	צלם	NOUN	NOUN	Definite=Cons|Gender=Masc|Number=Sing	14	obl	_	_
-17	אמריקה	אמריקה	PROPN	PROPN	_	16	compound:smixut	_	_
+17	אמריקה	אמריקה	PROPN	PROPN	_	16	compound:smixut	_	SpaceAfter=No
 18	,	_	PUNCT	PUNCT	_	14	punct	_	_
 19-20	שהוא	_	_	_	_	_	_	_	_
 19	ש	ש	SCONJ	SCONJ	_	21	mark	_	_
@@ -3581,7 +3581,7 @@
 21	מלא	מלא	ADJ	ADJ	Gender=Masc|Number=Sing	14	conj	_	_
 22	אנשים	איש	NOUN	NOUN	Gender=Masc|HebSource=ConvUncertainHead|Number=Plur	21	dep	_	_
 23	הגיוניים	הגיוני	ADJ	ADJ	Gender=Masc|Number=Plur	22	amod	_	_
-24-25	ופרגמטיים	_	_	_	_	_	_	_	_
+24-25	ופרגמטיים	_	_	_	_	_	_	_	SpaceAfter=No
 24	ו	ו	CCONJ	CCONJ	_	25	cc	_	_
 25	פרגמטיים	פרגמטי	ADJ	ADJ	Gender=Masc|Number=Plur	23	conj	_	_
 26	,	_	PUNCT	PUNCT	_	14	punct	_	_
@@ -3595,12 +3595,12 @@
 32	מוסרית	מוסרי	ADJ	ADJ	Gender=Fem|Number=Sing	30	amod	_	_
 33	של	של	PART	PART	Case=Gen	34	case:gen	_	_
 34	מוסד	מוסד	NOUN	NOUN	Gender=Masc|Number=Sing	30	nmod	_	_
-35-36	שאיש	_	_	_	_	_	_	_	_
+35-36	שאיש	_	_	_	_	_	_	_	SpaceAfter=No
 35	ש	ש	SCONJ	SCONJ	_	43	mark	_	_
 36	איש	איש	NOUN	NOUN	Gender=Masc|Number=Sing	43	nsubj	_	_
 37	,	_	PUNCT	PUNCT	_	39	punct	_	_
 38	כולל	כלל	VERB	VERB	Gender=Masc|HebBinyan=PAAL|Number=Sing|Person=1,2,3|VerbForm=Part|Voice=Act	39	case	_	_
-39	ארה"ב	ארה"ב	PROPN	PROPN	Abbr=Yes	36	appos	_	_
+39	ארה"ב	ארה"ב	PROPN	PROPN	Abbr=Yes	36	appos	_	SpaceAfter=No
 40	,	_	PUNCT	PUNCT	_	39	punct	_	_
 41	מעולם	מעולם	ADV	ADV	_	43	advmod:phrase	_	_
 42	לא	לא	ADV	ADV	HebSource=ConvUncertainHead|Polarity=Neg	41	dep	_	_
@@ -3613,11 +3613,11 @@
 48	מיידי	מיידי	ADJ	ADJ	Gender=Masc|Number=Sing	47	amod	_	_
 49	על	על	ADP	ADP	_	50	case	_	_
 50	סדאם	סדאם	PROPN	PROPN	_	46	obl	_	_
-51	חוסיין	חוסיין	PROPN	PROPN	_	50	flat:name	_	_
+51	חוסיין	חוסיין	PROPN	PROPN	_	50	flat:name	_	SpaceAfter=No
 52	.	_	PUNCT	PUNCT	_	9	punct	_	_
 
 # sent_id = 99
-# text = המשבר במפרץ הפרסי לא היה נושא בחירות מרכזי באיובה .
+# text = המשבר במפרץ הפרסי לא היה נושא בחירות מרכזי באיובה.
 1-2	המשבר	_	_	_	_	_	_	_	_
 1	ה	ה	DET	DET	PronType=Art	2	det:def	_	_
 2	משבר	משבר	NOUN	NOUN	Gender=Masc|Number=Sing	10	nsubj	_	_
@@ -3633,16 +3633,16 @@
 10	נושא	נושא	NOUN	NOUN	Definite=Cons|Gender=Masc|Number=Sing	0	root	_	_
 11	בחירות	בחירות	NOUN	NOUN	Gender=Fem|Number=Plur	10	compound:smixut	_	_
 12	מרכזי	מרכזי	ADJ	ADJ	Gender=Masc|Number=Sing	10	amod	_	_
-13-14	באיובה	_	_	_	_	_	_	_	_
+13-14	באיובה	_	_	_	_	_	_	_	SpaceAfter=No
 13	ב	ב	ADP	ADP	_	14	case	_	_
 14	איובה	איובה	PROPN	PROPN	_	10	nmod	_	_
 15	.	_	PUNCT	PUNCT	_	10	punct	_	_
 
 # sent_id = 100
-# text = טום הארקין הליברלי , ויריבו הרפובליקאי השמרן טום טקי , אמנם לא יכלו להסכים על שום עניין , אבל נטו להסכים על המפרץ הפרסי .
+# text = טום הארקין הליברלי, ויריבו הרפובליקאי השמרן טום טקי, אמנם לא יכלו להסכים על שום עניין, אבל נטו להסכים על המפרץ הפרסי.
 1	טום	טום	PROPN	PROPN	_	19	nsubj	_	_
 2	הארקין	הארקין	PROPN	PROPN	_	1	flat:name	_	_
-3-4	הליברלי	_	_	_	_	_	_	_	_
+3-4	הליברלי	_	_	_	_	_	_	_	SpaceAfter=No
 3	ה	ה	DET	DET	PronType=Art	4	det:def	_	_
 4	ליברלי	ליברלי	ADJ	ADJ	Gender=Masc|Number=Sing	1	amod	_	_
 5	,	_	PUNCT	PUNCT	_	1	punct	_	_
@@ -3658,7 +3658,7 @@
 12	ה	ה	DET	DET	PronType=Art	13	det:def	_	_
 13	שמרן	שמרן	ADJ	ADJ	Gender=Masc|Number=Sing	7	amod	_	_
 14	טום	טום	PROPN	PROPN	_	7	appos	_	_
-15	טקי	טקי	PROPN	PROPN	_	14	flat:name	_	_
+15	טקי	טקי	PROPN	PROPN	_	14	flat:name	_	SpaceAfter=No
 16	,	_	PUNCT	PUNCT	_	19	punct	_	_
 17	אמנם	אמנם	ADV	ADV	_	19	advmod	_	_
 18	לא	לא	ADV	ADV	Polarity=Neg	19	advmod	_	_
@@ -3666,7 +3666,7 @@
 20	להסכים	הסכים	VERB	VERB	HebBinyan=HIFIL|VerbForm=Inf|Voice=Act	19	xcomp	_	_
 21	על	על	ADP	ADP	_	23	case	_	_
 22	שום	שום	DET	DET	Definite=Cons	23	det	_	_
-23	עניין	עניין	NOUN	NOUN	Gender=Masc|Number=Sing	20	iobj	_	_
+23	עניין	עניין	NOUN	NOUN	Gender=Masc|Number=Sing	20	iobj	_	SpaceAfter=No
 24	,	_	PUNCT	PUNCT	_	19	punct	_	_
 25	אבל	אבל	CCONJ	CCONJ	_	26	cc	_	_
 26	נטו	נטה	VERB	VERB	Gender=Fem,Masc|HebBinyan=PAAL|Number=Plur|Person=3|Tense=Past|Voice=Act	19	conj	_	_
@@ -3675,16 +3675,16 @@
 29-30	המפרץ	_	_	_	_	_	_	_	_
 29	ה	ה	DET	DET	PronType=Art	30	det:def	_	_
 30	מפרץ	מפרץ	NOUN	NOUN	Gender=Masc|Number=Sing	27	obl	_	_
-31-32	הפרסי	_	_	_	_	_	_	_	_
+31-32	הפרסי	_	_	_	_	_	_	_	SpaceAfter=No
 31	ה	ה	DET	DET	PronType=Art	32	det:def	_	_
 32	פרסי	פרסי	ADJ	ADJ	Gender=Masc|Number=Sing	30	amod	_	_
 33	.	_	PUNCT	PUNCT	_	19	punct	_	_
 
 # sent_id = 101
-# text = שניהם תומכים בנשיא , ושניהם מאמינים בצורך בזהירות .
+# text = שניהם תומכים בנשיא, ושניהם מאמינים בצורך בזהירות.
 1	שניהם	שניים	PRON	PRON	Gender=Masc|Number=Plur|Person=3|PronType=Prs	2	nsubj	_	_
 2	תומכים	תמך	VERB	VERB	Gender=Masc|HebBinyan=PAAL|Number=Plur|Person=1,2,3|VerbForm=Part|Voice=Act	0	root	_	_
-3-5	בנשיא	_	_	_	_	_	_	_	_
+3-5	בנשיא	_	_	_	_	_	_	_	SpaceAfter=No
 3	ב	ב	ADP	ADP	_	5	case	_	_
 4	ה_	ה	DET	DET	PronType=Art	5	det:def	_	_
 5	נשיא	נשיא	NOUN	NOUN	Gender=Masc|Number=Sing	2	iobj	_	_
@@ -3697,13 +3697,13 @@
 10	ב	ב	ADP	ADP	_	12	case	_	_
 11	ה_	ה	DET	DET	PronType=Art	12	det:def	_	_
 12	צורך	צורך	NOUN	NOUN	Gender=Masc|Number=Sing	9	iobj	_	_
-13-14	בזהירות	_	_	_	_	_	_	_	_
+13-14	בזהירות	_	_	_	_	_	_	_	SpaceAfter=No
 13	ב	ב	ADP	ADP	_	14	case	_	_
 14	זהירות	זהירות	NOUN	NOUN	Gender=Fem|Number=Sing	12	nmod	_	_
 15	.	_	PUNCT	PUNCT	_	2	punct	_	_
 
 # sent_id = 102
-# text = בימי המלחמה הקרה היה טוקי אנטי - קומוניסט נלהב , והארקין היה יונה נלהבת .
+# text = בימי המלחמה הקרה היה טוקי אנטי - קומוניסט נלהב, והארקין היה יונה נלהבת.
 1-2	בימי	_	_	_	_	_	_	_	_
 1	ב	ב	ADP	ADP	_	2	case	_	_
 2	ימי	יום	NOUN	NOUN	Definite=Cons|Gender=Masc|Number=Plur	11	nmod	_	_
@@ -3718,18 +3718,18 @@
 9	אנטי	אנטי	ADV	ADV	HebSource=ConvUncertainHead|Prefix=Yes	11	dep	_	_
 10	-	_	PUNCT	PUNCT	_	11	punct	_	_
 11	קומוניסט	קומוניסט	NOUN	NOUN	Gender=Masc|Number=Sing	0	root	_	_
-12	נלהב	נלהב	VERB	VERB	Gender=Masc|HebBinyan=NIFAL|Number=Sing|Person=1,2,3|VerbForm=Part|Voice=Mid	11	amod	_	_
+12	נלהב	נלהב	VERB	VERB	Gender=Masc|HebBinyan=NIFAL|Number=Sing|Person=1,2,3|VerbForm=Part|Voice=Mid	11	amod	_	SpaceAfter=No
 13	,	_	PUNCT	PUNCT	_	11	punct	_	_
 14-15	והארקין	_	_	_	_	_	_	_	_
 14	ו	ו	CCONJ	CCONJ	_	17	cc	_	_
 15	הארקין	הארקין	PROPN	PROPN	_	17	nsubj	_	_
 16	היה	היה	VERB	VERB	Gender=Masc|Number=Sing|Person=3|Polarity=Pos|Tense=Past|VerbType=Cop	17	aux	_	_
 17	יונה	יון	NOUN	NOUN	Gender=Fem|Number=Sing	11	conj	_	_
-18	נלהבת	נלהב	VERB	VERB	Gender=Fem|HebBinyan=NIFAL|Number=Sing|Person=1,2,3|VerbForm=Part|Voice=Mid	17	amod	_	_
+18	נלהבת	נלהב	VERB	VERB	Gender=Fem|HebBinyan=NIFAL|Number=Sing|Person=1,2,3|VerbForm=Part|Voice=Mid	17	amod	_	SpaceAfter=No
 19	.	_	PUNCT	PUNCT	_	11	punct	_	_
 
 # sent_id = 103
-# text = טוקי תמך בכל סעיף הוצאות צבאיות אפשרי , וחייב את המאבק להפלת ממשלת ניקרגואה ; הארקין רצה קיצוצים ניכרים בתקציב הביטחון , ועמד בראש המאבק בסנאט נגד הסיוע לקונטראס .
+# text = טוקי תמך בכל סעיף הוצאות צבאיות אפשרי, וחייב את המאבק להפלת ממשלת ניקרגואה; הארקין רצה קיצוצים ניכרים בתקציב הביטחון, ועמד בראש המאבק בסנאט נגד הסיוע לקונטראס.
 1	טוקי	טוקי	PROPN	PROPN	_	2	nsubj	_	_
 2	תמך	תמך	VERB	VERB	Gender=Masc|HebBinyan=PAAL|Number=Sing|Person=3|Tense=Past|Voice=Act	0	root	_	_
 3-4	בכל	_	_	_	_	_	_	_	_
@@ -3738,7 +3738,7 @@
 5	סעיף	סעיף	NOUN	NOUN	Definite=Cons|Gender=Masc|Number=Sing	2	iobj	_	_
 6	הוצאות	הוצאה	NOUN	NOUN	Gender=Fem|Number=Plur	5	compound:smixut	_	_
 7	צבאיות	צבאי	ADJ	ADJ	Gender=Fem|Number=Plur	6	amod	_	_
-8	אפשרי	אפשרי	ADJ	ADJ	Gender=Masc|Number=Sing	5	amod	_	_
+8	אפשרי	אפשרי	ADJ	ADJ	Gender=Masc|Number=Sing	5	amod	_	SpaceAfter=No
 9	,	_	PUNCT	PUNCT	_	2	punct	_	_
 10-11	וחייב	_	_	_	_	_	_	_	_
 10	ו	ו	CCONJ	CCONJ	_	11	cc	_	_
@@ -3751,7 +3751,7 @@
 15	ל	ל	ADP	ADP	_	16	case	_	_
 16	הפלת	הפלה	NOUN	NOUN	Definite=Cons|Gender=Fem|Number=Sing	14	nmod	_	_
 17	ממשלת	ממשלה	NOUN	NOUN	Definite=Cons|Gender=Fem|Number=Sing	16	compound:smixut	_	_
-18	ניקרגואה	ניקרגוואה	PROPN	PROPN	_	17	compound:smixut	_	_
+18	ניקרגואה	ניקרגוואה	PROPN	PROPN	_	17	compound:smixut	_	SpaceAfter=No
 19	;	_	PUNCT	PUNCT	_	21	cc	_	_
 20	הארקין	הארקין	PROPN	PROPN	_	21	nsubj	_	_
 21	רצה	רצה	VERB	VERB	Gender=Masc|HebBinyan=PAAL|Number=Sing|Person=3|Tense=Past|Voice=Act	2	conj	_	_
@@ -3760,7 +3760,7 @@
 24-25	בתקציב	_	_	_	_	_	_	_	_
 24	ב	ב	ADP	ADP	_	25	case	_	_
 25	תקציב	תקציב	NOUN	NOUN	Definite=Cons|Gender=Masc|Number=Sing	22	nmod	_	_
-26-27	הביטחון	_	_	_	_	_	_	_	_
+26-27	הביטחון	_	_	_	_	_	_	_	SpaceAfter=No
 26	ה	ה	DET	DET	PronType=Art	27	det:def	_	_
 27	ביטחון	ביטחון	NOUN	NOUN	Gender=Masc|Number=Sing	25	compound:smixut	_	_
 28	,	_	PUNCT	PUNCT	_	21	punct	_	_
@@ -3781,14 +3781,14 @@
 39-40	הסיוע	_	_	_	_	_	_	_	_
 39	ה	ה	DET	DET	PronType=Art	40	det:def	_	_
 40	סיוע	סיוע	NOUN	NOUN	Gender=Masc|Number=Sing	34	nmod	_	_
-41-43	לקונטראס	_	_	_	_	_	_	_	_
+41-43	לקונטראס	_	_	_	_	_	_	_	SpaceAfter=No
 41	ל	_	ADP	ADP	_	43	case	_	_
 42	ה_	_	DET	DET	PronType=Art	43	det:def	_	_
 43	קונטראס	לקונטראס	PROPN	PROPN	_	40	nmod	_	_
 44	.	_	PUNCT	PUNCT	_	2	punct	_	_
 
 # sent_id = 104
-# text = במפרץ הפרסי שניהם נצים יוניים , או יונים נציות , במידה כמעט שווה .
+# text = במפרץ הפרסי שניהם נצים יוניים, או יונים נציות, במידה כמעט שווה.
 1-3	במפרץ	_	_	_	_	_	_	_	_
 1	ב	ב	ADP	ADP	_	3	case	_	_
 2	ה_	ה	DET	DET	PronType=Art	3	det:def	_	_
@@ -3798,21 +3798,21 @@
 5	פרסי	פרסי	ADJ	ADJ	Gender=Masc|Number=Sing	3	amod	_	_
 6	שניהם	שניים	PRON	PRON	Gender=Masc|Number=Plur|Person=3|PronType=Prs	7	nsubj	_	_
 7	נצים	נץ	NOUN	NOUN	Gender=Masc|Number=Plur	0	root	_	_
-8	יוניים	יוני	ADJ	ADJ	Gender=Masc|Number=Plur	7	amod	_	_
+8	יוניים	יוני	ADJ	ADJ	Gender=Masc|Number=Plur	7	amod	_	SpaceAfter=No
 9	,	_	PUNCT	PUNCT	_	7	punct	_	_
 10	או	או	CCONJ	CCONJ	_	11	cc	_	_
 11	יונים	יון	NOUN	NOUN	Gender=Masc|Number=Plur	7	conj	_	_
-12	נציות	ניצי	ADJ	ADJ	Gender=Fem|Number=Plur	11	amod	_	_
+12	נציות	ניצי	ADJ	ADJ	Gender=Fem|Number=Plur	11	amod	_	SpaceAfter=No
 13	,	_	PUNCT	PUNCT	_	7	punct	_	_
 14-15	במידה	_	_	_	_	_	_	_	_
 14	ב	ב	ADP	ADP	_	15	case	_	_
 15	מידה	מידה	NOUN	NOUN	Gender=Fem|Number=Sing	7	nmod	_	_
 16	כמעט	כמעט	ADV	ADV	_	17	advmod	_	_
-17	שווה	שווה	ADJ	ADJ	Gender=Fem|Number=Sing	15	amod	_	_
+17	שווה	שווה	ADJ	ADJ	Gender=Fem|Number=Sing	15	amod	_	SpaceAfter=No
 18	.	_	PUNCT	PUNCT	_	7	punct	_	_
 
 # sent_id = 105
-# text = בהעדר קומוניזם יש פרגמטיזם ואל פני השטח חוזרת גם מידה הגונה של בדלנות אינסטינקטיווית , אפיון היסטורי של מדינות המערב התיכון האמריקאי .
+# text = בהעדר קומוניזם יש פרגמטיזם ואל פני השטח חוזרת גם מידה הגונה של בדלנות אינסטינקטיווית, אפיון היסטורי של מדינות המערב התיכון האמריקאי.
 1-2	בהעדר	_	_	_	_	_	_	_	_
 1	ב	ב	ADP	ADP	_	3	case	_	_
 2	העדר	העדר	NOUN	NOUN	Gender=Masc|Number=Sing	1	fixed	_	_
@@ -3832,7 +3832,7 @@
 14	הגונה	הגון	ADJ	ADJ	Gender=Fem|Number=Sing	13	amod	_	_
 15	של	של	PART	PART	Case=Gen	16	case:gen	_	_
 16	בדלנות	בדלנות	NOUN	NOUN	Gender=Fem|Number=Sing	13	nmod	_	_
-17	אינסטינקטיווית	אינסטינקטיבי	ADJ	ADJ	Gender=Fem|Number=Sing	16	amod	_	_
+17	אינסטינקטיווית	אינסטינקטיבי	ADJ	ADJ	Gender=Fem|Number=Sing	16	amod	_	SpaceAfter=No
 18	,	_	PUNCT	PUNCT	_	13	punct	_	_
 19	אפיון	אפיון	NOUN	NOUN	Gender=Masc|Number=Sing	13	appos	_	_
 20	היסטורי	היסטורי	ADJ	ADJ	Gender=Masc|Number=Sing	19	amod	_	_
@@ -3844,13 +3844,13 @@
 25-26	התיכון	_	_	_	_	_	_	_	_
 25	ה	ה	DET	DET	PronType=Art	26	det:def	_	_
 26	תיכון	תיכון	ADJ	ADJ	Gender=Masc|Number=Sing	24	amod	_	_
-27-28	האמריקאי	_	_	_	_	_	_	_	_
+27-28	האמריקאי	_	_	_	_	_	_	_	SpaceAfter=No
 27	ה	ה	DET	DET	PronType=Art	28	det:def	_	_
 28	אמריקאי	אמריקני	ADJ	ADJ	Gender=Masc|Number=Sing	24	amod	_	_
 29	.	_	PUNCT	PUNCT	_	4	punct	_	_
 
 # sent_id = 106
-# text = במהלך מערכת הבחירות הקרין מטהו של טוקי תשדיר טלוויזיה , שאחד מסעיפיו היה התנגדות לסיוע חוץ .
+# text = במהלך מערכת הבחירות הקרין מטהו של טוקי תשדיר טלוויזיה, שאחד מסעיפיו היה התנגדות לסיוע חוץ.
 1-2	במהלך	_	_	_	_	_	_	_	_
 1	ב	ב	ADP	ADP	_	3	case	_	_
 2	מהלך	מהלך	NOUN	NOUN	Gender=Masc|Number=Sing	1	fixed	_	_
@@ -3866,7 +3866,7 @@
 10	של	של	PART	PART	Case=Gen	11	case:gen	_	_
 11	טוקי	טוקי	PROPN	PROPN	_	7	nmod:poss	_	_
 12	תשדיר	תשדיר	NOUN	NOUN	Definite=Cons|Gender=Masc|Number=Sing	6	obj	_	_
-13	טלוויזיה	טלוויזיה	NOUN	NOUN	Gender=Fem|Number=Sing	12	compound:smixut	_	_
+13	טלוויזיה	טלוויזיה	NOUN	NOUN	Gender=Fem|Number=Sing	12	compound:smixut	_	SpaceAfter=No
 14	,	_	PUNCT	PUNCT	_	12	punct	_	_
 15-16	שאחד	_	_	_	_	_	_	_	_
 15	ש	ש	SCONJ	SCONJ	_	22	mark	_	_
@@ -3881,11 +3881,11 @@
 23-24	לסיוע	_	_	_	_	_	_	_	_
 23	ל	ל	ADP	ADP	_	24	case	_	_
 24	סיוע	סיוע	NOUN	NOUN	Definite=Cons|Gender=Masc|Number=Sing	22	nmod	_	_
-25	חוץ	חוץ	NOUN	NOUN	Gender=Masc|Number=Sing	24	compound:smixut	_	_
+25	חוץ	חוץ	NOUN	NOUN	Gender=Masc|Number=Sing	24	compound:smixut	_	SpaceAfter=No
 26	.	_	PUNCT	PUNCT	_	6	punct	_	_
 
 # sent_id = 107
-# text = בעיני השדולה הפרו - ישראלית בוואשינגטון , התנגדות לסיוע חוץ מעמידה את המתנגד מחוץ למחנה גם אם אינה מוסבת ספציפית על ישראל .
+# text = בעיני השדולה הפרו - ישראלית בוואשינגטון, התנגדות לסיוע חוץ מעמידה את המתנגד מחוץ למחנה גם אם אינה מוסבת ספציפית על ישראל.
 1-2	בעיני	_	_	_	_	_	_	_	_
 1	ב	ב	ADP	ADP	_	2	case	_	_
 2	עיני	עין	NOUN	NOUN	Definite=Cons|Gender=Fem|Number=Plur	16	obl	_	_
@@ -3897,7 +3897,7 @@
 6	פרו	פרו	ADV	ADV	Prefix=Yes	8	advmod	_	_
 7	-	_	PUNCT	PUNCT	_	8	punct	_	_
 8	ישראלית	ישראלי	ADJ	ADJ	Gender=Fem|Number=Sing	4	amod	_	_
-9-10	בוואשינגטון	_	_	_	_	_	_	_	_
+9-10	בוואשינגטון	_	_	_	_	_	_	_	SpaceAfter=No
 9	ב	ב	ADP	ADP	_	10	case	_	_
 10	וואשינגטון	ואשינגטון	PROPN	PROPN	_	4	nmod	_	_
 11	,	_	PUNCT	PUNCT	_	16	punct	_	_
@@ -3924,11 +3924,11 @@
 28	מוסבת	הוסב	VERB	VERB	Gender=Fem|HebBinyan=HUFAL|Number=Sing|Person=1,2,3|VerbForm=Part|Voice=Pass	16	advcl	_	_
 29	ספציפית	ספציפית	ADV	ADV	_	28	advmod	_	_
 30	על	על	ADP	ADP	_	31	case	_	_
-31	ישראל	ישראל	PROPN	PROPN	_	28	iobj	_	_
+31	ישראל	ישראל	PROPN	PROPN	_	28	iobj	_	SpaceAfter=No
 32	.	_	PUNCT	PUNCT	_	16	punct	_	_
 
 # sent_id = 108
-# text = פעילים פרו - ישראליים עודדו מאז ומעולם יהודים לתרום כספים למועמדים , הנאבקים נגד מתנגדי סיוע החוץ .
+# text = פעילים פרו - ישראליים עודדו מאז ומעולם יהודים לתרום כספים למועמדים, הנאבקים נגד מתנגדי סיוע החוץ.
 1	פעילים	פעיל	NOUN	NOUN	Gender=Masc|Number=Plur	5	nsubj	_	_
 2	פרו	פרו	ADV	ADV	Prefix=Yes	4	advmod	_	_
 3	-	_	PUNCT	PUNCT	_	4	punct	_	_
@@ -3941,7 +3941,7 @@
 9	יהודים	יהודי	NOUN	NOUN	Gender=Masc|Number=Plur	5	obj	_	_
 10	לתרום	תרם	VERB	VERB	HebBinyan=PAAL|VerbForm=Inf|Voice=Act	5	xcomp	_	_
 11	כספים	כסף	NOUN	NOUN	Gender=Masc|Number=Plur	10	obj	_	_
-12-13	למועמדים	_	_	_	_	_	_	_	_
+12-13	למועמדים	_	_	_	_	_	_	_	SpaceAfter=No
 12	ל	ל	ADP	ADP	_	13	case	_	_
 13	מועמדים	מועמד	NOUN	NOUN	Gender=Masc|Number=Plur	10	obl	_	_
 14	,	_	PUNCT	PUNCT	_	13	punct	_	_
@@ -3951,24 +3951,24 @@
 17	נגד	נגד	ADP	ADP	_	18	case	_	_
 18	מתנגדי	מתנגד	NOUN	NOUN	Definite=Cons|Gender=Masc|Number=Plur	16	iobj	_	_
 19	סיוע	סיוע	NOUN	NOUN	Definite=Cons|Gender=Masc|Number=Sing	18	compound:smixut	_	_
-20-21	החוץ	_	_	_	_	_	_	_	_
+20-21	החוץ	_	_	_	_	_	_	_	SpaceAfter=No
 20	ה	ה	DET	DET	PronType=Art	21	det:def	_	_
 21	חוץ	חוץ	NOUN	NOUN	Gender=Masc|Number=Sing	19	compound:smixut	_	_
 22	.	_	PUNCT	PUNCT	_	5	punct	_	_
 
 # sent_id = 109
-# text = ממילא , טום הארקין , תומך עקיב בסיוע החוץ , היה אחד המקבלים הגדולים ביותר של תרומות יהודיות בשש השנים האחרונות .
-1	ממילא	ממילא	ADV	ADV	_	16	advmod	_	_
+# text = ממילא, טום הארקין, תומך עקיב בסיוע החוץ, היה אחד המקבלים הגדולים ביותר של תרומות יהודיות בשש השנים האחרונות.
+1	ממילא	ממילא	ADV	ADV	_	16	advmod	_	SpaceAfter=No
 2	,	_	PUNCT	PUNCT	_	16	punct	_	_
 3	טום	טום	PROPN	PROPN	_	16	nsubj	_	_
-4	הארקין	הארקין	PROPN	PROPN	_	3	flat:name	_	_
+4	הארקין	הארקין	PROPN	PROPN	_	3	flat:name	_	SpaceAfter=No
 5	,	_	PUNCT	PUNCT	_	3	punct	_	_
 6	תומך	תומך	NOUN	NOUN	Gender=Masc|Number=Sing	3	appos	_	_
 7	עקיב	עקיב	ADJ	ADJ	Gender=Masc|Number=Sing	6	amod	_	_
 8-9	בסיוע	_	_	_	_	_	_	_	_
 8	ב	ב	ADP	ADP	_	9	case	_	_
 9	סיוע	סיוע	NOUN	NOUN	Definite=Cons|Gender=Masc|Number=Sing	6	iobj	_	_
-10-11	החוץ	_	_	_	_	_	_	_	_
+10-11	החוץ	_	_	_	_	_	_	_	SpaceAfter=No
 10	ה	ה	DET	DET	PronType=Art	11	det:def	_	_
 11	חוץ	חוץ	NOUN	NOUN	Gender=Masc|Number=Sing	9	compound:smixut	_	_
 12	,	_	PUNCT	PUNCT	_	16	punct	_	_
@@ -3990,17 +3990,17 @@
 25-26	השנים	_	_	_	_	_	_	_	_
 25	ה	ה	DET	DET	PronType=Art	26	det:def	_	_
 26	שנים	שנה	NOUN	NOUN	Gender=Fem|Number=Plur	16	nmod	_	_
-27-28	האחרונות	_	_	_	_	_	_	_	_
+27-28	האחרונות	_	_	_	_	_	_	_	SpaceAfter=No
 27	ה	ה	DET	DET	PronType=Art	28	det:def	_	_
 28	אחרונות	אחרון	ADJ	ADJ	Gender=Fem|Number=Plur	26	amod	_	_
 29	.	_	PUNCT	PUNCT	_	16	punct	_	_
 
 # sent_id = 110
-# text = לפי מקור יהודי באיובה , הארקין קיבל 002 אלף דולר מוועדי פעולה פוליטיים פרו - ישראליים בכל רחבי ארה"ב .
+# text = לפי מקור יהודי באיובה, הארקין קיבל 002 אלף דולר מוועדי פעולה פוליטיים פרו - ישראליים בכל רחבי ארה"ב.
 1	לפי	לפי	ADP	ADP	_	2	case	_	_
 2	מקור	מקור	NOUN	NOUN	Gender=Masc|Number=Sing	8	obl	_	_
 3	יהודי	יהודי	ADJ	ADJ	Gender=Masc|Number=Sing	2	amod	_	_
-4-5	באיובה	_	_	_	_	_	_	_	_
+4-5	באיובה	_	_	_	_	_	_	_	SpaceAfter=No
 4	ב	ב	ADP	ADP	_	5	case	_	_
 5	איובה	איובה	PROPN	PROPN	_	2	nmod	_	_
 6	,	_	PUNCT	PUNCT	_	8	punct	_	_
@@ -4021,20 +4021,20 @@
 19	ב	ב	ADP	ADP	_	21	case	_	_
 20	כל	כול	DET	DET	Definite=Cons	21	det	_	_
 21	רחבי	רחב	NOUN	NOUN	Definite=Cons|Gender=Masc|Number=Plur	13	nmod	_	_
-22	ארה"ב	ארה"ב	PROPN	PROPN	Abbr=Yes	21	compound:smixut	_	_
+22	ארה"ב	ארה"ב	PROPN	PROPN	Abbr=Yes	21	compound:smixut	_	SpaceAfter=No
 23	.	_	PUNCT	PUNCT	_	8	punct	_	_
 
 # sent_id = 111
-# text = טוקי קיבל רק 52 אלף .
+# text = טוקי קיבל רק 52 אלף.
 1	טוקי	טוקי	PROPN	PROPN	_	2	nsubj	_	_
 2	קיבל	קיבל	VERB	VERB	Gender=Masc|HebBinyan=PIEL|Number=Sing|Person=3|Tense=Past|Voice=Act	0	root	_	_
 3	רק	רק	ADV	ADV	_	5	det	_	_
 4	52	_	NUM	NUM	_	5	nummod	_	_
-5	אלף	אלף	NUM	NUM	Gender=Masc|Number=Sing	2	obj	_	_
+5	אלף	אלף	NUM	NUM	Gender=Masc|Number=Sing	2	obj	_	SpaceAfter=No
 6	.	_	PUNCT	PUNCT	_	2	punct	_	_
 
 # sent_id = 112
-# text = ב48 תיאר מנכ"ל אייפא"ק טום דאיין את הארקין כאחד מששה או שבעה סנאטורים , שנבחרו בזכות " כסף יהודי " .
+# text = ב48 תיאר מנכ"ל אייפא"ק טום דאיין את הארקין כאחד מששה או שבעה סנאטורים, שנבחרו בזכות " כסף יהודי ".
 1-2	ב48	_	_	_	_	_	_	_	_
 1	ב	ב	ADP	ADP	_	2	case	_	_
 2	48	_	NUM	NUM	_	3	obl	_	_
@@ -4053,7 +4053,7 @@
 13	ששה	שישה	NUM	NUM	Gender=Masc|Number=Sing	16	nummod	_	_
 14	או	או	CCONJ	CCONJ	_	15	cc	_	_
 15	שבעה	שבעה	NUM	NUM	Gender=Masc|Number=Sing	13	conj	_	_
-16	סנאטורים	סנטור	NOUN	NOUN	Gender=Masc|Number=Plur	3	iobj	_	_
+16	סנאטורים	סנטור	NOUN	NOUN	Gender=Masc|Number=Plur	3	iobj	_	SpaceAfter=No
 17	,	_	PUNCT	PUNCT	_	16	punct	_	_
 18-19	שנבחרו	_	_	_	_	_	_	_	_
 18	ש	ש	SCONJ	SCONJ	_	19	mark	_	_
@@ -4062,17 +4062,17 @@
 21	"	_	PUNCT	PUNCT	_	22	punct	_	_
 22	כסף	כסף	NOUN	NOUN	Gender=Masc|Number=Sing	19	obl	_	_
 23	יהודי	יהודי	ADJ	ADJ	Gender=Masc|Number=Sing	22	amod	_	_
-24	"	_	PUNCT	PUNCT	_	22	punct	_	_
+24	"	_	PUNCT	PUNCT	_	22	punct	_	SpaceAfter=No
 25	.	_	PUNCT	PUNCT	_	3	punct	_	_
 
 # sent_id = 113
-# text = זו היתה התרברבות לא - דיסקרטית , ואין ספק שיימנע ממנה השנה .
+# text = זו היתה התרברבות לא - דיסקרטית, ואין ספק שיימנע ממנה השנה.
 1	זו	זו	PRON	PRON	Gender=Fem|Number=Sing|Person=3|PronType=Dem	3	nsubj	_	_
 2	היתה	היה	VERB	VERB	Gender=Fem|Number=Sing|Person=3|Polarity=Pos|Tense=Past|VerbType=Cop	3	aux	_	_
 3	התרברבות	התרברבות	NOUN	NOUN	Gender=Fem|Number=Sing	0	root	_	_
 4	לא	לא	ADV	ADV	Polarity=Neg	6	advmod	_	_
 5	-	_	PUNCT	PUNCT	_	6	punct	_	_
-6	דיסקרטית	דיסקרטי	ADJ	ADJ	Gender=Fem|Number=Sing	3	amod	_	_
+6	דיסקרטית	דיסקרטי	ADJ	ADJ	Gender=Fem|Number=Sing	3	amod	_	SpaceAfter=No
 7	,	_	PUNCT	PUNCT	_	3	punct	_	_
 8-9	ואין	_	_	_	_	_	_	_	_
 8	ו	ו	CCONJ	CCONJ	_	9	cc	_	_
@@ -4084,18 +4084,18 @@
 13-14	ממנה	_	_	_	_	_	_	_	_
 13	ממנה	מן	ADP	ADP	_	14	case	_	_
 14	_היא	הוא	PRON	PRON	Gender=Fem|Number=Sing|Person=3|PronType=Prs	12	iobj	_	_
-15	השנה	השנה	ADV	ADV	_	12	obl:tmod	_	_
+15	השנה	השנה	ADV	ADV	_	12	obl:tmod	_	SpaceAfter=No
 16	.	_	PUNCT	PUNCT	_	3	punct	_	_
 
 # sent_id = 114
-# text = אף - על - פי - כן , שתדלנים פרו - ישראליים בוואשינגטון חככו השבוע את ידיהם בשביעות רצון למשמע הידיעה , שהארקין גבר על טוקי בהפרש משכנע של 10 % .
+# text = אף - על - פי - כן, שתדלנים פרו - ישראליים בוואשינגטון חככו השבוע את ידיהם בשביעות רצון למשמע הידיעה, שהארקין גבר על טוקי בהפרש משכנע של 10 %.
 1	אף	אף	CCONJ	CCONJ	_	5	advmod	_	_
 2	-	_	PUNCT	PUNCT	_	5	punct	_	_
 3	על	על	ADP	ADP	_	5	case	_	_
 4	-	_	PUNCT	PUNCT	_	5	punct	_	_
 5	פי	פה	NOUN	NOUN	Definite=Cons|Gender=Masc|Number=Sing	15	advmod	_	_
 6	-	_	PUNCT	PUNCT	_	5	punct	_	_
-7	כן	_	PRON	PRON	HebSource=ConvUncertainHead|Person=3|PronType=Dem	5	dep	_	_
+7	כן	_	PRON	PRON	HebSource=ConvUncertainHead|Person=3|PronType=Dem	5	dep	_	SpaceAfter=No
 8	,	_	PUNCT	PUNCT	_	15	punct	_	_
 9	שתדלנים	שתדלן	NOUN	NOUN	Gender=Masc|Number=Plur	15	nsubj	_	_
 10	פרו	פרו	ADV	ADV	Prefix=Yes	12	advmod	_	_
@@ -4118,7 +4118,7 @@
 24-25	למשמע	_	_	_	_	_	_	_	_
 24	ל	ל	ADP	ADP	_	25	case	_	_
 25	משמע	משמע	NOUN	NOUN	Definite=Cons|Gender=Masc|Number=Sing	15	obl	_	_
-26-27	הידיעה	_	_	_	_	_	_	_	_
+26-27	הידיעה	_	_	_	_	_	_	_	SpaceAfter=No
 26	ה	ה	DET	DET	PronType=Art	27	det:def	_	_
 27	ידיעה	ידיעה	NOUN	NOUN	Gender=Fem|Number=Sing	25	compound:smixut	_	_
 28	,	_	PUNCT	PUNCT	_	27	punct	_	_
@@ -4134,11 +4134,11 @@
 36	משכנע	שכנע	VERB	VERB	Gender=Masc|HebBinyan=PIEL|Number=Sing|Person=1,2,3|VerbForm=Part|Voice=Act	35	amod	_	_
 37	של	של	PART	PART	Case=Gen	39	case:gen	_	_
 38	10	_	NUM	NUM	_	39	nummod	_	_
-39	%	%	NOUN	NOUN	Gender=Masc|Number=Plur,Sing	35	nmod	_	_
+39	%	%	NOUN	NOUN	Gender=Masc|Number=Plur,Sing	35	nmod	_	SpaceAfter=No
 40	.	_	PUNCT	PUNCT	_	15	punct	_	_
 
 # sent_id = 115
-# text = הוא הסנאטור הדמוקרטי הראשון בתולדות איובה הנבחר לתקופת כהונה שנייה .
+# text = הוא הסנאטור הדמוקרטי הראשון בתולדות איובה הנבחר לתקופת כהונה שנייה.
 1	הוא	הוא	PRON	PRON	Gender=Masc|Number=Sing|Person=3|PronType=Prs	3	nsubj	_	_
 2-3	הסנאטור	_	_	_	_	_	_	_	_
 2	ה	ה	DET	DET	PronType=Art	3	det:def	_	_
@@ -4160,14 +4160,14 @@
 13	ל	ל	ADP	ADP	_	14	case	_	_
 14	תקופת	תקופה	NOUN	NOUN	Definite=Cons|Gender=Fem|Number=Sing	12	iobj	_	_
 15	כהונה	כהונה	NOUN	NOUN	Gender=Fem|Number=Sing	14	compound:smixut	_	_
-16	שנייה	שני	NUM	NUM	Gender=Fem|Number=Sing	14	amod	_	_
+16	שנייה	שני	NUM	NUM	Gender=Fem|Number=Sing	14	amod	_	SpaceAfter=No
 17	.	_	PUNCT	PUNCT	_	3	punct	_	_
 
 # sent_id = 116
-# text = הוא גם יודע , שבלי תרומות מחוץ לגבולות מדינתו הקטנה , יתקשה לאסוף די כסף לניהול מערכת הבחירות הטלוויזיונית היקרה , שבלעדיה אין פוליטיקאים אמריקאיים מסוגלים לנצח .
+# text = הוא גם יודע, שבלי תרומות מחוץ לגבולות מדינתו הקטנה, יתקשה לאסוף די כסף לניהול מערכת הבחירות הטלוויזיונית היקרה, שבלעדיה אין פוליטיקאים אמריקאיים מסוגלים לנצח.
 1	הוא	הוא	PRON	PRON	Gender=Masc|Number=Sing|Person=3|PronType=Prs	3	nsubj	_	_
 2	גם	גם	ADV	ADV	_	3	advmod	_	_
-3	יודע	ידע	VERB	VERB	Gender=Masc|HebBinyan=PAAL|Number=Sing|Person=1,2,3|VerbForm=Part|Voice=Act	0	root	_	_
+3	יודע	ידע	VERB	VERB	Gender=Masc|HebBinyan=PAAL|Number=Sing|Person=1,2,3|VerbForm=Part|Voice=Act	0	root	_	SpaceAfter=No
 4	,	_	PUNCT	PUNCT	_	3	punct	_	_
 5-6	שבלי	_	_	_	_	_	_	_	_
 5	ש	ש	SCONJ	SCONJ	_	18	mark	_	_
@@ -4183,7 +4183,7 @@
 12	מדינה_	מדינה	NOUN	NOUN	Definite=Def|Gender=Fem|Number=Sing	11	compound:smixut	_	_
 13	_של_	של	ADP	ADP	_	14	case:gen	_	_
 14	_הוא	הוא	PRON	PRON	Case=Gen|Gender=Masc|Number=Sing|Person=3|PronType=Prs	12	nmod:poss	_	_
-15-16	הקטנה	_	_	_	_	_	_	_	_
+15-16	הקטנה	_	_	_	_	_	_	_	SpaceAfter=No
 15	ה	ה	DET	DET	PronType=Art	16	det:def	_	_
 16	קטנה	קטן	ADJ	ADJ	Gender=Fem|Number=Sing	12	amod	_	_
 17	,	_	PUNCT	PUNCT	_	18	punct	_	_
@@ -4201,7 +4201,7 @@
 27-28	הטלוויזיונית	_	_	_	_	_	_	_	_
 27	ה	ה	DET	DET	PronType=Art	28	det:def	_	_
 28	טלוויזיונית	טלוויזיוני	ADJ	ADJ	Gender=Fem|Number=Sing	24	amod	_	_
-29-30	היקרה	_	_	_	_	_	_	_	_
+29-30	היקרה	_	_	_	_	_	_	_	SpaceAfter=No
 29	ה	ה	DET	DET	PronType=Art	30	det:def	_	_
 30	יקרה	יקר	ADJ	ADJ	Gender=Fem|Number=Sing	24	amod	_	_
 31	,	_	PUNCT	PUNCT	_	24	punct	_	_
@@ -4213,14 +4213,14 @@
 36	פוליטיקאים	פוליטיקאי	NOUN	NOUN	Gender=Masc|Number=Plur	38	nsubj	_	_
 37	אמריקאיים	אמריקני	ADJ	ADJ	Gender=Masc|Number=Plur	36	amod	_	_
 38	מסוגלים	מסוגל	AUX	AUX	Gender=Masc|Number=Plur|Person=1,2,3|VerbType=Mod	24	acl:relcl	_	_
-39	לנצח	ניצח	VERB	VERB	HebBinyan=PIEL|VerbForm=Inf|Voice=Act	38	xcomp	_	_
+39	לנצח	ניצח	VERB	VERB	HebBinyan=PIEL|VerbForm=Inf|Voice=Act	38	xcomp	_	SpaceAfter=No
 40	.	_	PUNCT	PUNCT	_	3	punct	_	_
 
 # sent_id = 117
-# text = חזקה על הארקין , שיצביע גם בעתיד בעד חוק סיוע החוץ .
+# text = חזקה על הארקין, שיצביע גם בעתיד בעד חוק סיוע החוץ.
 1	חזקה	חזקה	NOUN	NOUN	Gender=Fem|Number=Sing	0	root	_	_
 2	על	על	ADP	ADP	_	3	case	_	_
-3	הארקין	הארקין	PROPN	PROPN	_	1	nmod	_	_
+3	הארקין	הארקין	PROPN	PROPN	_	1	nmod	_	SpaceAfter=No
 4	,	_	PUNCT	PUNCT	_	1	punct	_	_
 5-6	שיצביע	_	_	_	_	_	_	_	_
 5	ש	ש	SCONJ	SCONJ	_	6	mark	_	_
@@ -4233,13 +4233,13 @@
 11	בעד	בעד	ADP	ADP	_	12	case	_	_
 12	חוק	חוק	NOUN	NOUN	Definite=Cons|Gender=Masc|Number=Sing	6	iobj	_	_
 13	סיוע	סיוע	NOUN	NOUN	Definite=Cons|Gender=Masc|Number=Sing	12	compound:smixut	_	_
-14-15	החוץ	_	_	_	_	_	_	_	_
+14-15	החוץ	_	_	_	_	_	_	_	SpaceAfter=No
 14	ה	ה	DET	DET	PronType=Art	15	det:def	_	_
 15	חוץ	חוץ	NOUN	NOUN	Gender=Masc|Number=Sing	13	compound:smixut	_	_
 16	.	_	PUNCT	PUNCT	_	1	punct	_	_
 
 # sent_id = 118
-# text = מזכירות איגוד הפועלים החקלאיים הציעה אתמול שהממשלה תשלם מענק חודשי של 500 ש"ח , נוסף לשכר הרגיל , לכל ישראלי שיעבוד בקטיף ההדרים במשך שלושה חודשים לפחות .
+# text = מזכירות איגוד הפועלים החקלאיים הציעה אתמול שהממשלה תשלם מענק חודשי של 500 ש"ח, נוסף לשכר הרגיל, לכל ישראלי שיעבוד בקטיף ההדרים במשך שלושה חודשים לפחות.
 1	מזכירות	מזכירות	NOUN	NOUN	Definite=Cons|Gender=Fem|Number=Sing	7	nsubj	_	_
 2	איגוד	איגוד	NOUN	NOUN	Definite=Cons|Gender=Masc|Number=Sing	1	compound:smixut	_	_
 3-4	הפועלים	_	_	_	_	_	_	_	_
@@ -4259,14 +4259,14 @@
 14	חודשי	חודשי	ADJ	ADJ	Gender=Masc|Number=Sing	13	amod	_	_
 15	של	של	PART	PART	Case=Gen	17	case:gen	_	_
 16	500	_	NUM	NUM	_	17	nummod	_	_
-17	ש"ח	ש"ח	NOUN	NOUN	Abbr=Yes|Gender=Masc|Number=Sing	13	nmod	_	_
+17	ש"ח	ש"ח	NOUN	NOUN	Abbr=Yes|Gender=Masc|Number=Sing	13	nmod	_	SpaceAfter=No
 18	,	_	PUNCT	PUNCT	_	13	punct	_	_
 19	נוסף	נוסף	VERB	VERB	Gender=Masc|Number=Sing|Person=1,2,3|VerbForm=Part	22	case	_	_
 20-22	לשכר	_	_	_	_	_	_	_	_
 20	ל	ל	ADP	ADP	_	22	case	_	_
 21	ה_	ה	DET	DET	PronType=Art	22	det:def	_	_
 22	שכר	שכר	NOUN	NOUN	Gender=Masc|Number=Sing	13	nmod	_	_
-23-24	הרגיל	_	_	_	_	_	_	_	_
+23-24	הרגיל	_	_	_	_	_	_	_	SpaceAfter=No
 23	ה	ה	DET	DET	PronType=Art	24	det:def	_	_
 24	רגיל	רגיל	ADJ	ADJ	Gender=Masc|Number=Sing	22	amod	_	_
 25	,	_	PUNCT	PUNCT	_	13	punct	_	_
@@ -4286,22 +4286,22 @@
 35	במשך	במשך	ADP	ADP	_	37	case	_	_
 36	שלושה	שלושה	NUM	NUM	Gender=Masc|Number=Sing	37	nummod	_	_
 37	חודשים	חודש	NOUN	NOUN	Gender=Masc|Number=Plur	30	obl	_	_
-38	לפחות	לפחות	ADV	ADV	_	37	advmod	_	_
+38	לפחות	לפחות	ADV	ADV	_	37	advmod	_	SpaceAfter=No
 39	.	_	PUNCT	PUNCT	_	7	punct	_	_
 
 # sent_id = 119
-# text = מזכיר איגוד הפועלים החקלאיים , חיים אביבי , מסר שההצעה הועלתה לנוכח המחסור בעובדי קטיף המורגש כבר כעת ויוחרף בחודש הבא , כשהקטיף יהיה בעיצומו , בעיקר עקב היעדרות עובדים מהשטחים .
+# text = מזכיר איגוד הפועלים החקלאיים, חיים אביבי, מסר שההצעה הועלתה לנוכח המחסור בעובדי קטיף המורגש כבר כעת ויוחרף בחודש הבא, כשהקטיף יהיה בעיצומו, בעיקר עקב היעדרות עובדים מהשטחים.
 1	מזכיר	מזכיר	NOUN	NOUN	Definite=Cons|Gender=Masc|Number=Sing	11	nsubj	_	_
 2	איגוד	איגוד	NOUN	NOUN	Definite=Cons|Gender=Masc|Number=Sing	1	compound:smixut	_	_
 3-4	הפועלים	_	_	_	_	_	_	_	_
 3	ה	ה	DET	DET	PronType=Art	4	det:def	_	_
 4	פועלים	פועל	NOUN	NOUN	Gender=Masc|Number=Plur	2	compound:smixut	_	_
-5-6	החקלאיים	_	_	_	_	_	_	_	_
+5-6	החקלאיים	_	_	_	_	_	_	_	SpaceAfter=No
 5	ה	ה	DET	DET	PronType=Art	6	det:def	_	_
 6	חקלאיים	חקלאי	ADJ	ADJ	Gender=Masc|Number=Plur	4	amod	_	_
 7	,	_	PUNCT	PUNCT	_	1	punct	_	_
 8	חיים	חיים	PROPN	PROPN	_	1	appos	_	_
-9	אביבי	אביבי	PROPN	PROPN	_	8	flat:name	_	_
+9	אביבי	אביבי	PROPN	PROPN	_	8	flat:name	_	SpaceAfter=No
 10	,	_	PUNCT	PUNCT	_	11	punct	_	_
 11	מסר	מסר	VERB	VERB	Gender=Masc|HebBinyan=PAAL|Number=Sing|Person=3|Tense=Past|Voice=Act	0	root	_	_
 12-14	שההצעה	_	_	_	_	_	_	_	_
@@ -4329,7 +4329,7 @@
 28	ב	ב	ADP	ADP	_	30	case	_	_
 29	ה_	ה	DET	DET	PronType=Art	30	det:def	_	_
 30	חודש	חודש	NOUN	NOUN	Gender=Masc|Number=Sing	27	obl	_	_
-31-32	הבא	_	_	_	_	_	_	_	_
+31-32	הבא	_	_	_	_	_	_	_	SpaceAfter=No
 31	ה	ה	DET	DET	PronType=Art	32	det:def	_	_
 32	בא	בא	ADJ	ADJ	Gender=Masc|Number=Sing	30	amod	_	_
 33	,	_	PUNCT	PUNCT	_	30	punct	_	_
@@ -4338,7 +4338,7 @@
 35	ה	ה	DET	DET	PronType=Art	36	det:def	_	_
 36	קטיף	קטיף	NOUN	NOUN	Gender=Masc|Number=Sing	39	nsubj	_	_
 37	יהיה	היה	VERB	VERB	Gender=Masc|Number=Sing|Person=3|Polarity=Pos|Tense=Fut|VerbType=Cop	39	aux	_	_
-38-41	בעיצומו	_	_	_	_	_	_	_	_
+38-41	בעיצומו	_	_	_	_	_	_	_	SpaceAfter=No
 38	ב	ב	ADP	ADP	_	39	case	_	_
 39	עיצום_	עיצום	NOUN	NOUN	Definite=Def|Gender=Masc|Number=Sing	30	acl:relcl	_	_
 40	_של_	של	ADP	ADP	_	41	case:gen	_	_
@@ -4348,14 +4348,14 @@
 44	עקב	_	CCONJ	CCONJ	_	45	case	_	_
 45	היעדרות	היעדרות	NOUN	NOUN	Definite=Cons|Gender=Fem|Number=Sing	27	obl	_	_
 46	עובדים	עובד	NOUN	NOUN	Gender=Masc|Number=Plur	45	compound:smixut	_	_
-47-49	מהשטחים	_	_	_	_	_	_	_	_
+47-49	מהשטחים	_	_	_	_	_	_	_	SpaceAfter=No
 47	מ	מ	ADP	ADP	_	49	case	_	_
 48	ה	ה	DET	DET	PronType=Art	49	det:def	_	_
 49	שטחים	שטח	NOUN	NOUN	Gender=Masc|Number=Plur	46	nmod	_	_
 50	.	_	PUNCT	PUNCT	_	11	punct	_	_
 
 # sent_id = 120
-# text = המעסיקים אינם מצפים שיצליחו למשוך מספר ניכר של עובדים ישראליים לקטיף , בגלל השכר הנמוך המשולם לעבודה זו מעט מעל שכר המינימום במשק .
+# text = המעסיקים אינם מצפים שיצליחו למשוך מספר ניכר של עובדים ישראליים לקטיף, בגלל השכר הנמוך המשולם לעבודה זו מעט מעל שכר המינימום במשק.
 1-2	המעסיקים	_	_	_	_	_	_	_	_
 1	ה	ה	DET	DET	PronType=Art	2	det:def	_	_
 2	מעסיקים	מעסיק	NOUN	NOUN	Gender=Masc|Number=Plur	4	nsubj	_	_
@@ -4370,7 +4370,7 @@
 10	של	של	PART	PART	Case=Gen	11	case:gen	_	_
 11	עובדים	עובד	NOUN	NOUN	Gender=Masc|Number=Plur	8	nmod	_	_
 12	ישראליים	ישראלי	ADJ	ADJ	Gender=Masc|Number=Plur	11	amod	_	_
-13-15	לקטיף	_	_	_	_	_	_	_	_
+13-15	לקטיף	_	_	_	_	_	_	_	SpaceAfter=No
 13	ל	ל	ADP	ADP	_	15	case	_	_
 14	ה_	ה	DET	DET	PronType=Art	15	det:def	_	_
 15	קטיף	קטיף	NOUN	NOUN	Gender=Masc|Number=Sing	7	iobj	_	_
@@ -4395,14 +4395,14 @@
 30-31	המינימום	_	_	_	_	_	_	_	_
 30	ה	ה	DET	DET	PronType=Art	31	det:def	_	_
 31	מינימום	מינימום	NOUN	NOUN	Gender=Masc|Number=Sing	29	compound:smixut	_	_
-32-34	במשק	_	_	_	_	_	_	_	_
+32-34	במשק	_	_	_	_	_	_	_	SpaceAfter=No
 32	ב	ב	ADP	ADP	_	34	case	_	_
 33	ה_	ה	DET	DET	PronType=Art	34	det:def	_	_
 34	משק	משק	NOUN	NOUN	Gender=Masc|Number=Sing	29	nmod	_	_
 35	.	_	PUNCT	PUNCT	_	4	punct	_	_
 
 # sent_id = 121
-# text = בשבוע הבא ידון מנכ"ל התאחדות האיכרים , שלמה רייזמן , עם מנכ"ל שירות התעסוקה , דוד מנע , בדרישת ההתאחדות לשכנע עולים חדשים הלומדים באולפנים לעבוד בקטיף .
+# text = בשבוע הבא ידון מנכ"ל התאחדות האיכרים, שלמה רייזמן, עם מנכ"ל שירות התעסוקה, דוד מנע, בדרישת ההתאחדות לשכנע עולים חדשים הלומדים באולפנים לעבוד בקטיף.
 1-3	בשבוע	_	_	_	_	_	_	_	_
 1	ב	ב	ADP	ADP	_	3	case	_	_
 2	ה_	ה	DET	DET	PronType=Art	3	det:def	_	_
@@ -4413,22 +4413,22 @@
 6	ידון	דן	VERB	VERB	Gender=Masc|Number=Sing|Person=3|Tense=Fut	0	root	_	_
 7	מנכ"ל	מנכ"ל	NOUN	NOUN	Abbr=Yes|Definite=Cons|Gender=Masc|Number=Sing	6	nsubj	_	_
 8	התאחדות	התאחדות	NOUN	NOUN	Definite=Cons|Gender=Fem|Number=Sing	7	compound:smixut	_	_
-9-10	האיכרים	_	_	_	_	_	_	_	_
+9-10	האיכרים	_	_	_	_	_	_	_	SpaceAfter=No
 9	ה	ה	DET	DET	PronType=Art	10	det:def	_	_
 10	איכרים	איכר	NOUN	NOUN	Gender=Masc|Number=Plur	8	compound:smixut	_	_
 11	,	_	PUNCT	PUNCT	_	7	punct	_	_
 12	שלמה	שלמה	PROPN	PROPN	_	7	appos	_	_
-13	רייזמן	רייזמן	PROPN	PROPN	_	12	flat:name	_	_
+13	רייזמן	רייזמן	PROPN	PROPN	_	12	flat:name	_	SpaceAfter=No
 14	,	_	PUNCT	PUNCT	_	6	punct	_	_
 15	עם	עם	ADP	ADP	_	16	case	_	_
 16	מנכ"ל	מנכ"ל	NOUN	NOUN	Abbr=Yes|Definite=Cons|Gender=Masc|Number=Sing	6	obl	_	_
 17	שירות	שירות	NOUN	NOUN	Definite=Cons|Gender=Masc|Number=Sing	16	compound:smixut	_	_
-18-19	התעסוקה	_	_	_	_	_	_	_	_
+18-19	התעסוקה	_	_	_	_	_	_	_	SpaceAfter=No
 18	ה	ה	DET	DET	PronType=Art	19	det:def	_	_
 19	תעסוקה	תעסוקה	NOUN	NOUN	Gender=Fem|Number=Sing	17	compound:smixut	_	_
 20	,	_	PUNCT	PUNCT	_	16	punct	_	_
 21	דוד	דוד	PROPN	PROPN	_	16	appos	_	_
-22	מנע	מנע	NOUN	NOUN	Gender=Masc|Number=Sing	21	flat:name	_	_
+22	מנע	מנע	NOUN	NOUN	Gender=Masc|Number=Sing	21	flat:name	_	SpaceAfter=No
 23	,	_	PUNCT	PUNCT	_	6	punct	_	_
 24-25	בדרישת	_	_	_	_	_	_	_	_
 24	ב	ב	ADP	ADP	_	25	case	_	_
@@ -4446,14 +4446,14 @@
 33	ב	ב	ADP	ADP	_	34	case	_	_
 34	אולפנים	אולפן	NOUN	NOUN	Gender=Masc|Number=Plur	32	obl	_	_
 35	לעבוד	עבד	VERB	VERB	HebBinyan=PAAL|HebSource=ConvUncertainHead|VerbForm=Inf|Voice=Act	28	dep	_	_
-36-38	בקטיף	_	_	_	_	_	_	_	_
+36-38	בקטיף	_	_	_	_	_	_	_	SpaceAfter=No
 36	ב	ב	ADP	ADP	_	38	case	_	_
 37	ה_	ה	DET	DET	PronType=Art	38	det:def	_	_
 38	קטיף	קטיף	NOUN	NOUN	Gender=Masc|Number=Sing	35	obl	_	_
 39	.	_	PUNCT	PUNCT	_	6	punct	_	_
 
 # sent_id = 122
-# text = רייזמן מציע שהממשלה תסבסד מחצית מעלות העסקתם של העולים בקטיף .
+# text = רייזמן מציע שהממשלה תסבסד מחצית מעלות העסקתם של העולים בקטיף.
 1	רייזמן	רייזמן	PROPN	PROPN	_	2	nsubj	_	_
 2	מציע	הציע	VERB	VERB	Gender=Masc|HebBinyan=HIFIL|Number=Sing|Person=1,2,3|VerbForm=Part|Voice=Act	0	root	_	_
 3-5	שהממשלה	_	_	_	_	_	_	_	_
@@ -4473,14 +4473,14 @@
 14-15	העולים	_	_	_	_	_	_	_	_
 14	ה	ה	DET	DET	PronType=Art	15	det:def	_	_
 15	עולים	עולה	NOUN	NOUN	Gender=Masc|Number=Plur	10	nmod:poss	_	_
-16-18	בקטיף	_	_	_	_	_	_	_	_
+16-18	בקטיף	_	_	_	_	_	_	_	SpaceAfter=No
 16	ב	ב	ADP	ADP	_	18	case	_	_
 17	ה_	ה	DET	DET	PronType=Art	18	det:def	_	_
 18	קטיף	קטיף	NOUN	NOUN	Gender=Masc|Number=Sing	10	nmod	_	_
 19	.	_	PUNCT	PUNCT	_	2	punct	_	_
 
 # sent_id = 123
-# text = מזכירות איגוד הפועלים החקלאיים אישרה אתמול נקיטת עיצומים אם עד סוף השבוע הבא לא יושג הסכם שכר לשנתיים הבאות , במסגרתו יועלה שכר העובדים ב20 % .
+# text = מזכירות איגוד הפועלים החקלאיים אישרה אתמול נקיטת עיצומים אם עד סוף השבוע הבא לא יושג הסכם שכר לשנתיים הבאות, במסגרתו יועלה שכר העובדים ב20 %.
 1	מזכירות	מזכירות	NOUN	NOUN	Definite=Cons|Gender=Fem|Number=Sing	7	nsubj	_	_
 2	איגוד	איגוד	NOUN	NOUN	Definite=Cons|Gender=Masc|Number=Sing	1	compound:smixut	_	_
 3-4	הפועלים	_	_	_	_	_	_	_	_
@@ -4510,7 +4510,7 @@
 22	ל	ל	ADP	ADP	_	24	case	_	_
 23	ה_	ה	DET	DET	PronType=Art	24	det:def	_	_
 24	שנתיים	שנה	NOUN	NOUN	Gender=Fem|Number=Dual	20	nmod	_	_
-25-26	הבאות	_	_	_	_	_	_	_	_
+25-26	הבאות	_	_	_	_	_	_	_	SpaceAfter=No
 25	ה	ה	DET	DET	PronType=Art	26	det:def	_	_
 26	באות	בא	ADJ	ADJ	Gender=Fem|Number=Plur	24	amod	_	_
 27	,	_	PUNCT	PUNCT	_	20	punct	_	_
@@ -4527,32 +4527,32 @@
 36-37	ב20	_	_	_	_	_	_	_	_
 36	ב	ב	ADP	ADP	_	38	case	_	_
 37	20	_	NUM	NUM	_	38	nummod	_	_
-38	%	%	NOUN	NOUN	Gender=Masc|Number=Plur,Sing	32	iobj	_	_
+38	%	%	NOUN	NOUN	Gender=Masc|Number=Plur,Sing	32	iobj	_	SpaceAfter=No
 39	.	_	PUNCT	PUNCT	_	7	punct	_	_
 
 # sent_id = 124
-# text = הסכם השכר פג באפריל .
+# text = הסכם השכר פג באפריל.
 1	הסכם	הסכם	NOUN	NOUN	Definite=Cons|Gender=Masc|Number=Sing	4	nsubj	_	_
 2-3	השכר	_	_	_	_	_	_	_	_
 2	ה	ה	DET	DET	PronType=Art	3	det:def	_	_
 3	שכר	שכר	NOUN	NOUN	Gender=Masc|Number=Sing	1	compound:smixut	_	_
 4	פג	פג	VERB	VERB	Gender=Masc|HebBinyan=PAAL|Number=Sing|Person=3|Tense=Past|Voice=Act	0	root	_	_
-5-6	באפריל	_	_	_	_	_	_	_	_
+5-6	באפריל	_	_	_	_	_	_	_	SpaceAfter=No
 5	ב	ב	ADP	ADP	_	6	case	_	_
 6	אפריל	אפריל	PROPN	PROPN	_	4	obl	_	_
 7	.	_	PUNCT	PUNCT	_	4	punct	_	_
 
 # sent_id = 125
-# text = יו"ר רשות שדות התעופה , אריה גרוסבורד , נהרג ביום שני בתאונת דרכים בארצות - הברית .
+# text = יו"ר רשות שדות התעופה, אריה גרוסבורד, נהרג ביום שני בתאונת דרכים בארצות - הברית.
 1	יו"ר	יו"ר	NOUN	NOUN	Abbr=Yes|Definite=Cons|Gender=Masc|Number=Sing	10	nsubj	_	_
 2	רשות	רשות	NOUN	NOUN	Definite=Cons|Gender=Fem|Number=Sing	1	compound:smixut	_	_
 3	שדות	שדה	NOUN	NOUN	Definite=Cons|Gender=Masc|Number=Plur	2	compound:smixut	_	_
-4-5	התעופה	_	_	_	_	_	_	_	_
+4-5	התעופה	_	_	_	_	_	_	_	SpaceAfter=No
 4	ה	ה	DET	DET	PronType=Art	5	det:def	_	_
 5	תעופה	תעופה	NOUN	NOUN	Gender=Fem|Number=Sing	3	compound:smixut	_	_
 6	,	_	PUNCT	PUNCT	_	1	punct	_	_
 7	אריה	אריה	PROPN	PROPN	_	1	appos	_	_
-8	גרוסבורד	גרוסבורד	PROPN	PROPN	_	7	flat:name	_	_
+8	גרוסבורד	גרוסבורד	PROPN	PROPN	_	7	flat:name	_	SpaceAfter=No
 9	,	_	PUNCT	PUNCT	_	10	punct	_	_
 10	נהרג	נהרג	VERB	VERB	Gender=Masc|HebBinyan=NIFAL|Number=Sing|Person=3|Tense=Past|Voice=Mid	0	root	_	_
 11-12	ביום	_	_	_	_	_	_	_	_
@@ -4567,17 +4567,17 @@
 17	ב	ב	ADP	ADP	_	18	case	_	_
 18	ארצות	ארץ	NOUN	NOUN	Definite=Cons|Gender=Fem|Number=Plur	10	obl	_	_
 19	-	_	PUNCT	PUNCT	_	18	punct	_	_
-20-21	הברית	_	_	_	_	_	_	_	_
+20-21	הברית	_	_	_	_	_	_	_	SpaceAfter=No
 20	ה	ה	DET	DET	PronType=Art	21	det:def	_	_
 21	ברית	ברית	NOUN	NOUN	Gender=Fem|HebSource=ConvUncertainLabel|Number=Sing	18	nmod	_	_
 22	.	_	PUNCT	PUNCT	_	10	punct	_	_
 
 # sent_id = 126
-# text = גרוסבורד נהג לבדו במכונית , בדרכו מהעיר מיניאפוליס באינדיאנה לנמל התעופה שלה .
+# text = גרוסבורד נהג לבדו במכונית, בדרכו מהעיר מיניאפוליס באינדיאנה לנמל התעופה שלה.
 1	גרוסבורד	גרוסבורד	PROPN	PROPN	_	2	nsubj	_	_
 2	נהג	נהג	VERB	VERB	Gender=Masc|HebBinyan=PAAL|Number=Sing|Person=3|Tense=Past|Voice=Act	0	root	_	_
 3	לבדו	לבד	ADV	ADV	_	2	advmod	_	_
-4-6	במכונית	_	_	_	_	_	_	_	_
+4-6	במכונית	_	_	_	_	_	_	_	SpaceAfter=No
 4	ב	ב	ADP	ADP	_	6	case	_	_
 5	ה_	ה	DET	DET	PronType=Art	6	det:def	_	_
 6	מכונית	מכונית	NOUN	NOUN	Gender=Fem|Number=Sing	2	iobj	_	_
@@ -4601,16 +4601,16 @@
 20-21	התעופה	_	_	_	_	_	_	_	_
 20	ה	ה	DET	DET	PronType=Art	21	det:def	_	_
 21	תעופה	תעופה	NOUN	NOUN	Gender=Fem|Number=Sing	19	compound:smixut	_	_
-22-23	שלה	_	_	_	_	_	_	_	_
+22-23	שלה	_	_	_	_	_	_	_	SpaceAfter=No
 22	של_	של	ADP	ADP	Case=Gen	23	case:gen	_	_
 23	_היא	הוא	PRON	PRON	Gender=Fem|Number=Sing|Person=3|PronType=Prs	19	nmod:poss	_	_
 24	.	_	PUNCT	PUNCT	_	2	punct	_	_
 
 # sent_id = 127
-# text = משאית פגעה במכוניתו , והוא נהרג במקום .
+# text = משאית פגעה במכוניתו, והוא נהרג במקום.
 1	משאית	משאית	NOUN	NOUN	Gender=Fem|Number=Sing	2	nsubj	_	_
 2	פגעה	פגע	VERB	VERB	Gender=Fem|HebBinyan=PAAL|Number=Sing|Person=3|Tense=Past|Voice=Act	0	root	_	_
-3-6	במכוניתו	_	_	_	_	_	_	_	_
+3-6	במכוניתו	_	_	_	_	_	_	_	SpaceAfter=No
 3	ב	ב	ADP	ADP	_	4	case	_	_
 4	מכונית_	מכונית	NOUN	NOUN	Definite=Def|Gender=Fem|Number=Sing	2	iobj	_	_
 5	_של_	של	ADP	ADP	_	6	case:gen	_	_
@@ -4620,14 +4620,14 @@
 8	ו	ו	CCONJ	CCONJ	_	10	cc	_	_
 9	הוא	הוא	PRON	PRON	Gender=Masc|Number=Sing|Person=3|PronType=Prs	10	nsubj	_	_
 10	נהרג	נהרג	VERB	VERB	Gender=Masc|HebBinyan=NIFAL|Number=Sing|Person=3|Tense=Past|Voice=Mid	2	conj	_	_
-11-13	במקום	_	_	_	_	_	_	_	_
+11-13	במקום	_	_	_	_	_	_	_	SpaceAfter=No
 11	ב	ב	ADP	ADP	_	13	case	_	_
 12	ה_	ה	DET	DET	PronType=Art	13	det:def	_	_
 13	מקום	מקום	NOUN	NOUN	Gender=Masc|Number=Sing	10	obl	_	_
 14	.	_	PUNCT	PUNCT	_	2	punct	_	_
 
 # sent_id = 128
-# text = אריה גרוסבורד אמור היה לטוס ממיניאפוליס לשיקאגו , וממנה לניו - יורק .
+# text = אריה גרוסבורד אמור היה לטוס ממיניאפוליס לשיקאגו, וממנה לניו - יורק.
 1	אריה	אריה	PROPN	PROPN	_	3	nsubj	_	_
 2	גרוסבורד	גרוסבורד	PROPN	PROPN	_	1	flat:name	_	_
 3	אמור	אמור	AUX	AUX	Gender=Masc|Number=Sing|Person=1,2,3|VerbType=Mod	0	root	_	_
@@ -4636,7 +4636,7 @@
 6-7	ממיניאפוליס	_	_	_	_	_	_	_	_
 6	מ	מ	ADP	ADP	_	7	case	_	_
 7	מיניאפוליס	מיניאפוליס	PROPN	PROPN	_	5	iobj	_	_
-8-9	לשיקאגו	_	_	_	_	_	_	_	_
+8-9	לשיקאגו	_	_	_	_	_	_	_	SpaceAfter=No
 8	ל	ל	ADP	ADP	_	9	case	_	_
 9	שיקאגו	שיקאגו	PROPN	PROPN	HebSource=ConvUncertainHead	7	dep	_	_
 10	,	_	PUNCT	PUNCT	_	7	punct	_	_
@@ -4648,17 +4648,17 @@
 14	ל	_	ADP	ADP	_	15	case	_	_
 15	ניו	ניו	PROPN	PROPN	HebSource=ConvUncertainHead	13	dep	_	_
 16	-	_	PUNCT	PUNCT	_	15	flat:name	_	_
-17	יורק	יורק	PROPN	PROPN	_	15	flat:name	_	_
+17	יורק	יורק	PROPN	PROPN	_	15	flat:name	_	SpaceAfter=No
 18	.	_	PUNCT	PUNCT	_	3	punct	_	_
 
 # sent_id = 129
-# text = שם היה אמור להיפגש עם אשתו , שעשתה בבוסטון .
+# text = שם היה אמור להיפגש עם אשתו, שעשתה בבוסטון.
 1	שם	שם	ADV	ADV	_	3	advmod	_	_
 2	היה	היה	VERB	VERB	Gender=Masc|Number=Sing|Person=3|Polarity=Pos|Tense=Past|VerbType=Cop	3	aux	_	_
 3	אמור	אמור	AUX	AUX	Gender=Masc|Number=Sing|Person=1,2,3|VerbType=Mod	0	root	_	_
 4	להיפגש	נפגש	VERB	VERB	HebBinyan=NIFAL|VerbForm=Inf|Voice=Mid	3	xcomp	_	_
 5	עם	עם	ADP	ADP	_	6	case	_	_
-6-8	אשתו	_	_	_	_	_	_	_	_
+6-8	אשתו	_	_	_	_	_	_	_	SpaceAfter=No
 6	איש_	איש	NOUN	NOUN	Definite=Def|Gender=Fem|Number=Sing	4	obl	_	_
 7	_של_	של	ADP	ADP	_	8	case:gen	_	_
 8	_הוא	הוא	PRON	PRON	Case=Gen|Gender=Masc|Number=Sing|Person=3|PronType=Prs	6	nmod:poss	_	_
@@ -4666,13 +4666,13 @@
 10-11	שעשתה	_	_	_	_	_	_	_	_
 10	ש	ש	SCONJ	SCONJ	_	11	mark	_	_
 11	עשתה	עשה	VERB	VERB	Gender=Fem|HebBinyan=PAAL|Number=Sing|Person=3|Tense=Past|Voice=Act	6	acl:relcl	_	_
-12-13	בבוסטון	_	_	_	_	_	_	_	_
+12-13	בבוסטון	_	_	_	_	_	_	_	SpaceAfter=No
 12	ב	ב	ADP	ADP	_	13	case	_	_
 13	בוסטון	בוסטון	PROPN	PROPN	_	11	obl	_	_
 14	.	_	PUNCT	PUNCT	_	3	punct	_	_
 
 # sent_id = 130
-# text = בני הזוג גרוסבורד תוכננו לשוב היום אחרי - הצהריים לישראל .
+# text = בני הזוג גרוסבורד תוכננו לשוב היום אחרי - הצהריים לישראל.
 1	בני	בן	NOUN	NOUN	Definite=Cons|Gender=Masc|Number=Plur	5	nsubj	_	_
 2-3	הזוג	_	_	_	_	_	_	_	_
 2	ה	ה	DET	DET	PronType=Art	3	det:def	_	_
@@ -4686,13 +4686,13 @@
 10-11	הצהריים	_	_	_	_	_	_	_	_
 10	ה	ה	DET	DET	PronType=Art	11	det:def	_	_
 11	צהריים	צהריים	NOUN	NOUN	Gender=Masc|Number=Plur	7	advmod	_	_
-12-13	לישראל	_	_	_	_	_	_	_	_
+12-13	לישראל	_	_	_	_	_	_	_	SpaceAfter=No
 12	ל	ל	ADP	ADP	_	13	case	_	_
 13	ישראל	ישראל	PROPN	PROPN	_	6	obl	_	_
 14	.	_	PUNCT	PUNCT	_	5	punct	_	_
 
 # sent_id = 131
-# text = דבר מותו של גרוסבורד נודע רק אתמול בצהריים לרשות שדות התעופה .
+# text = דבר מותו של גרוסבורד נודע רק אתמול בצהריים לרשות שדות התעופה.
 1	דבר	דבר	NOUN	NOUN	Definite=Cons|Gender=Masc|Number=Sing	7	nsubj	_	_
 2-4	מותו	_	_	_	_	_	_	_	_
 2	מוות_	מוות	NOUN	NOUN	Definite=Def|Gender=Masc|Number=Sing	1	compound:smixut	_	_
@@ -4711,14 +4711,14 @@
 13	ל	ל	ADP	ADP	_	14	case	_	_
 14	רשות	רשות	NOUN	NOUN	Definite=Cons|Gender=Fem|Number=Sing	7	iobj	_	_
 15	שדות	שדה	NOUN	NOUN	Definite=Cons|Gender=Masc|Number=Plur	14	compound:smixut	_	_
-16-17	התעופה	_	_	_	_	_	_	_	_
+16-17	התעופה	_	_	_	_	_	_	_	SpaceAfter=No
 16	ה	ה	DET	DET	PronType=Art	17	det:def	_	_
 17	תעופה	תעופה	NOUN	NOUN	Gender=Fem|Number=Sing	15	compound:smixut	_	_
 18	.	_	PUNCT	PUNCT	_	7	punct	_	_
 
 # sent_id = 132
-# text = הגורמים , שטיפלו בדבר בארץ , לא קישרו את שמו עם תפקידו .
-1-2	הגורמים	_	_	_	_	_	_	_	_
+# text = הגורמים, שטיפלו בדבר בארץ, לא קישרו את שמו עם תפקידו.
+1-2	הגורמים	_	_	_	_	_	_	_	SpaceAfter=No
 1	ה	ה	DET	DET	PronType=Art	2	det:def	_	_
 2	גורמים	גורם	NOUN	NOUN	Gender=Masc|Number=Plur	14	nsubj	_	_
 3	,	_	PUNCT	PUNCT	_	2	punct	_	_
@@ -4729,7 +4729,7 @@
 6	ב	ב	ADP	ADP	_	8	case	_	_
 7	ה_	ה	DET	DET	PronType=Art	8	det:def	_	_
 8	דבר	דבר	NOUN	NOUN	Gender=Masc|Number=Sing	5	iobj	_	_
-9-11	בארץ	_	_	_	_	_	_	_	_
+9-11	בארץ	_	_	_	_	_	_	_	SpaceAfter=No
 9	ב	ב	ADP	ADP	_	11	case	_	_
 10	ה_	ה	DET	DET	PronType=Art	11	det:def	_	_
 11	ארץ	ארץ	NOUN	NOUN	Gender=Fem|Number=Sing	5	obl	_	_
@@ -4742,14 +4742,14 @@
 17	_של_	של	ADP	ADP	_	18	case:gen	_	_
 18	_הוא	הוא	PRON	PRON	Case=Gen|Gender=Masc|Number=Sing|Person=3|PronType=Prs	16	nmod:poss	_	_
 19	עם	עם	ADP	ADP	_	20	case	_	_
-20-22	תפקידו	_	_	_	_	_	_	_	_
+20-22	תפקידו	_	_	_	_	_	_	_	SpaceAfter=No
 20	תפקיד_	תפקיד	NOUN	NOUN	Definite=Def|Gender=Masc|Number=Sing	14	iobj	_	_
 21	_של_	של	ADP	ADP	_	22	case:gen	_	_
 22	_הוא	הוא	PRON	PRON	Case=Gen|Gender=Masc|Number=Sing|Person=3|PronType=Prs	20	nmod:poss	_	_
 23	.	_	PUNCT	PUNCT	_	14	punct	_	_
 
 # sent_id = 133
-# text = משטרת מיניאפוליס מצאה במכוניתו את מזוודותיו עם תגי הזיהוי .
+# text = משטרת מיניאפוליס מצאה במכוניתו את מזוודותיו עם תגי הזיהוי.
 1	משטרת	משטרה	NOUN	NOUN	Definite=Cons|Gender=Fem|Number=Sing	3	nsubj	_	_
 2	מיניאפוליס	מיניאפוליס	PROPN	PROPN	_	1	compound:smixut	_	_
 3	מצאה	מצא	VERB	VERB	Gender=Fem|HebBinyan=PAAL|Number=Sing|Person=3|Tense=Past|Voice=Act	0	root	_	_
@@ -4765,13 +4765,13 @@
 11	_הוא	הוא	PRON	PRON	Case=Gen|Gender=Masc|Number=Sing|Person=3|PronType=Prs	9	nmod:poss	_	_
 12	עם	עם	ADP	ADP	_	13	case	_	_
 13	תגי	תג	NOUN	NOUN	Definite=Cons|Gender=Masc|Number=Plur	9	nmod	_	_
-14-15	הזיהוי	_	_	_	_	_	_	_	_
+14-15	הזיהוי	_	_	_	_	_	_	_	SpaceAfter=No
 14	ה	ה	DET	DET	PronType=Art	15	det:def	_	_
 15	זיהוי	זיהוי	NOUN	NOUN	Gender=Fem|Number=Sing	13	compound:smixut	_	_
 16	.	_	PUNCT	PUNCT	_	3	punct	_	_
 
 # sent_id = 134
-# text = המשטרה דיווחה למחלקת המדינה האמריקאית , שהעבירה את המידע לקונסוליה הישראלית בשיקאגו , המטפלת באזור מיניאפוליס .
+# text = המשטרה דיווחה למחלקת המדינה האמריקאית, שהעבירה את המידע לקונסוליה הישראלית בשיקאגו, המטפלת באזור מיניאפוליס.
 1-2	המשטרה	_	_	_	_	_	_	_	_
 1	ה	ה	DET	DET	PronType=Art	2	det:def	_	_
 2	משטרה	משטרה	NOUN	NOUN	Gender=Fem|Number=Sing	3	nsubj	_	_
@@ -4782,7 +4782,7 @@
 6-7	המדינה	_	_	_	_	_	_	_	_
 6	ה	ה	DET	DET	PronType=Art	7	det:def	_	_
 7	מדינה	מדינה	NOUN	NOUN	Gender=Fem|Number=Sing	5	compound:smixut	_	_
-8-9	האמריקאית	_	_	_	_	_	_	_	_
+8-9	האמריקאית	_	_	_	_	_	_	_	SpaceAfter=No
 8	ה	ה	DET	DET	PronType=Art	9	det:def	_	_
 9	אמריקאית	אמריקני	ADJ	ADJ	Gender=Fem|Number=Sing	5	amod	_	_
 10	,	_	PUNCT	PUNCT	_	5	punct	_	_
@@ -4800,7 +4800,7 @@
 19-20	הישראלית	_	_	_	_	_	_	_	_
 19	ה	ה	DET	DET	PronType=Art	20	det:def	_	_
 20	ישראלית	ישראלי	ADJ	ADJ	Gender=Fem|Number=Sing	18	amod	_	_
-21-22	בשיקאגו	_	_	_	_	_	_	_	_
+21-22	בשיקאגו	_	_	_	_	_	_	_	SpaceAfter=No
 21	ב	ב	ADP	ADP	_	22	case	_	_
 22	שיקאגו	שיקאגו	PROPN	PROPN	_	18	nmod	_	_
 23	,	_	PUNCT	PUNCT	_	18	punct	_	_
@@ -4810,11 +4810,11 @@
 26-27	באזור	_	_	_	_	_	_	_	_
 26	ב	ב	ADP	ADP	_	27	case	_	_
 27	אזור	אזור	NOUN	NOUN	Definite=Cons|Gender=Masc|Number=Sing	25	iobj	_	_
-28	מיניאפוליס	מיניאפוליס	PROPN	PROPN	_	27	compound:smixut	_	_
+28	מיניאפוליס	מיניאפוליס	PROPN	PROPN	_	27	compound:smixut	_	SpaceAfter=No
 29	.	_	PUNCT	PUNCT	_	3	punct	_	_
 
 # sent_id = 135
-# text = הקונסוליה בשיקאגו הבריקה לירושלים .
+# text = הקונסוליה בשיקאגו הבריקה לירושלים.
 1-2	הקונסוליה	_	_	_	_	_	_	_	_
 1	ה	ה	DET	DET	PronType=Art	2	det:def	_	_
 2	קונסוליה	קונסוליה	NOUN	NOUN	Gender=Fem|Number=Sing	5	nsubj	_	_
@@ -4822,13 +4822,13 @@
 3	ב	ב	ADP	ADP	_	4	case	_	_
 4	שיקאגו	שיקאגו	PROPN	PROPN	_	2	nmod	_	_
 5	הבריקה	הבריק	VERB	VERB	Gender=Fem|HebBinyan=HIFIL|Number=Sing|Person=3|Tense=Past|Voice=Act	0	root	_	_
-6-7	לירושלים	_	_	_	_	_	_	_	_
+6-7	לירושלים	_	_	_	_	_	_	_	SpaceAfter=No
 6	ל	ל	ADP	ADP	_	7	case	_	_
 7	ירושלים	ירושלים	PROPN	PROPN	_	5	iobj	_	_
 8	.	_	PUNCT	PUNCT	_	5	punct	_	_
 
 # sent_id = 136
-# text = ממשרד החוץ בירושלים נשלח שליח להודיע על דבר המוות לבני המשפחה , אולם לא היה איש בדירתו .
+# text = ממשרד החוץ בירושלים נשלח שליח להודיע על דבר המוות לבני המשפחה, אולם לא היה איש בדירתו.
 1-2	ממשרד	_	_	_	_	_	_	_	_
 1	מ	מ	ADP	ADP	_	2	case	_	_
 2	משרד	משרד	NOUN	NOUN	Definite=Cons|Gender=Masc|Number=Sing	7	obl	_	_
@@ -4849,7 +4849,7 @@
 14-15	לבני	_	_	_	_	_	_	_	_
 14	ל	ל	ADP	ADP	_	15	case	_	_
 15	בני	בן	NOUN	NOUN	Definite=Cons|Gender=Masc|Number=Plur	9	obl	_	_
-16-17	המשפחה	_	_	_	_	_	_	_	_
+16-17	המשפחה	_	_	_	_	_	_	_	SpaceAfter=No
 16	ה	ה	DET	DET	PronType=Art	17	det:def	_	_
 17	משפחה	משפחה	NOUN	NOUN	Gender=Fem|Number=Sing	15	compound:smixut	_	_
 18	,	_	PUNCT	PUNCT	_	7	punct	_	_
@@ -4857,7 +4857,7 @@
 20	לא	לא	ADV	ADV	Polarity=Neg	21	advmod	_	_
 21	היה	היה	VERB	VERB	Gender=Masc|Number=Sing|Person=3|Polarity=Pos|Tense=Past|VerbType=Cop	7	conj	_	_
 22	איש	איש	NOUN	NOUN	Gender=Masc|Number=Sing	21	nsubj	_	_
-23-26	בדירתו	_	_	_	_	_	_	_	_
+23-26	בדירתו	_	_	_	_	_	_	_	SpaceAfter=No
 23	ב	ב	ADP	ADP	_	24	case	_	_
 24	דירה_	דירה	NOUN	NOUN	Definite=Def|Gender=Fem|Number=Sing	21	iobj	_	_
 25	_של_	של	ADP	ADP	_	26	case:gen	_	_
@@ -4865,14 +4865,14 @@
 27	.	_	PUNCT	PUNCT	_	7	punct	_	_
 
 # sent_id = 137
-# text = רק אחר - כך נמצא כרטיס ביקור , ובו שמו ותוארו של גרוסבורד כמנהל מפעל פרטי .
+# text = רק אחר - כך נמצא כרטיס ביקור, ובו שמו ותוארו של גרוסבורד כמנהל מפעל פרטי.
 1	רק	רק	ADV	ADV	HebSource=ConvUncertainHead	4	dep	_	_
 2	אחר	אחר	ADP	ADP	_	4	case	_	_
 3	-	_	PUNCT	PUNCT	_	4	punct	_	_
 4	כך	כך	PRON	PRON	Person=3|PronType=Dem	5	obl	_	_
 5	נמצא	נמצא	VERB	VERB	Gender=Masc|HebBinyan=NIFAL|Number=Sing|Person=3|Tense=Past|Voice=Mid	0	root	_	_
 6	כרטיס	כרטיס	NOUN	NOUN	Definite=Cons|Gender=Masc|Number=Sing	5	nsubj	_	_
-7	ביקור	ביקור	NOUN	NOUN	Gender=Masc|Number=Sing	6	compound:smixut	_	_
+7	ביקור	ביקור	NOUN	NOUN	Gender=Masc|Number=Sing	6	compound:smixut	_	SpaceAfter=No
 8	,	_	PUNCT	PUNCT	_	5	punct	_	_
 9-11	ובו	_	_	_	_	_	_	_	_
 9	ו	ו	CCONJ	CCONJ	_	11	cc	_	_
@@ -4893,11 +4893,11 @@
 21	כ	כ	ADP	ADP	_	22	case	_	_
 22	מנהל	מנהל	NOUN	NOUN	Definite=Cons|Gender=Masc|Number=Sing	16	nmod	_	_
 23	מפעל	מפעל	NOUN	NOUN	Gender=Masc|Number=Sing	22	compound:smixut	_	_
-24	פרטי	פרטי	ADJ	ADJ	Gender=Masc|Number=Sing	23	amod	_	_
+24	פרטי	פרטי	ADJ	ADJ	Gender=Masc|Number=Sing	23	amod	_	SpaceAfter=No
 25	.	_	PUNCT	PUNCT	_	5	punct	_	_
 
 # sent_id = 138
-# text = אנשי משרד החוץ התקשרו אתמול למפעל , ורק אז התברר כי מדובר ביו"ר רשות שדות התעופה .
+# text = אנשי משרד החוץ התקשרו אתמול למפעל, ורק אז התברר כי מדובר ביו"ר רשות שדות התעופה.
 1	אנשי	איש	NOUN	NOUN	Definite=Cons|Gender=Masc|Number=Plur	5	nsubj	_	_
 2	משרד	משרד	NOUN	NOUN	Definite=Cons|Gender=Masc|Number=Sing	1	compound:smixut	_	_
 3-4	החוץ	_	_	_	_	_	_	_	_
@@ -4905,7 +4905,7 @@
 4	חוץ	חוץ	NOUN	NOUN	Gender=Masc|Number=Sing	2	compound:smixut	_	_
 5	התקשרו	התקשר	VERB	VERB	Gender=Fem,Masc|HebBinyan=HITPAEL|Number=Plur|Person=3|Tense=Past	0	root	_	_
 6	אתמול	אתמול	ADV	ADV	_	5	obl:tmod	_	_
-7-9	למפעל	_	_	_	_	_	_	_	_
+7-9	למפעל	_	_	_	_	_	_	_	SpaceAfter=No
 7	ל	ל	ADP	ADP	_	9	case	_	_
 8	ה_	ה	DET	DET	PronType=Art	9	det:def	_	_
 9	מפעל	מפעל	NOUN	NOUN	Gender=Masc|Number=Sing	5	iobj	_	_
@@ -4922,18 +4922,18 @@
 18	יו"ר	יו"ר	NOUN	NOUN	Abbr=Yes|Definite=Cons|Gender=Masc|Number=Sing	16	iobj	_	_
 19	רשות	רשות	NOUN	NOUN	Definite=Cons|Gender=Fem|Number=Sing	18	compound:smixut	_	_
 20	שדות	שדה	NOUN	NOUN	Definite=Cons|Gender=Masc|Number=Plur	19	compound:smixut	_	_
-21-22	התעופה	_	_	_	_	_	_	_	_
+21-22	התעופה	_	_	_	_	_	_	_	SpaceAfter=No
 21	ה	ה	DET	DET	PronType=Art	22	det:def	_	_
 22	תעופה	תעופה	NOUN	NOUN	Gender=Fem|Number=Sing	20	compound:smixut	_	_
 23	.	_	PUNCT	PUNCT	_	5	punct	_	_
 
 # sent_id = 139
-# text = גרוסבורד , בן 95 במותו , השאיר אחריו אם , אחות , רעיה , בן ושתי בנות .
-1	גרוסבורד	גרוסבורד	PROPN	PROPN	_	10	nsubj	_	_
+# text = גרוסבורד, בן 95 במותו, השאיר אחריו אם, אחות, רעיה, בן ושתי בנות.
+1	גרוסבורד	גרוסבורד	PROPN	PROPN	_	10	nsubj	_	SpaceAfter=No
 2	,	_	PUNCT	PUNCT	_	1	punct	_	_
 3	בן	בן	NOUN	NOUN	Definite=Cons|Gender=Masc|Number=Sing	1	appos	_	_
 4	95	_	NUM	NUM	_	3	compound:smixut	_	_
-5-8	במותו	_	_	_	_	_	_	_	_
+5-8	במותו	_	_	_	_	_	_	_	SpaceAfter=No
 5	ב	ב	ADP	ADP	_	6	case	_	_
 6	מוות_	מוות	NOUN	NOUN	Definite=Def|Gender=Masc|Number=Sing	3	nmod	_	_
 7	_של_	של	ADP	ADP	_	8	case:gen	_	_
@@ -4943,26 +4943,26 @@
 11-12	אחריו	_	_	_	_	_	_	_	_
 11	אחריו	אחרי	ADP	ADP	_	12	case	_	_
 12	_הוא	הוא	PRON	PRON	Gender=Masc|Number=Sing|Person=3|PronType=Prs	10	obl	_	_
-13	אם	אם	NOUN	NOUN	Gender=Fem|Number=Sing	10	obj	_	_
+13	אם	אם	NOUN	NOUN	Gender=Fem|Number=Sing	10	obj	_	SpaceAfter=No
 14	,	_	PUNCT	PUNCT	_	13	punct	_	_
-15	אחות	אח	NOUN	NOUN	Gender=Fem|Number=Sing	13	conj	_	_
+15	אחות	אח	NOUN	NOUN	Gender=Fem|Number=Sing	13	conj	_	SpaceAfter=No
 16	,	_	PUNCT	PUNCT	_	13	punct	_	_
-17	רעיה	רעייה	NOUN	NOUN	Gender=Fem|Number=Sing	13	conj	_	_
+17	רעיה	רעייה	NOUN	NOUN	Gender=Fem|Number=Sing	13	conj	_	SpaceAfter=No
 18	,	_	PUNCT	PUNCT	_	13	punct	_	_
 19	בן	בן	NOUN	NOUN	Gender=Masc|Number=Sing	13	conj	_	_
 20-21	ושתי	_	_	_	_	_	_	_	_
 20	ו	ו	CCONJ	CCONJ	_	22	cc	_	_
 21	שתי	שתיים	NUM	NUM	Definite=Cons|Gender=Fem|Number=Plur	22	nummod	_	_
-22	בנות	בת	NOUN	NOUN	Gender=Fem|Number=Plur	13	conj	_	_
+22	בנות	בת	NOUN	NOUN	Gender=Fem|Number=Plur	13	conj	_	SpaceAfter=No
 23	.	_	PUNCT	PUNCT	_	10	punct	_	_
 
 # sent_id = 140
-# text = עדיין לא נקבע מועד להלווייתו .
+# text = עדיין לא נקבע מועד להלווייתו.
 1	עדיין	עדיין	ADV	ADV	_	2	advmod	_	_
 2	לא	לא	ADV	ADV	Polarity=Neg	3	advmod:phrase	_	_
 3	נקבע	נקבע	VERB	VERB	Gender=Masc|HebBinyan=NIFAL|Number=Sing|Person=3|Tense=Past|Voice=Mid	0	root	_	_
 4	מועד	מועד	NOUN	NOUN	Gender=Masc|Number=Sing	3	nsubj	_	_
-5-8	להלווייתו	_	_	_	_	_	_	_	_
+5-8	להלווייתו	_	_	_	_	_	_	_	SpaceAfter=No
 5	ל	ל	ADP	ADP	_	6	case	_	_
 6	הלוויה_	הלוויה	NOUN	NOUN	Definite=Def|Gender=Fem|Number=Sing	4	nmod	_	_
 7	_של_	של	ADP	ADP	_	8	case:gen	_	_
@@ -4970,7 +4970,7 @@
 9	.	_	PUNCT	PUNCT	_	3	punct	_	_
 
 # sent_id = 141
-# text = מרכז המידע לזכויות האדם בשטחים , " בצלם " , מפרסם מפעם לפעם דפי מידע ובהם פרטים על הנעשה בשטחים בתחומים שונים .
+# text = מרכז המידע לזכויות האדם בשטחים, "בצלם", מפרסם מפעם לפעם דפי מידע ובהם פרטים על הנעשה בשטחים בתחומים שונים.
 1	מרכז	מרכז	NOUN	NOUN	Definite=Cons|Gender=Masc|Number=Sing	16	nsubj	_	_
 2-3	המידע	_	_	_	_	_	_	_	_
 2	ה	ה	DET	DET	PronType=Art	3	det:def	_	_
@@ -4981,14 +4981,14 @@
 6-7	האדם	_	_	_	_	_	_	_	_
 6	ה	ה	DET	DET	PronType=Art	7	det:def	_	_
 7	אדם	אדם	NOUN	NOUN	Gender=Masc|Number=Sing	5	compound:smixut	_	_
-8-10	בשטחים	_	_	_	_	_	_	_	_
+8-10	בשטחים	_	_	_	_	_	_	_	SpaceAfter=No
 8	ב	ב	ADP	ADP	_	10	case	_	_
 9	ה_	ה	DET	DET	PronType=Art	10	det:def	_	_
 10	שטחים	שטח	NOUN	NOUN	Gender=Masc|Number=Plur	5	nmod	_	_
 11	,	_	PUNCT	PUNCT	_	1	punct	_	_
-12	"	_	PUNCT	PUNCT	_	13	punct	_	_
-13	בצלם	בצלם	PROPN	PROPN	_	1	appos	_	_
-14	"	_	PUNCT	PUNCT	_	13	punct	_	_
+12	"	_	PUNCT	PUNCT	_	13	punct	_	SpaceAfter=No
+13	בצלם	בצלם	PROPN	PROPN	_	1	appos	_	SpaceAfter=No
+14	"	_	PUNCT	PUNCT	_	13	punct	_	SpaceAfter=No
 15	,	_	PUNCT	PUNCT	_	16	punct	_	_
 16	מפרסם	פרסם	VERB	VERB	Gender=Masc|HebBinyan=PIEL|Number=Sing|Person=1,2,3|VerbForm=Part|Voice=Act	0	root	_	_
 17-18	מפעם	_	_	_	_	_	_	_	_
@@ -5015,16 +5015,16 @@
 33-34	בתחומים	_	_	_	_	_	_	_	_
 33	ב	ב	ADP	ADP	_	34	case	_	_
 34	תחומים	תחום	NOUN	NOUN	Gender=Masc|Number=Plur	29	iobj	_	_
-35	שונים	שונה	ADJ	ADJ	Gender=Masc|Number=Plur	34	amod	_	_
+35	שונים	שונה	ADJ	ADJ	Gender=Masc|Number=Plur	34	amod	_	SpaceAfter=No
 36	.	_	PUNCT	PUNCT	_	16	punct	_	_
 
 # sent_id = 142
-# text = הסגנון ענייני מאוד , בדרך כלל יש בו נגיעה לענייני חוק .
+# text = הסגנון ענייני מאוד, בדרך כלל יש בו נגיעה לענייני חוק.
 1-2	הסגנון	_	_	_	_	_	_	_	_
 1	ה	ה	DET	DET	PronType=Art	2	det:def	_	_
 2	סגנון	סגנון	NOUN	NOUN	Gender=Masc|Number=Sing	3	nsubj	_	_
 3	ענייני	ענייני	ADJ	ADJ	Gender=Masc|Number=Sing	0	root	_	_
-4	מאוד	מאוד	ADV	ADV	_	3	advmod	_	_
+4	מאוד	מאוד	ADV	ADV	_	3	advmod	_	SpaceAfter=No
 5	,	_	PUNCT	PUNCT	_	3	punct	_	_
 6-7	בדרך	_	_	_	_	_	_	_	_
 6	ב	ב	ADP	ADP	_	9	advmod	_	_
@@ -5038,13 +5038,13 @@
 13-14	לענייני	_	_	_	_	_	_	_	_
 13	ל	ל	ADP	ADP	_	14	case	_	_
 14	ענייני	עניין	NOUN	NOUN	Definite=Cons|Gender=Masc|Number=Plur	12	nmod	_	_
-15	חוק	חוק	NOUN	NOUN	Gender=Masc|Number=Sing	14	compound:smixut	_	_
+15	חוק	חוק	NOUN	NOUN	Gender=Masc|Number=Sing	14	compound:smixut	_	SpaceAfter=No
 16	.	_	PUNCT	PUNCT	_	3	punct	_	_
 
 # sent_id = 143
-# text = " בצלם " נוהג להפיץ את דפי המידע שלו בין בעלי עניין שונים , חלקם בעלי משרות במערכת המשפט .
-1	"	_	PUNCT	PUNCT	_	2	punct	_	_
-2	בצלם	בצלם	PROPN	PROPN	_	4	nsubj	_	_
+# text = "בצלם" נוהג להפיץ את דפי המידע שלו בין בעלי עניין שונים, חלקם בעלי משרות במערכת המשפט.
+1	"	_	PUNCT	PUNCT	_	2	punct	_	SpaceAfter=No
+2	בצלם	בצלם	PROPN	PROPN	_	4	nsubj	_	SpaceAfter=No
 3	"	_	PUNCT	PUNCT	_	2	punct	_	_
 4	נוהג	נהג	VERB	VERB	Gender=Masc|HebBinyan=PAAL|Number=Sing|Person=1,2,3|VerbForm=Part|Voice=Act	0	root	_	_
 5	להפיץ	הפיץ	VERB	VERB	HebBinyan=HIFIL|VerbForm=Inf|Voice=Act	4	xcomp	_	_
@@ -5059,7 +5059,7 @@
 12	בין	בין	ADP	ADP	_	13	case	_	_
 13	בעלי	בעל	NOUN	NOUN	Definite=Cons|Gender=Masc|Number=Plur	5	iobj	_	_
 14	עניין	עניין	NOUN	NOUN	Gender=Masc|Number=Sing	13	compound:smixut	_	_
-15	שונים	שונה	ADJ	ADJ	Gender=Masc|Number=Plur	13	amod	_	_
+15	שונים	שונה	ADJ	ADJ	Gender=Masc|Number=Plur	13	amod	_	SpaceAfter=No
 16	,	_	PUNCT	PUNCT	_	13	punct	_	_
 17-19	חלקם	_	_	_	_	_	_	_	_
 17	חלק_	חלק	NOUN	NOUN	Definite=Def|Gender=Masc|Number=Sing	20	nsubj	_	_
@@ -5070,13 +5070,13 @@
 22-23	במערכת	_	_	_	_	_	_	_	_
 22	ב	ב	ADP	ADP	_	23	case	_	_
 23	מערכת	מערכת	NOUN	NOUN	Definite=Cons|Gender=Fem|Number=Sing	21	nmod	_	_
-24-25	המשפט	_	_	_	_	_	_	_	_
+24-25	המשפט	_	_	_	_	_	_	_	SpaceAfter=No
 24	ה	ה	DET	DET	PronType=Art	25	det:def	_	_
 25	משפט	משפט	NOUN	NOUN	Gender=Masc|Number=Sing	23	compound:smixut	_	_
 26	.	_	PUNCT	PUNCT	_	4	punct	_	_
 
 # sent_id = 144
-# text = בימים אלה התקבל במשרדי הארגון מכתב ממשרד המשפטים , על נייר רשמי , וזה לשונו : " הנדון החוברת שלכם .
+# text = בימים אלה התקבל במשרדי הארגון מכתב ממשרד המשפטים, על נייר רשמי, וזה לשונו: " הנדון החוברת שלכם.
 1-2	בימים	_	_	_	_	_	_	_	_
 1	ב	ב	ADP	ADP	_	2	case	_	_
 2	ימים	יום	NOUN	NOUN	Gender=Masc|Number=Plur	4	obl	_	_
@@ -5092,18 +5092,18 @@
 10-11	ממשרד	_	_	_	_	_	_	_	_
 10	מ	מ	ADP	ADP	_	11	case	_	_
 11	משרד	משרד	NOUN	NOUN	Definite=Cons|Gender=Masc|Number=Sing	9	nmod	_	_
-12-13	המשפטים	_	_	_	_	_	_	_	_
+12-13	המשפטים	_	_	_	_	_	_	_	SpaceAfter=No
 12	ה	ה	DET	DET	PronType=Art	13	det:def	_	_
 13	משפטים	משפט	NOUN	NOUN	Gender=Masc|Number=Plur	11	compound:smixut	_	_
 14	,	_	PUNCT	PUNCT	_	9	punct	_	_
 15	על	על	ADP	ADP	_	16	case	_	_
 16	נייר	נייר	NOUN	NOUN	Gender=Masc|Number=Sing	9	nmod	_	_
-17	רשמי	רשמי	ADJ	ADJ	Gender=Masc|Number=Sing	16	amod	_	_
+17	רשמי	רשמי	ADJ	ADJ	Gender=Masc|Number=Sing	16	amod	_	SpaceAfter=No
 18	,	_	PUNCT	PUNCT	_	4	punct	_	_
 19-20	וזה	_	_	_	_	_	_	_	_
 19	ו	ו	CCONJ	CCONJ	_	21	cc	_	_
 20	זה	זה	PRON	PRON	Gender=Masc|Number=Sing|Person=3	21	nsubj	_	_
-21-23	לשונו	_	_	_	_	_	_	_	_
+21-23	לשונו	_	_	_	_	_	_	_	SpaceAfter=No
 21	לשון_	לשון	NOUN	NOUN	Definite=Def|Gender=Fem|Number=Sing	4	conj	_	_
 22	_של_	של	ADP	ADP	_	23	case:gen	_	_
 23	_הוא	הוא	PRON	PRON	Case=Gen|Gender=Masc|Number=Sing|Person=3|PronType=Prs	21	nmod:poss	_	_
@@ -5115,13 +5115,13 @@
 28-29	החוברת	_	_	_	_	_	_	_	_
 28	ה	ה	DET	DET	PronType=Art	29	det:def	_	_
 29	חוברת	חוברת	NOUN	NOUN	Gender=Fem|Number=Sing	21	appos	_	_
-30-31	שלכם	_	_	_	_	_	_	_	_
+30-31	שלכם	_	_	_	_	_	_	_	SpaceAfter=No
 30	של_	_	ADP	ADP	Case=Gen	31	case:gen	_	_
 31	_אתם	הוא	PRON	PRON	Gender=Masc|Number=Plur|Person=2|PronType=Prs	29	nmod:poss	_	_
 32	.	_	PUNCT	PUNCT	_	4	punct	_	_
 
 # sent_id = 145
-# text = רצ"ב מוחזר אליכם החומר שנשלח אלי .
+# text = רצ"ב מוחזר אליכם החומר שנשלח אלי.
 1	רצ"ב	רצ"ב	ADV	ADV	Abbr=Yes	2	advmod	_	_
 2	מוחזר	הוחזר	VERB	VERB	Gender=Masc|HebBinyan=HUFAL|Number=Sing|Person=1,2,3|VerbForm=Part|Voice=Pass	0	root	_	_
 3-4	אליכם	_	_	_	_	_	_	_	_
@@ -5133,13 +5133,13 @@
 7-8	שנשלח	_	_	_	_	_	_	_	_
 7	ש	ש	SCONJ	SCONJ	_	8	mark	_	_
 8	נשלח	נשלח	VERB	VERB	Gender=Masc|HebBinyan=NIFAL|Number=Sing|Person=3|Tense=Past|Voice=Mid	6	acl:relcl	_	_
-9-10	אלי	_	_	_	_	_	_	_	_
+9-10	אלי	_	_	_	_	_	_	_	SpaceAfter=No
 9	אלי	אל	ADP	ADP	_	10	case	_	_
 10	_אני	הוא	PRON	PRON	Gender=Fem,Masc|Number=Sing|Person=1|PronType=Prs	8	iobj	_	_
 11	.	_	PUNCT	PUNCT	_	2	punct	_	_
 
 # sent_id = 146
-# text = כמותו אתם שולחים אלי מדי פעם והוא נזרק ישר לפח .
+# text = כמותו אתם שולחים אלי מדי פעם והוא נזרק ישר לפח.
 1-2	כמותו	_	_	_	_	_	_	_	_
 1	כמותו	כמו	ADP	ADP	_	2	case	_	_
 2	_הוא	הוא	PRON	PRON	Gender=Masc|Number=Sing|Person=3|PronType=Prs	4	obl	_	_
@@ -5155,14 +5155,14 @@
 10	הוא	הוא	PRON	PRON	Gender=Masc|Number=Sing|Person=3|PronType=Prs	11	nsubj	_	_
 11	נזרק	נזרק	VERB	VERB	Gender=Masc|HebBinyan=NIFAL|Number=Sing|Person=3|Tense=Past|Voice=Mid	4	conj	_	_
 12	ישר	ישר	ADV	ADV	_	11	advmod	_	_
-13-15	לפח	_	_	_	_	_	_	_	_
+13-15	לפח	_	_	_	_	_	_	_	SpaceAfter=No
 13	ל	ל	ADP	ADP	_	15	case	_	_
 14	ה_	ה	DET	DET	PronType=Art	15	det:def	_	_
 15	פח	פח	NOUN	NOUN	Gender=Masc|Number=Sing	11	obl	_	_
 16	.	_	PUNCT	PUNCT	_	4	punct	_	_
 
 # sent_id = 147
-# text = אבקשכם לשלוח אלי חומר זה .
+# text = אבקשכם לשלוח אלי חומר זה.
 1-2	אבקשכם	_	_	_	_	_	_	_	_
 1	אבקשכם	_	VERB	VERB	_	0	root	_	_
 2	_אתם	הוא	PRON	PRON	Case=Acc|Gender=Masc|Number=Plur|Person=2|PronType=Prs	1	obj	_	_
@@ -5171,11 +5171,11 @@
 4	אלי	אל	ADP	ADP	_	5	case	_	_
 5	_אני	הוא	PRON	PRON	Gender=Fem,Masc|Number=Sing|Person=1|PronType=Prs	3	obl	_	_
 6	חומר	חומר	NOUN	NOUN	Gender=Masc|Number=Sing	3	obj	_	_
-7	זה	זה	PRON	PRON	Gender=Masc|Number=Sing|Person=3|PronType=Dem	6	amod	_	_
+7	זה	זה	PRON	PRON	Gender=Masc|Number=Sing|Person=3|PronType=Dem	6	amod	_	SpaceAfter=No
 8	.	_	PUNCT	PUNCT	_	1	punct	_	_
 
 # sent_id = 148
-# text = מען עבודתי מיועד לקבלת חומר עבודה בלבד " .
+# text = מען עבודתי מיועד לקבלת חומר עבודה בלבד ".
 1	מען	מען	NOUN	NOUN	Definite=Cons|Gender=Masc|Number=Sing	5	nsubj	_	_
 2-4	עבודתי	_	_	_	_	_	_	_	_
 2	עבודה_	עבודה	NOUN	NOUN	Definite=Def|Gender=Fem|Number=Sing	1	compound:smixut	_	_
@@ -5188,17 +5188,17 @@
 8	חומר	חומר	NOUN	NOUN	Definite=Cons|Gender=Masc|Number=Sing	7	compound:smixut	_	_
 9	עבודה	עבודה	NOUN	NOUN	Gender=Fem|Number=Sing	8	compound:smixut	_	_
 10	בלבד	בלבד	ADV	ADV	_	7	advmod	_	_
-11	"	_	PUNCT	PUNCT	_	5	punct	_	_
+11	"	_	PUNCT	PUNCT	_	5	punct	_	SpaceAfter=No
 12	.	_	PUNCT	PUNCT	_	5	punct	_	_
 
 # sent_id = 149
-# text = על החתום נגה ענתבי , הממונה על נוסח החוק ורשומות .
+# text = על החתום נגה ענתבי, הממונה על נוסח החוק ורשומות.
 1	על	על	ADP	ADP	_	3	case	_	_
 2-3	החתום	_	_	_	_	_	_	_	_
 2	ה	ה	DET	DET	PronType=Art	3	det:def	_	_
 3	חתום	חתום	NOUN	NOUN	Gender=Masc|Number=Sing	0	root	_	_
 4	נגה	נגה	PROPN	PROPN	_	3	nsubj	_	_
-5	ענתבי	ענתבי	PROPN	PROPN	_	4	flat:name	_	_
+5	ענתבי	ענתבי	PROPN	PROPN	_	4	flat:name	_	SpaceAfter=No
 6	,	_	PUNCT	PUNCT	_	4	punct	_	_
 7-8	הממונה	_	_	_	_	_	_	_	_
 7	ה	ה	DET	DET	PronType=Art	8	det:def	_	_
@@ -5208,13 +5208,13 @@
 11-12	החוק	_	_	_	_	_	_	_	_
 11	ה	ה	DET	DET	PronType=Art	12	det:def	_	_
 12	חוק	חוק	NOUN	NOUN	Gender=Masc|Number=Sing	10	compound:smixut	_	_
-13-14	ורשומות	_	_	_	_	_	_	_	_
+13-14	ורשומות	_	_	_	_	_	_	_	SpaceAfter=No
 13	ו	ו	CCONJ	CCONJ	_	14	cc	_	_
 14	רשומות	רשומות	NOUN	NOUN	Gender=Fem|Number=Plur	10	conj	_	_
 15	.	_	PUNCT	PUNCT	_	3	punct	_	_
 
 # sent_id = 150
-# text = ולמי שיספר פעם את סיפורה של שגרת החיים בימים המטורפים האלה , הנה הערת שוליים .
+# text = ולמי שיספר פעם את סיפורה של שגרת החיים בימים המטורפים האלה, הנה הערת שוליים.
 1-3	ולמי	_	_	_	_	_	_	_	_
 1	ו	ו	CCONJ	CCONJ	_	3	cc	_	_
 2	ל	ל	ADP	ADP	_	3	case	_	_
@@ -5240,17 +5240,17 @@
 18-19	המטורפים	_	_	_	_	_	_	_	_
 18	ה	ה	DET	DET	PronType=Art	19	det:def	_	_
 19	מטורפים	מטורף	ADJ	ADJ	Gender=Masc|Number=Plur	17	amod	_	_
-20-21	האלה	_	_	_	_	_	_	_	_
+20-21	האלה	_	_	_	_	_	_	_	SpaceAfter=No
 20	ה	ה	DET	DET	PronType=Art	21	det:def	_	_
 21	אלה	אלה	PRON	PRON	Gender=Masc|Number=Plur|Person=3|PronType=Dem	17	amod	_	_
 22	,	_	PUNCT	PUNCT	HebSource=ConvUncertainHead	3	dep	_	_
 23	הנה	הנה	ADV	ADV	HebSource=ConvUncertainHead	3	dep	_	_
 24	הערת	הערה	NOUN	NOUN	Definite=Cons|Gender=Fem|HebSource=ConvUncertainHead|Number=Sing	3	dep	_	_
-25	שוליים	שול	NOUN	NOUN	Gender=Masc|Number=Dual,Plur	24	compound:smixut	_	_
+25	שוליים	שול	NOUN	NOUN	Gender=Masc|Number=Dual,Plur	24	compound:smixut	_	SpaceAfter=No
 26	.	_	PUNCT	PUNCT	_	3	punct	_	_
 
 # sent_id = 151
-# text = על חשבונות המים שעיריית ירושלים שלחה בימים אלה לתושבים הודפסה הנחיה בזו הלשון : " אם יש לך מיכל מים על גג הבית , אנא דאג לנעילת הכניסה אל הגג , כדי למנוע מאנשים זרים לזהם או להרעיל את מי השתייה " .
+# text = על חשבונות המים שעיריית ירושלים שלחה בימים אלה לתושבים הודפסה הנחיה בזו הלשון: " אם יש לך מיכל מים על גג הבית, אנא דאג לנעילת הכניסה אל הגג, כדי למנוע מאנשים זרים לזהם או להרעיל את מי השתייה ".
 1	על	על	ADP	ADP	_	2	case	_	_
 2	חשבונות	חשבון	NOUN	NOUN	Definite=Cons|Gender=Masc|Number=Plur	15	obl	_	_
 3-4	המים	_	_	_	_	_	_	_	_
@@ -5274,7 +5274,7 @@
 17-18	בזו	_	_	_	_	_	_	_	_
 17	ב	ב	ADP	ADP	_	20	case	_	_
 18	זו	זו	PRON	PRON	Gender=Fem|Number=Sing|Person=3|PronType=Dem	20	det	_	_
-19-20	הלשון	_	_	_	_	_	_	_	_
+19-20	הלשון	_	_	_	_	_	_	_	SpaceAfter=No
 19	ה	ה	DET	DET	PronType=Art	20	det:def	_	_
 20	לשון	לשון	NOUN	NOUN	Gender=Fem|Number=Sing	16	nmod	_	_
 21	:	_	PUNCT	PUNCT	_	35	punct	_	_
@@ -5288,7 +5288,7 @@
 28	מים	מים	NOUN	NOUN	Gender=Masc|Number=Plur	27	compound:smixut	_	_
 29	על	על	ADP	ADP	_	30	case	_	_
 30	גג	גג	NOUN	NOUN	Definite=Cons|Gender=Masc|Number=Sing	24	obl	_	_
-31-32	הבית	_	_	_	_	_	_	_	_
+31-32	הבית	_	_	_	_	_	_	_	SpaceAfter=No
 31	ה	ה	DET	DET	PronType=Art	32	det:def	_	_
 32	בית	בית	NOUN	NOUN	Gender=Masc|Number=Sing	30	compound:smixut	_	_
 33	,	_	PUNCT	PUNCT	_	35	punct	_	_
@@ -5301,7 +5301,7 @@
 38	ה	ה	DET	DET	PronType=Art	39	det:def	_	_
 39	כניסה	כניסה	NOUN	NOUN	Gender=Fem|Number=Sing	37	compound:smixut	_	_
 40	אל	אל	ADP	ADP	_	42	case	_	_
-41-42	הגג	_	_	_	_	_	_	_	_
+41-42	הגג	_	_	_	_	_	_	_	SpaceAfter=No
 41	ה	ה	DET	DET	PronType=Art	42	det:def	_	_
 42	גג	גג	NOUN	NOUN	Gender=Masc|Number=Sing	39	nmod	_	_
 43	,	_	PUNCT	PUNCT	_	35	punct	_	_
@@ -5319,29 +5319,29 @@
 54-55	השתייה	_	_	_	_	_	_	_	_
 54	ה	ה	DET	DET	PronType=Art	55	det:def	_	_
 55	שתייה	שתייה	NOUN	NOUN	Gender=Fem|Number=Sing	53	compound:smixut	_	_
-56	"	_	PUNCT	PUNCT	_	35	punct	_	_
+56	"	_	PUNCT	PUNCT	_	35	punct	_	SpaceAfter=No
 57	.	_	PUNCT	PUNCT	_	15	punct	_	_
 
 # sent_id = 152
-# text = הסתיו אתנו .
+# text = הסתיו אתנו.
 1-2	הסתיו	_	_	_	_	_	_	_	_
 1	ה	ה	DET	DET	PronType=Art	2	det:def	_	_
 2	סתיו	סתיו	NOUN	NOUN	Gender=Masc|Number=Sing	4	nsubj	_	_
-3-4	אתנו	_	_	_	_	_	_	_	_
+3-4	אתנו	_	_	_	_	_	_	_	SpaceAfter=No
 3	אתנו	את	ADP	ADP	_	4	case	_	_
 4	_אנחנו	הוא	PRON	PRON	Gender=Fem,Masc|Number=Plur|Person=1|PronType=Prs	0	root	_	_
 5	.	_	PUNCT	PUNCT	_	4	punct	_	_
 
 # sent_id = 153
-# text = העלים מזהיבים .
+# text = העלים מזהיבים.
 1-2	העלים	_	_	_	_	_	_	_	_
 1	ה	ה	DET	DET	PronType=Art	2	det:def	_	_
 2	עלים	עלה	NOUN	NOUN	Gender=Masc|Number=Plur	3	nsubj	_	_
-3	מזהיבים	הזהיב	VERB	VERB	Gender=Masc|HebBinyan=HIFIL|Number=Plur|Person=1,2,3|VerbForm=Part|Voice=Act	0	root	_	_
+3	מזהיבים	הזהיב	VERB	VERB	Gender=Masc|HebBinyan=HIFIL|Number=Plur|Person=1,2,3|VerbForm=Part|Voice=Act	0	root	_	SpaceAfter=No
 4	.	_	PUNCT	PUNCT	_	3	punct	_	_
 
 # sent_id = 154
-# text = קצה של שנה נוספת נראה במעורפל באופק , ועדיין לא זכית במענק " גאונות " של קרן מקארתור .
+# text = קצה של שנה נוספת נראה במעורפל באופק, ועדיין לא זכית במענק "גאונות" של קרן מקארתור.
 1-3	קצה	_	_	_	_	_	_	_	_
 1	קץ_	קץ	NOUN	NOUN	Definite=Def|Gender=Masc|Number=Sing	7	nsubj	_	_
 2	_של_	של	ADP	ADP	_	3	case:gen	_	_
@@ -5351,7 +5351,7 @@
 6	נוספת	נוסף	ADJ	ADJ	Gender=Fem|Number=Sing	5	amod	_	_
 7	נראה	נראה	VERB	VERB	Gender=Masc|HebBinyan=NIFAL|Number=Sing|Person=1,2,3|VerbForm=Part|Voice=Mid	0	root	_	_
 8	במעורפל	במעורפל	ADV	ADV	_	7	advmod	_	_
-9-11	באופק	_	_	_	_	_	_	_	_
+9-11	באופק	_	_	_	_	_	_	_	SpaceAfter=No
 9	ב	ב	ADP	ADP	_	11	case	_	_
 10	ה_	ה	DET	DET	PronType=Art	11	det:def	_	_
 11	אופק	אופק	NOUN	NOUN	Gender=Masc|Number=Sing	7	obl	_	_
@@ -5364,32 +5364,32 @@
 17-18	במענק	_	_	_	_	_	_	_	_
 17	ב	ב	ADP	ADP	_	18	case	_	_
 18	מענק	מענק	NOUN	NOUN	Definite=Cons|Gender=Masc|Number=Sing	16	obl	_	_
-19	"	_	PUNCT	PUNCT	_	20	punct	_	_
-20	גאונות	גאונות	NOUN	NOUN	Gender=Fem|Number=Sing	18	compound:smixut	_	_
+19	"	_	PUNCT	PUNCT	_	20	punct	_	SpaceAfter=No
+20	גאונות	גאונות	NOUN	NOUN	Gender=Fem|Number=Sing	18	compound:smixut	_	SpaceAfter=No
 21	"	_	PUNCT	PUNCT	_	20	punct	_	_
 22	של	של	PART	PART	Case=Gen	23	case:gen	_	_
 23	קרן	קרן	NOUN	NOUN	Definite=Cons|Gender=Fem|Number=Sing	18	nmod:poss	_	_
-24	מקארתור	מקארתור	PROPN	PROPN	_	23	flat:name	_	_
+24	מקארתור	מקארתור	PROPN	PROPN	_	23	flat:name	_	SpaceAfter=No
 25	.	_	PUNCT	PUNCT	_	7	punct	_	_
 
 # sent_id = 155
-# text = גם אני לא .
+# text = גם אני לא.
 1	גם	גם	ADV	ADV	_	2	det	_	_
 2	אני	הוא	PRON	PRON	Gender=Fem,Masc|Number=Sing|Person=1|PronType=Prs	0	root	_	_
-3	לא	לא	ADV	ADV	Polarity=Neg	2	det	_	_
+3	לא	לא	ADV	ADV	Polarity=Neg	2	det	_	SpaceAfter=No
 4	.	_	PUNCT	PUNCT	_	2	punct	_	_
 
 # sent_id = 156
-# text = פרסום רשימת הזוכים השנה , כמו תמיד , די בו כדי לגרום לסופרים , לאמנים , לאקדמאים ולפעילים במסגרות שונות ברחבי ארצות הברית כולה לצפות לרשימת השנה הבאה , כשבלבם מקננת התקווה שאולי גם הם ייכללו בה .
+# text = פרסום רשימת הזוכים השנה, כמו תמיד, די בו כדי לגרום לסופרים, לאמנים, לאקדמאים ולפעילים במסגרות שונות ברחבי ארצות הברית כולה לצפות לרשימת השנה הבאה, כשבלבם מקננת התקווה שאולי גם הם ייכללו בה.
 1	פרסום	פרסום	NOUN	NOUN	Definite=Cons|Gender=Masc|Number=Sing	0	root	_	_
 2	רשימת	רשימה	NOUN	NOUN	Definite=Cons|Gender=Fem|Number=Sing	1	compound:smixut	_	_
 3-4	הזוכים	_	_	_	_	_	_	_	_
 3	ה	ה	DET	DET	PronType=Art	4	det:def	_	_
 4	זוכים	זכה	VERB	VERB	Gender=Masc|HebBinyan=PAAL|Number=Plur|Person=1,2,3|VerbForm=Part|Voice=Act	2	compound:smixut	_	_
-5	השנה	השנה	ADV	ADV	_	1	obl:tmod	_	_
+5	השנה	השנה	ADV	ADV	_	1	obl:tmod	_	SpaceAfter=No
 6	,	_	PUNCT	PUNCT	_	8	punct	_	_
 7	כמו	כמו	ADP	ADP	_	8	case	_	_
-8	תמיד	תמיד	ADV	ADV	_	1	parataxis	_	_
+8	תמיד	תמיד	ADV	ADV	_	1	parataxis	_	SpaceAfter=No
 9	,	_	PUNCT	PUNCT	_	8	punct	_	_
 10	די	די	ADV	ADV	HebSource=ConvUncertainHead	1	dep	_	_
 11-12	בו	_	_	_	_	_	_	_	_
@@ -5397,11 +5397,11 @@
 12	_הוא	הוא	PRON	PRON	Gender=Masc|Number=Sing|Person=3|PronType=Prs	10	iobj	_	_
 13	כדי	_	ADP	ADP	_	14	case	_	_
 14	לגרום	גרם	VERB	VERB	HebBinyan=PAAL|VerbForm=Inf|Voice=Act	10	advcl	_	_
-15-16	לסופרים	_	_	_	_	_	_	_	_
+15-16	לסופרים	_	_	_	_	_	_	_	SpaceAfter=No
 15	ל	ל	ADP	ADP	_	16	case	_	_
 16	סופרים	סופר	NOUN	NOUN	Gender=Masc|Number=Plur	14	iobj	_	_
 17	,	_	PUNCT	PUNCT	_	16	punct	_	_
-18-19	לאמנים	_	_	_	_	_	_	_	_
+18-19	לאמנים	_	_	_	_	_	_	_	SpaceAfter=No
 18	ל	ל	ADP	ADP	_	19	case	_	_
 19	אמנים	אמן	NOUN	NOUN	Gender=Masc|Number=Plur	16	conj	_	_
 20	,	_	PUNCT	PUNCT	_	16	punct	_	_
@@ -5433,7 +5433,7 @@
 39-40	השנה	_	_	_	_	_	_	_	_
 39	ה	ה	DET	DET	PronType=Art	40	det:def	_	_
 40	שנה	שנה	NOUN	NOUN	Gender=Fem|Number=Sing	38	compound:smixut	_	_
-41-42	הבאה	_	_	_	_	_	_	_	_
+41-42	הבאה	_	_	_	_	_	_	_	SpaceAfter=No
 41	ה	ה	DET	DET	PronType=Art	42	det:def	_	_
 42	באה	בא	ADJ	ADJ	Gender=Fem|Number=Sing	40	amod	_	_
 43	,	_	PUNCT	PUNCT	HebSource=ConvUncertainHead	36	dep	_	_
@@ -5453,18 +5453,18 @@
 54	גם	גם	ADV	ADV	_	55	det	_	_
 55	הם	הוא	PRON	PRON	Gender=Masc|Number=Plur|Person=3|PronType=Prs	56	nsubj	_	_
 56	ייכללו	נכלל	VERB	VERB	Gender=Fem,Masc|HebBinyan=NIFAL|Number=Plur|Person=3|Tense=Fut|Voice=Mid	51	acl:relcl	_	_
-57-58	בה	_	_	_	_	_	_	_	_
+57-58	בה	_	_	_	_	_	_	_	SpaceAfter=No
 57	בה	ב	ADP	ADP	_	58	case	_	_
 58	_היא	הוא	PRON	PRON	Gender=Fem|Number=Sing|Person=3|PronType=Prs	56	obl	_	_
 59	.	_	PUNCT	PUNCT	_	1	punct	_	_
 
 # sent_id = 157
-# text = אחרי ככלות הכל , 63 הזוכים אם לשפוט על פי הכתוב עליהם בעיתונות אינם נראים מיוחדים כל כך .
+# text = אחרי ככלות הכל, 63 הזוכים אם לשפוט על פי הכתוב עליהם בעיתונות אינם נראים מיוחדים כל כך.
 1	אחרי	אחרי	ADP	ADP	_	3	case	_	_
 2-3	ככלות	_	_	_	_	_	_	_	_
 2	כ	כ	ADP	ADP	_	3	case	_	_
 3	כלות	כלה	NOUN	NOUN	Definite=Cons|Gender=Fem|Number=Plur	21	parataxis	_	_
-4	הכל	הכיל	NOUN	NOUN	HebSource=ConvUncertainHead	3	dep	_	_
+4	הכל	הכיל	NOUN	NOUN	HebSource=ConvUncertainHead	3	dep	_	SpaceAfter=No
 5	,	_	PUNCT	PUNCT	_	21	punct	_	_
 6	63	_	NUM	NUM	_	8	nummod	_	_
 7-8	הזוכים	_	_	_	_	_	_	_	_
@@ -5488,17 +5488,17 @@
 21	נראים	נראה	VERB	VERB	Gender=Masc|HebBinyan=NIFAL|Number=Plur|Person=1,2,3|VerbForm=Part|Voice=Mid	0	root	_	_
 22	מיוחדים	מיוחד	ADJ	ADJ	Gender=Masc|HebSource=ConvUncertainLabel|Number=Plur	21	advmod	_	_
 23	כל	כול	DET	DET	Definite=Cons	22	advmod	_	_
-24	כך	כך	ADV	ADV	_	23	fixed	_	_
+24	כך	כך	ADV	ADV	_	23	fixed	_	SpaceAfter=No
 25	.	_	PUNCT	PUNCT	_	21	punct	_	_
 
 # sent_id = 158
-# text = אבל כמובן , לאחר בדיקה קפדנית , מתברר שזה בדיוק מה שהם מיוחדים .
+# text = אבל כמובן, לאחר בדיקה קפדנית, מתברר שזה בדיוק מה שהם מיוחדים.
 1	אבל	אבל	CCONJ	CCONJ	_	8	cc	_	_
-2	כמובן	כמובן	ADV	ADV	_	8	advmod	_	_
+2	כמובן	כמובן	ADV	ADV	_	8	advmod	_	SpaceAfter=No
 3	,	_	PUNCT	PUNCT	_	8	punct	_	_
 4	לאחר	לאחר	ADP	ADP	_	5	case	_	_
 5	בדיקה	בדיקה	NOUN	NOUN	Gender=Fem|Number=Sing	8	obl	_	_
-6	קפדנית	קפדני	ADJ	ADJ	Gender=Fem|Number=Sing	5	amod	_	_
+6	קפדנית	קפדני	ADJ	ADJ	Gender=Fem|Number=Sing	5	amod	_	SpaceAfter=No
 7	,	_	PUNCT	PUNCT	_	8	punct	_	_
 8	מתברר	התברר	VERB	VERB	Gender=Masc|HebBinyan=HITPAEL|Number=Sing|Person=1,2,3|VerbForm=Part	0	root	_	_
 9-10	שזה	_	_	_	_	_	_	_	_
@@ -5509,20 +5509,20 @@
 13-14	שהם	_	_	_	_	_	_	_	_
 13	ש	ש	SCONJ	SCONJ	_	15	mark	_	_
 14	הם	הוא	PRON	PRON	Gender=Masc|Number=Plur|Person=3|PronType=Prs	15	nsubj	_	_
-15	מיוחדים	מיוחד	ADJ	ADJ	Gender=Masc|Number=Plur	12	acl:relcl	_	_
+15	מיוחדים	מיוחד	ADJ	ADJ	Gender=Masc|Number=Plur	12	acl:relcl	_	SpaceAfter=No
 16	.	_	PUNCT	PUNCT	_	8	punct	_	_
 
 # sent_id = 159
-# text = קחו למשל את מריה ואראלה .
+# text = קחו למשל את מריה ואראלה.
 1	קחו	לקח	VERB	VERB	Gender=Fem,Masc|HebBinyan=PAAL|Mood=Imp|Number=Plur|Person=2|Voice=Act	0	root	_	_
 2	למשל	למשל	CCONJ	CCONJ	_	1	advmod	_	_
 3	את	את	PART	PART	Case=Acc	4	case:acc	_	_
 4	מריה	מריה	PROPN	PROPN	_	1	obj	_	_
-5	ואראלה	ואראלה	PROPN	PROPN	_	4	flat:name	_	_
+5	ואראלה	ואראלה	PROPN	PROPN	_	4	flat:name	_	SpaceAfter=No
 6	.	_	PUNCT	PUNCT	_	1	punct	_	_
 
 # sent_id = 160
-# text = בתחילה היא מצטיירת כמו כל מארגנת קהילתית אחרת .
+# text = בתחילה היא מצטיירת כמו כל מארגנת קהילתית אחרת.
 1-2	בתחילה	_	_	_	_	_	_	_	_
 1	ב	ב	ADP	ADP	_	4	advmod	_	_
 2	תחילה	תחילה	NOUN	NOUN	Gender=Fem|Number=Sing	1	fixed	_	_
@@ -5532,11 +5532,11 @@
 6	כל	כול	DET	DET	Definite=Cons	7	det	_	_
 7	מארגנת	ארגן	VERB	VERB	Gender=Fem|HebBinyan=PIEL|Number=Sing|Person=1,2,3|VerbForm=Part|Voice=Act	4	iobj	_	_
 8	קהילתית	קהילתי	ADJ	ADJ	Gender=Fem|Number=Sing	7	amod	_	_
-9	אחרת	אחר	ADJ	ADJ	Gender=Fem|Number=Sing	7	amod	_	_
+9	אחרת	אחר	ADJ	ADJ	Gender=Fem|Number=Sing	7	amod	_	SpaceAfter=No
 10	.	_	PUNCT	PUNCT	_	4	punct	_	_
 
 # sent_id = 161
-# text = אבל במבט מקרוב מתברר שהיא נמנתה עם מקימי גנאדאס דל ואיה , קואופרטיב לגידול כבשים ולאריגה בלוס אוחוס , ניו - מקסיקו .
+# text = אבל במבט מקרוב מתברר שהיא נמנתה עם מקימי גנאדאס דל ואיה, קואופרטיב לגידול כבשים ולאריגה בלוס אוחוס, ניו - מקסיקו.
 1	אבל	אבל	CCONJ	CCONJ	_	6	cc	_	_
 2-3	במבט	_	_	_	_	_	_	_	_
 2	ב	ב	ADP	ADP	_	3	case	_	_
@@ -5553,7 +5553,7 @@
 11	מקימי	הקים	VERB	VERB	Definite=Cons|Gender=Masc|HebBinyan=HIFIL|Number=Plur|Person=1,2,3|VerbForm=Part|Voice=Act	9	iobj	_	_
 12	גנאדאס	גנאדאס	PROPN	PROPN	_	11	compound:smixut	_	_
 13	דל	דל	PROPN	PROPN	_	12	flat:name	_	_
-14	ואיה	ואיה	PROPN	PROPN	_	12	flat:name	_	_
+14	ואיה	ואיה	PROPN	PROPN	_	12	flat:name	_	SpaceAfter=No
 15	,	_	PUNCT	PUNCT	_	12	punct	_	_
 16	קואופרטיב	קואופרטיב	NOUN	NOUN	Gender=Masc|Number=Sing	12	appos	_	_
 17-18	לגידול	_	_	_	_	_	_	_	_
@@ -5567,25 +5567,25 @@
 23-24	בלוס	_	_	_	_	_	_	_	_
 23	ב	ב	ADP	ADP	_	24	case	_	_
 24	לוס	לוס	PROPN	PROPN	_	16	nmod	_	_
-25	אוחוס	אוחוס	PROPN	PROPN	_	24	flat:name	_	_
+25	אוחוס	אוחוס	PROPN	PROPN	_	24	flat:name	_	SpaceAfter=No
 26	,	_	PUNCT	PUNCT	_	24	punct	_	_
 27	ניו	ניו	PROPN	PROPN	_	24	appos	_	_
 28	-	_	PUNCT	PUNCT	_	27	flat:name	_	_
-29	מקסיקו	מקסיקו	PROPN	PROPN	_	27	flat:name	_	_
+29	מקסיקו	מקסיקו	PROPN	PROPN	_	27	flat:name	_	SpaceAfter=No
 30	.	_	PUNCT	PUNCT	_	6	punct	_	_
 
 # sent_id = 162
-# text = האם אתם יכולים להתעלות על כך ?
+# text = האם אתם יכולים להתעלות על כך?
 1	האם	האם	ADV	ADV	PronType=Int	3	aux:q	_	_
 2	אתם	הוא	PRON	PRON	Gender=Masc|Number=Plur|Person=2|PronType=Prs	3	nsubj	_	_
 3	יכולים	יכול	AUX	AUX	Gender=Masc|Number=Plur|Person=1,2,3|VerbForm=Part|VerbType=Mod	0	root	_	_
 4	להתעלות	התעלה	VERB	VERB	HebBinyan=HITPAEL|VerbForm=Inf	3	xcomp	_	_
 5	על	על	ADP	ADP	_	6	case	_	_
-6	כך	כך	PRON	PRON	Person=3|PronType=Dem	4	iobj	_	_
+6	כך	כך	PRON	PRON	Person=3|PronType=Dem	4	iobj	_	SpaceAfter=No
 7	?	_	PUNCT	PUNCT	_	3	punct	_	_
 
 # sent_id = 163
-# text = וישנם גם הזוכים המיוחדים במובן היותר שנוי במחלוקת של המלה .
+# text = וישנם גם הזוכים המיוחדים במובן היותר שנוי במחלוקת של המלה.
 1-2	וישנם	_	_	_	_	_	_	_	_
 1	ו	ו	CCONJ	CCONJ	_	2	cc	_	_
 2	ישנם	יש	VERB	VERB	HebExistential=True	0	root	_	_
@@ -5608,13 +5608,13 @@
 14	ב	ב	ADP	ADP	_	15	case	_	_
 15	מחלוקת	מחלוקת	NOUN	NOUN	Gender=Fem|Number=Sing	13	obl	_	_
 16	של	של	PART	PART	Case=Gen	18	case:gen	_	_
-17-18	המלה	_	_	_	_	_	_	_	_
+17-18	המלה	_	_	_	_	_	_	_	SpaceAfter=No
 17	ה	ה	DET	DET	PronType=Art	18	det:def	_	_
 18	מלה	מילה	NOUN	NOUN	Gender=Fem|Number=Sing	10	nmod	_	_
 19	.	_	PUNCT	PUNCT	_	2	punct	_	_
 
 # sent_id = 164
-# text = למרות שמענקי קרן מקארתור נועדו לשחרר את המוכשרים מנטל ההשתכרות למחייתם , כמה מענקים מגיעים תמיד לאנשים שאינם בדיוק נאבקים כדי לזכות בהכרה ובחופש יצירה ( הדוגמה העיקרית של השנה היא סוזן זונטג ) .
+# text = למרות שמענקי קרן מקארתור נועדו לשחרר את המוכשרים מנטל ההשתכרות למחייתם, כמה מענקים מגיעים תמיד לאנשים שאינם בדיוק נאבקים כדי לזכות בהכרה ובחופש יצירה (הדוגמה העיקרית של השנה היא סוזן זונטג).
 1	למרות	למרות	ADP	ADP	_	6	case	_	_
 2-3	שמענקי	_	_	_	_	_	_	_	_
 2	ש	ש	SCONJ	SCONJ	_	6	mark	_	_
@@ -5633,7 +5633,7 @@
 13-14	ההשתכרות	_	_	_	_	_	_	_	_
 13	ה	ה	DET	DET	PronType=Art	14	det:def	_	_
 14	השתכרות	השתכרות	NOUN	NOUN	Gender=Fem|Number=Sing	12	compound:smixut	_	_
-15-18	למחייתם	_	_	_	_	_	_	_	_
+15-18	למחייתם	_	_	_	_	_	_	_	SpaceAfter=No
 15	ל	ל	ADP	ADP	_	16	case	_	_
 16	מחיה_	מחיה	NOUN	NOUN	Definite=Def|Gender=Fem|Number=Sing	14	nmod	_	_
 17	_של_	של	ADP	ADP	_	18	case:gen	_	_
@@ -5661,7 +5661,7 @@
 35	ב	ב	ADP	ADP	_	36	case	_	_
 36	חופש	חופש	NOUN	NOUN	Definite=Cons|Gender=Masc|Number=Sing	33	conj	_	_
 37	יצירה	יצירה	NOUN	NOUN	Gender=Fem|Number=Sing	36	compound:smixut	_	_
-38	(	_	PUNCT	PUNCT	_	47	punct	_	_
+38	(	_	PUNCT	PUNCT	_	47	punct	_	SpaceAfter=No
 39-40	הדוגמה	_	_	_	_	_	_	_	_
 39	ה	ה	DET	DET	PronType=Art	40	det:def	_	_
 40	דוגמה	דוגמה	NOUN	NOUN	Gender=Fem|Number=Sing	47	nsubj:cop	_	_
@@ -5674,12 +5674,12 @@
 45	שנה	שנה	NOUN	NOUN	Gender=Fem|Number=Sing	40	nmod	_	_
 46	היא	הוא	VERB	VERB	Gender=Fem|Number=Sing|Person=3|Polarity=Pos|VerbForm=Part|VerbType=Cop	47	cop	_	_
 47	סוזן	סוזן	PROPN	PROPN	_	22	parataxis	_	_
-48	זונטג	זונטג	PROPN	PROPN	_	47	flat:name	_	_
-49	)	_	PUNCT	PUNCT	_	47	punct	_	_
+48	זונטג	זונטג	PROPN	PROPN	_	47	flat:name	_	SpaceAfter=No
+49	)	_	PUNCT	PUNCT	_	47	punct	_	SpaceAfter=No
 50	.	_	PUNCT	PUNCT	_	22	punct	_	_
 
 # sent_id = 165
-# text = אם בכל זאת אתם רוצים סבסוד למחשבותיכם ולמעשיכם , עליכם להשיג אותו בדרך המיושנת : לפנות לקרן , ולשכנע אנשים בעלי כסף שאתם זכאים לחלק ממנו .
+# text = אם בכל זאת אתם רוצים סבסוד למחשבותיכם ולמעשיכם, עליכם להשיג אותו בדרך המיושנת: לפנות לקרן, ולשכנע אנשים בעלי כסף שאתם זכאים לחלק ממנו.
 1	אם	אם	SCONJ	SCONJ	_	6	mark	_	_
 2-3	בכל	_	_	_	_	_	_	_	_
 2	ב	ב	ADP	ADP	_	6	advmod	_	_
@@ -5693,7 +5693,7 @@
 9	מחשבה_	מחשבה	NOUN	NOUN	Definite=Def|Gender=Fem|Number=Plur	7	nmod	_	_
 10	_של_	של	ADP	ADP	_	11	case:gen	_	_
 11	_אתם	הוא	PRON	PRON	Case=Gen|Gender=Masc|Number=Plur|Person=2|PronType=Prs	9	nmod:poss	_	_
-12-16	ולמעשיכם	_	_	_	_	_	_	_	_
+12-16	ולמעשיכם	_	_	_	_	_	_	_	SpaceAfter=No
 12	ו	ו	CCONJ	CCONJ	_	14	cc	_	_
 13	ל	ל	ADP	ADP	_	14	case	_	_
 14	מעשה_	מעשה	NOUN	NOUN	Definite=Def|Gender=Masc|Number=Plur	9	conj	_	_
@@ -5711,12 +5711,12 @@
 23	ב	ב	ADP	ADP	_	25	case	_	_
 24	ה_	ה	DET	DET	PronType=Art	25	det:def	_	_
 25	דרך	דרך	NOUN	NOUN	Gender=Fem|Number=Sing	20	iobj	_	_
-26-27	המיושנת	_	_	_	_	_	_	_	_
+26-27	המיושנת	_	_	_	_	_	_	_	SpaceAfter=No
 26	ה	ה	DET	DET	PronType=Art	27	det:def	_	_
 27	מיושנת	מיושן	ADJ	ADJ	Gender=Fem|Number=Sing	25	amod	_	_
 28	:	_	PUNCT	PUNCT	_	25	punct	_	_
 29	לפנות	פנה	VERB	VERB	VerbForm=Inf	25	acl:inf	_	_
-30-32	לקרן	_	_	_	_	_	_	_	_
+30-32	לקרן	_	_	_	_	_	_	_	SpaceAfter=No
 30	ל	ל	ADP	ADP	_	32	case	_	_
 31	ה_	ה	DET	DET	PronType=Art	32	det:def	_	_
 32	קרן	קרן	NOUN	NOUN	Gender=Fem|Number=Sing	29	iobj	_	_
@@ -5734,32 +5734,32 @@
 42-43	לחלק	_	_	_	_	_	_	_	_
 42	ל	ל	ADP	ADP	_	43	case	_	_
 43	חלק	חלק	NOUN	NOUN	Gender=Masc|Number=Sing	41	iobj	_	_
-44-45	ממנו	_	_	_	_	_	_	_	_
+44-45	ממנו	_	_	_	_	_	_	_	SpaceAfter=No
 44	ממנו	מן	ADP	ADP	_	43	dep	_	_
 45	_הוא	הוא	PRON	PRON	Gender=Masc|HebSource=ConvUncertainHead|Number=Sing|Person=3|PronType=Prs	43	dep	_	_
 46	.	_	PUNCT	PUNCT	_	19	punct	_	_
 
 # sent_id = 166
-# text = להלן כמה עצות .
+# text = להלן כמה עצות.
 1	להלן	להלן	ADV	ADV	_	0	root	_	_
 2	כמה	כמה	DET	DET	Definite=Cons	3	det	_	_
-3	עצות	עצה	NOUN	NOUN	Gender=Fem|Number=Plur	1	nsubj	_	_
+3	עצות	עצה	NOUN	NOUN	Gender=Fem|Number=Plur	1	nsubj	_	SpaceAfter=No
 4	.	_	PUNCT	PUNCT	_	1	punct	_	_
 
 # sent_id = 167
-# text = עצה מספר 1 : הצטרפו לגופים .
+# text = עצה מספר 1: הצטרפו לגופים.
 1	עצה	עצה	NOUN	NOUN	Gender=Fem|Number=Sing	5	nsubj	_	_
 2	מספר	מספר	NOUN	NOUN	Gender=Masc|HebSource=ConvUncertainLabel|Number=Sing	1	nmod	_	_
-3	1	_	NUM	NUM	_	2	nummod	_	_
+3	1	_	NUM	NUM	_	2	nummod	_	SpaceAfter=No
 4	:	_	PUNCT	PUNCT	_	5	punct	_	_
 5	הצטרפו	הצטרף	VERB	VERB	Gender=Fem,Masc|HebBinyan=HITPAEL|Mood=Imp|Number=Plur|Person=2	0	root	_	_
-6-7	לגופים	_	_	_	_	_	_	_	_
+6-7	לגופים	_	_	_	_	_	_	_	SpaceAfter=No
 6	ל	ל	ADP	ADP	_	7	case	_	_
 7	גופים	גוף	NOUN	NOUN	Gender=Masc|Number=Plur	5	iobj	_	_
 8	.	_	PUNCT	PUNCT	_	5	punct	_	_
 
 # sent_id = 168
-# text = כמעט אף אחד משבעה מיליארדי הדולרים שקרנות אמריקאיות מחלקות מדי שנה אינו מיועד ליחידים .
+# text = כמעט אף אחד משבעה מיליארדי הדולרים שקרנות אמריקאיות מחלקות מדי שנה אינו מיועד ליחידים.
 1	כמעט	כמעט	ADV	ADV	_	3	det	_	_
 2	אף	אף	DET	DET	Definite=Cons	3	det	_	_
 3	אחד	אחד	NUM	NUM	Gender=Masc|Number=Sing	16	nsubj	_	_
@@ -5779,13 +5779,13 @@
 14	שנה	שנה	NOUN	NOUN	Gender=Fem|Number=Sing	12	dep	_	_
 15	אינו	אינו	VERB	VERB	Gender=Masc|Number=Sing|Person=3|Polarity=Neg|VerbForm=Part|VerbType=Cop	16	advmod	_	_
 16	מיועד	יועד	VERB	VERB	Gender=Masc|HebBinyan=PUAL|Number=Sing|Person=1,2,3|VerbForm=Part|Voice=Pass	0	root	_	_
-17-18	ליחידים	_	_	_	_	_	_	_	_
+17-18	ליחידים	_	_	_	_	_	_	_	SpaceAfter=No
 17	ל	ל	ADP	ADP	_	18	case	_	_
 18	יחידים	יחיד	ADJ	ADJ	Gender=Masc|Number=Plur	16	iobj	_	_
 19	.	_	PUNCT	PUNCT	_	16	punct	_	_
 
 # sent_id = 169
-# text = זו אחת הסיבות לכך שמענקי מקארתור מבוקשים כל כך .
+# text = זו אחת הסיבות לכך שמענקי מקארתור מבוקשים כל כך.
 1	זו	זו	PRON	PRON	Gender=Fem|Number=Sing|Person=3|PronType=Dem	4	nsubj	_	_
 2	אחת	אחת	NUM	NUM	Definite=Cons|Gender=Fem|Number=Sing	4	nummod	_	_
 3-4	הסיבות	_	_	_	_	_	_	_	_
@@ -5800,11 +5800,11 @@
 9	מקארתור	מקארתור	PROPN	PROPN	_	8	compound:smixut	_	_
 10	מבוקשים	מבוקש	ADJ	ADJ	Gender=Masc|Number=Plur	6	acl:relcl	_	_
 11	כל	כול	DET	DET	Definite=Cons	10	advmod	_	_
-12	כך	כך	ADV	ADV	_	11	fixed	_	_
+12	כך	כך	ADV	ADV	_	11	fixed	_	SpaceAfter=No
 13	.	_	PUNCT	PUNCT	_	4	punct	_	_
 
 # sent_id = 170
-# text = בדרך כלל מופנה הכסף לקולגים , למכוני מחקר , ( כולל צוותות חשיבה ) , לקבוצות לשירות קהילתי , למוזיאונים , לספריות ולארגונים אחרים שלא למטרות רווח .
+# text = בדרך כלל מופנה הכסף לקולגים, למכוני מחקר, (כולל צוותות חשיבה), לקבוצות לשירות קהילתי, למוזיאונים, לספריות ולארגונים אחרים שלא למטרות רווח.
 1-2	בדרך	_	_	_	_	_	_	_	_
 1	ב	ב	ADP	ADP	_	4	advmod	_	_
 2	דרך	דרך	NOUN	NOUN	Definite=Cons|Gender=Fem|Number=Sing	1	fixed	_	_
@@ -5813,20 +5813,20 @@
 5-6	הכסף	_	_	_	_	_	_	_	_
 5	ה	ה	DET	DET	PronType=Art	6	det:def	_	_
 6	כסף	כסף	NOUN	NOUN	Gender=Masc|Number=Sing	4	nsubj	_	_
-7-8	לקולגים	_	_	_	_	_	_	_	_
+7-8	לקולגים	_	_	_	_	_	_	_	SpaceAfter=No
 7	ל	ל	ADP	ADP	_	8	case	_	_
 8	קולגים	קולגה	NOUN	NOUN	Gender=Masc|Number=Plur	4	iobj	_	_
 9	,	_	PUNCT	PUNCT	_	8	punct	_	_
 10-11	למכוני	_	_	_	_	_	_	_	_
 10	ל	ל	ADP	ADP	_	11	case	_	_
 11	מכוני	מכון	NOUN	NOUN	Definite=Cons|Gender=Masc|Number=Plur	8	conj	_	_
-12	מחקר	מחקר	NOUN	NOUN	Gender=Masc|Number=Sing	11	compound:smixut	_	_
+12	מחקר	מחקר	NOUN	NOUN	Gender=Masc|Number=Sing	11	compound:smixut	_	SpaceAfter=No
 13	,	_	PUNCT	PUNCT	_	11	punct	_	_
-14	(	_	PUNCT	PUNCT	_	16	punct	_	_
+14	(	_	PUNCT	PUNCT	_	16	punct	_	SpaceAfter=No
 15	כולל	כלל	VERB	VERB	Gender=Masc|HebBinyan=PAAL|Number=Sing|Person=1,2,3|VerbForm=Part|Voice=Act	16	case	_	_
 16	צוותות	צוות	NOUN	NOUN	Definite=Cons|Gender=Masc|Number=Plur	11	appos	_	_
-17	חשיבה	חשיבה	NOUN	NOUN	Gender=Fem|Number=Sing	16	compound:smixut	_	_
-18	)	_	PUNCT	PUNCT	_	16	punct	_	_
+17	חשיבה	חשיבה	NOUN	NOUN	Gender=Fem|Number=Sing	16	compound:smixut	_	SpaceAfter=No
+18	)	_	PUNCT	PUNCT	_	16	punct	_	SpaceAfter=No
 19	,	_	PUNCT	PUNCT	_	8	punct	_	_
 20-21	לקבוצות	_	_	_	_	_	_	_	_
 20	ל	ל	ADP	ADP	_	21	case	_	_
@@ -5834,9 +5834,9 @@
 22-23	לשירות	_	_	_	_	_	_	_	_
 22	ל	ל	ADP	ADP	_	23	case	_	_
 23	שירות	שירות	NOUN	NOUN	Gender=Masc|Number=Sing	8	conj	_	_
-24	קהילתי	קהילתי	ADJ	ADJ	Gender=Masc|Number=Sing	23	amod	_	_
+24	קהילתי	קהילתי	ADJ	ADJ	Gender=Masc|Number=Sing	23	amod	_	SpaceAfter=No
 25	,	_	PUNCT	PUNCT	_	8	punct	_	_
-26-27	למוזיאונים	_	_	_	_	_	_	_	_
+26-27	למוזיאונים	_	_	_	_	_	_	_	SpaceAfter=No
 26	ל	ל	ADP	ADP	_	27	case	_	_
 27	מוזיאונים	מוזיאון	NOUN	NOUN	Gender=Masc|Number=Plur	8	conj	_	_
 28	,	_	PUNCT	PUNCT	_	8	punct	_	_
@@ -5852,13 +5852,13 @@
 36-37	למטרות	_	_	_	_	_	_	_	_
 36	ל	ל	ADP	ADP	_	37	case	_	_
 37	מטרות	מטרה	NOUN	NOUN	Definite=Cons|Gender=Fem|Number=Plur	33	nmod	_	_
-38	רווח	רווח	NOUN	NOUN	Gender=Masc|Number=Sing	37	compound:smixut	_	_
+38	רווח	רווח	NOUN	NOUN	Gender=Masc|Number=Sing	37	compound:smixut	_	SpaceAfter=No
 39	.	_	PUNCT	PUNCT	_	4	punct	_	_
 
 # sent_id = 171
-# text = משום כך , ראשית כל עליך לחשוב על קבלת תפקיד חשוב באחד ממאות הגופים הללו .
+# text = משום כך, ראשית כל עליך לחשוב על קבלת תפקיד חשוב באחד ממאות הגופים הללו.
 1	משום	משום	SCONJ	SCONJ	_	2	case	_	_
-2	כך	כך	PRON	PRON	Person=3|PronType=Dem	7	nmod	_	_
+2	כך	כך	PRON	PRON	Person=3|PronType=Dem	7	nmod	_	SpaceAfter=No
 3	,	_	PUNCT	PUNCT	_	7	punct	_	_
 4	ראשית	ראשית	ADV	ADV	_	7	parataxis	_	_
 5	כל	כול	DET	DET	Definite=Cons	4	fixed	_	_
@@ -5879,11 +5879,11 @@
 17-18	הגופים	_	_	_	_	_	_	_	_
 17	ה	ה	DET	DET	PronType=Art	18	det:def	_	_
 18	גופים	גוף	NOUN	NOUN	Gender=Masc|Number=Plur	11	nmod	_	_
-19	הללו	הללו	PRON	PRON	Gender=Masc|Number=Plur|Person=3|PronType=Dem	18	amod	_	_
+19	הללו	הללו	PRON	PRON	Gender=Masc|Number=Plur|Person=3|PronType=Dem	18	amod	_	SpaceAfter=No
 20	.	_	PUNCT	PUNCT	_	7	punct	_	_
 
 # sent_id = 172
-# text = אז תוכל לתור אחר כסף באורח עצמאי פחות או יותר , אפילו לייסד במשך הזמן מכון משלך במסגרת המכון נותן החסות , למרות שנותן החסות שלך ירצה אחוז שמן מהמענק כדי לכסות " הוצאות קבועות " .
+# text = אז תוכל לתור אחר כסף באורח עצמאי פחות או יותר, אפילו לייסד במשך הזמן מכון משלך במסגרת המכון נותן החסות, למרות שנותן החסות שלך ירצה אחוז שמן מהמענק כדי לכסות " הוצאות קבועות ".
 1	אז	אז	ADV	ADV	_	2	advmod	_	_
 2	תוכל	_	AUX	AUX	Gender=Masc|Number=Sing|Person=2|Tense=Fut|VerbType=Mod	0	root	_	_
 3	לתור	תר	VERB	VERB	HebBinyan=PAAL|VerbForm=Inf|Voice=Act	2	xcomp	_	_
@@ -5895,7 +5895,7 @@
 8	עצמאי	עצמאי	ADJ	ADJ	Gender=Masc|Number=Sing	7	amod	_	_
 9	פחות	פחות	ADV	ADV	_	8	advmod	_	_
 10	או	או	CCONJ	CCONJ	_	9	fixed	_	_
-11	יותר	יותר	ADV	ADV	_	9	fixed	_	_
+11	יותר	יותר	ADV	ADV	_	9	fixed	_	SpaceAfter=No
 12	,	_	PUNCT	PUNCT	_	3	punct	_	_
 13	אפילו	אפילו	CCONJ	CCONJ	_	14	advmod	_	_
 14	לייסד	ייסד	VERB	VERB	HebBinyan=PIEL|HebSource=ConvUncertainHead|VerbForm=Inf|Voice=Act	3	dep	_	_
@@ -5915,7 +5915,7 @@
 24	ה	ה	DET	DET	PronType=Art	25	det:def	_	_
 25	מכון	מכון	NOUN	NOUN	Gender=Masc|Number=Sing	18	nmod	_	_
 26	נותן	נתן	VERB	VERB	Definite=Cons|Gender=Masc|HebBinyan=PAAL|Number=Sing|Person=1,2,3|VerbForm=Part|Voice=Act	25	acl	_	_
-27-28	החסות	_	_	_	_	_	_	_	_
+27-28	החסות	_	_	_	_	_	_	_	SpaceAfter=No
 27	ה	ה	DET	DET	PronType=Art	28	det:def	_	_
 28	חסות	חסות	NOUN	NOUN	Gender=Fem|Number=Sing	26	compound:smixut	_	_
 29	,	_	PUNCT	PUNCT	_	2	punct	_	_
@@ -5941,18 +5941,18 @@
 45	"	_	PUNCT	PUNCT	_	46	punct	_	_
 46	הוצאות	הוצאה	NOUN	NOUN	Gender=Fem|Number=Plur	44	obj	_	_
 47	קבועות	קבוע	ADJ	ADJ	Gender=Fem|Number=Plur	46	amod	_	_
-48	"	_	PUNCT	PUNCT	_	46	punct	_	_
+48	"	_	PUNCT	PUNCT	_	46	punct	_	SpaceAfter=No
 49	.	_	PUNCT	PUNCT	_	2	punct	_	_
 
 # sent_id = 173
-# text = אם אתה מעדיף לפעול בלי איש ביניים , אתה יכול להקים ארגון משלך שלא למטרות רווח .
+# text = אם אתה מעדיף לפעול בלי איש ביניים, אתה יכול להקים ארגון משלך שלא למטרות רווח.
 1	אם	אם	SCONJ	SCONJ	_	3	mark	_	_
 2	אתה	הוא	PRON	PRON	Gender=Masc|Number=Sing|Person=2|PronType=Prs	3	dep	_	_
 3	מעדיף	העדיף	VERB	VERB	Gender=Masc|HebBinyan=HIFIL|Number=Sing|Person=1,2,3|VerbForm=Part|Voice=Act	10	advcl	_	_
 4	לפעול	פעל	VERB	VERB	HebBinyan=PAAL|VerbForm=Inf|Voice=Act	3	xcomp	_	_
 5	בלי	בלי	ADP	ADP	_	6	case	_	_
 6	איש	איש	NOUN	NOUN	Definite=Cons|Gender=Masc|Number=Sing	4	obl	_	_
-7	ביניים	ביניים	NOUN	NOUN	Gender=Masc|Number=Sing	6	compound:smixut	_	_
+7	ביניים	ביניים	NOUN	NOUN	Gender=Masc|Number=Sing	6	compound:smixut	_	SpaceAfter=No
 8	,	_	PUNCT	PUNCT	_	10	punct	_	_
 9	אתה	הוא	PRON	PRON	Gender=Masc|Number=Sing|Person=2|PronType=Prs	10	nsubj	_	_
 10	יכול	_	AUX	AUX	Gender=Masc|Number=Sing|Person=1,2,3|VerbForm=Part|VerbType=Mod	0	root	_	_
@@ -5966,11 +5966,11 @@
 17-18	למטרות	_	_	_	_	_	_	_	_
 17	ל	ל	ADP	ADP	_	18	case	_	_
 18	מטרות	מטרה	NOUN	NOUN	Definite=Cons|Gender=Fem|Number=Plur	12	nmod	_	_
-19	רווח	רווח	NOUN	NOUN	Gender=Masc|Number=Sing	18	compound:smixut	_	_
+19	רווח	רווח	NOUN	NOUN	Gender=Masc|Number=Sing	18	compound:smixut	_	SpaceAfter=No
 20	.	_	PUNCT	PUNCT	_	10	punct	_	_
 
 # sent_id = 174
-# text = כך נהג איל ההון בעל המודעות החברתית טד טרנר , כאשר מימן את " ההתאחדות לעולם טוב יותר " , המבקשת מענקים מקרנות כדי להפיק סרטי טלוויזיה דוקומנטריים .
+# text = כך נהג איל ההון בעל המודעות החברתית טד טרנר, כאשר מימן את "ההתאחדות לעולם טוב יותר", המבקשת מענקים מקרנות כדי להפיק סרטי טלוויזיה דוקומנטריים.
 1	כך	כך	ADV	ADV	_	2	advmod	_	_
 2	נהג	נהג	VERB	VERB	Gender=Masc|HebBinyan=PAAL|Number=Sing|Person=3|Tense=Past|Voice=Act	0	root	_	_
 3	איל	איל	NOUN	NOUN	Definite=Cons|Gender=Masc|Number=Sing	2	nsubj	_	_
@@ -5985,12 +5985,12 @@
 9	ה	ה	DET	DET	PronType=Art	10	det:def	_	_
 10	חברתית	חברתי	ADJ	ADJ	Gender=Fem|Number=Sing	8	amod	_	_
 11	טד	טד	PROPN	PROPN	_	3	appos	_	_
-12	טרנר	טרנר	PROPN	PROPN	_	11	flat:name	_	_
+12	טרנר	טרנר	PROPN	PROPN	_	11	flat:name	_	SpaceAfter=No
 13	,	_	PUNCT	PUNCT	_	2	punct	_	_
 14	כאשר	כאשר	SCONJ	SCONJ	_	15	mark	_	_
 15	מימן	מימן	VERB	VERB	Gender=Masc|HebBinyan=PIEL|Number=Sing|Person=3|Tense=Past|Voice=Act	2	advcl	_	_
 16	את	את	PART	PART	Case=Acc	19	case:acc	_	_
-17	"	_	PUNCT	PUNCT	_	19	punct	_	_
+17	"	_	PUNCT	PUNCT	_	19	punct	_	SpaceAfter=No
 18-19	ההתאחדות	_	_	_	_	_	_	_	_
 18	ה	ה	DET	DET	PronType=Art	19	det:def	_	_
 19	התאחדות	התאחדות	NOUN	NOUN	Gender=Fem|Number=Sing	15	obj	_	_
@@ -5998,8 +5998,8 @@
 20	ל	ל	ADP	ADP	_	21	case	_	_
 21	עולם	עולם	NOUN	NOUN	Gender=Masc|Number=Sing	19	nmod	_	_
 22	טוב	טוב	ADJ	ADJ	Gender=Masc|Number=Sing	21	amod	_	_
-23	יותר	יותר	ADV	ADV	_	22	advmod	_	_
-24	"	_	PUNCT	PUNCT	_	19	punct	_	_
+23	יותר	יותר	ADV	ADV	_	22	advmod	_	SpaceAfter=No
+24	"	_	PUNCT	PUNCT	_	19	punct	_	SpaceAfter=No
 25	,	_	PUNCT	PUNCT	_	19	punct	_	_
 26-27	המבקשת	_	_	_	_	_	_	_	_
 26	ה	ה	SCONJ	SCONJ	_	27	mark	_	_
@@ -6012,12 +6012,12 @@
 32	להפיק	הפיק	VERB	VERB	HebBinyan=HIFIL|VerbForm=Inf|Voice=Act	27	advcl	_	_
 33	סרטי	סרט	NOUN	NOUN	Definite=Cons|Gender=Masc|Number=Plur	32	obj	_	_
 34	טלוויזיה	טלוויזיה	NOUN	NOUN	Gender=Fem|Number=Sing	33	compound:smixut	_	_
-35	דוקומנטריים	דוקומנטרי	ADJ	ADJ	Gender=Masc|Number=Plur	33	amod	_	_
+35	דוקומנטריים	דוקומנטרי	ADJ	ADJ	Gender=Masc|Number=Plur	33	amod	_	SpaceAfter=No
 36	.	_	PUNCT	PUNCT	_	2	punct	_	_
 
 # sent_id = 175
-# text = לפעמים , אחרי שקיבל מימון פטור ממס באמצעות ההתאחדות שלו שלא למטרות רווח מקרין טרנר את הסרטים הדוקומנטריים ברשת הטלוויזיה שלו הקיימת בהחלט כדי לשאת רווחים וברשתות אחרות כמוה .
-1	לפעמים	לפעמים	ADV	ADV	_	19	advmod	_	_
+# text = לפעמים, אחרי שקיבל מימון פטור ממס באמצעות ההתאחדות שלו שלא למטרות רווח מקרין טרנר את הסרטים הדוקומנטריים ברשת הטלוויזיה שלו הקיימת בהחלט כדי לשאת רווחים וברשתות אחרות כמוה.
+1	לפעמים	לפעמים	ADV	ADV	_	19	advmod	_	SpaceAfter=No
 2	,	_	PUNCT	PUNCT	_	19	punct	_	_
 3	אחרי	אחרי	ADP	ADP	_	5	case	_	_
 4-5	שקיבל	_	_	_	_	_	_	_	_
@@ -6070,13 +6070,13 @@
 39	ב	ב	ADP	ADP	_	40	case	_	_
 40	רשתות	רשת	NOUN	NOUN	Gender=Fem|Number=Plur	27	conj	_	_
 41	אחרות	אחר	ADJ	ADJ	Gender=Fem|Number=Plur	40	amod	_	_
-42-43	כמוה	_	_	_	_	_	_	_	_
+42-43	כמוה	_	_	_	_	_	_	_	SpaceAfter=No
 42	כמוה	כמו	ADP	ADP	_	43	case	_	_
 43	_היא	הוא	PRON	PRON	Gender=Fem|Number=Sing|Person=3|PronType=Prs	40	nmod	_	_
 44	.	_	PUNCT	PUNCT	_	19	punct	_	_
 
 # sent_id = 176
-# text = אבל אל תטרחו לדווח לשלטונות המקומיים .
+# text = אבל אל תטרחו לדווח לשלטונות המקומיים.
 1	אבל	אבל	CCONJ	CCONJ	_	3	cc	_	_
 2	אל	_	ADV	ADV	_	3	advmod	_	_
 3	תטרחו	טרח	VERB	VERB	Gender=Fem,Masc|HebBinyan=PAAL|Number=Plur|Person=2|Tense=Fut|Voice=Act	0	root	_	_
@@ -6085,37 +6085,37 @@
 5	ל	ל	ADP	ADP	_	7	case	_	_
 6	ה_	ה	DET	DET	PronType=Art	7	det:def	_	_
 7	שלטונות	שלטון	NOUN	NOUN	Gender=Masc|Number=Plur	4	obl	_	_
-8-9	המקומיים	_	_	_	_	_	_	_	_
+8-9	המקומיים	_	_	_	_	_	_	_	SpaceAfter=No
 8	ה	ה	DET	DET	PronType=Art	9	det:def	_	_
 9	מקומיים	מקומי	ADJ	ADJ	Gender=Masc|Number=Plur	7	amod	_	_
 10	.	_	PUNCT	PUNCT	_	3	punct	_	_
 
 # sent_id = 177
-# text = הגבול בין " שלא למטרות רווח " ובין " למטרות רווח " מטושטש מאוד , ובדרך כלל הכל חוקי למהדרין .
+# text = הגבול בין "שלא למטרות רווח" ובין "למטרות רווח" מטושטש מאוד, ובדרך כלל הכל חוקי למהדרין.
 1-2	הגבול	_	_	_	_	_	_	_	_
 1	ה	ה	DET	DET	PronType=Art	2	det:def	_	_
 2	גבול	גבול	NOUN	NOUN	Gender=Masc|Number=Sing	18	nsubj	_	_
 3	בין	בין	ADP	ADP	_	8	case	_	_
-4	"	_	PUNCT	PUNCT	_	8	punct	_	_
+4	"	_	PUNCT	PUNCT	_	8	punct	_	SpaceAfter=No
 5-6	שלא	_	_	_	_	_	_	_	_
 5	ש	ש	SCONJ	SCONJ	_	8	mark	_	_
 6	לא	לא	ADV	ADV	Polarity=Neg	7	advmod	_	_
 7-8	למטרות	_	_	_	_	_	_	_	_
 7	ל	ל	ADP	ADP	_	8	case	_	_
 8	מטרות	מטרה	NOUN	NOUN	Definite=Cons|Gender=Fem|Number=Plur	2	nmod	_	_
-9	רווח	רווח	NOUN	NOUN	Gender=Masc|Number=Sing	8	compound:smixut	_	_
+9	רווח	רווח	NOUN	NOUN	Gender=Masc|Number=Sing	8	compound:smixut	_	SpaceAfter=No
 10	"	_	PUNCT	PUNCT	_	8	punct	_	_
 11-12	ובין	_	_	_	_	_	_	_	_
 11	ו	ו	CCONJ	CCONJ	_	8	cc	_	_
 12	בין	בין	ADP	ADP	_	15	case	_	_
-13	"	_	PUNCT	PUNCT	_	15	punct	_	_
+13	"	_	PUNCT	PUNCT	_	15	punct	_	SpaceAfter=No
 14-15	למטרות	_	_	_	_	_	_	_	_
 14	ל	ל	ADP	ADP	_	15	case	_	_
 15	מטרות	מטרה	NOUN	NOUN	Definite=Cons|Gender=Fem|HebSource=ConvUncertainHead|Number=Plur	8	dep	_	_
-16	רווח	רווח	NOUN	NOUN	Gender=Masc|Number=Sing	15	compound:smixut	_	_
+16	רווח	רווח	NOUN	NOUN	Gender=Masc|Number=Sing	15	compound:smixut	_	SpaceAfter=No
 17	"	_	PUNCT	PUNCT	_	15	punct	_	_
 18	מטושטש	מטושטש	ADJ	ADJ	Gender=Masc|Number=Sing	0	root	_	_
-19	מאוד	מאוד	ADV	ADV	_	18	advmod	_	_
+19	מאוד	מאוד	ADV	ADV	_	18	advmod	_	SpaceAfter=No
 20	,	_	PUNCT	PUNCT	_	18	punct	_	_
 21-23	ובדרך	_	_	_	_	_	_	_	_
 21	ו	ו	CCONJ	CCONJ	_	26	cc	_	_
@@ -6124,11 +6124,11 @@
 24	כלל	כלל	NOUN	NOUN	Gender=Masc|Number=Sing	22	fixed	_	_
 25	הכל	הכיל	NOUN	NOUN	_	26	nsubj	_	_
 26	חוקי	חוקי	ADJ	ADJ	Gender=Masc|Number=Sing	18	conj	_	_
-27	למהדרין	למהדרין	ADV	ADV	_	26	advmod	_	_
+27	למהדרין	למהדרין	ADV	ADV	_	26	advmod	_	SpaceAfter=No
 28	.	_	PUNCT	PUNCT	_	18	punct	_	_
 
 # sent_id = 178
-# text = הדוגמה הידועה ביותר לשמצה מהתקופה האחרונה היא השימוש בכספי קרן גאנט לרכישת אלפי עותקים של האוטוביוגרפיה של יו"ר גאנט לשעבר , אלאן נויהארט .
+# text = הדוגמה הידועה ביותר לשמצה מהתקופה האחרונה היא השימוש בכספי קרן גאנט לרכישת אלפי עותקים של האוטוביוגרפיה של יו"ר גאנט לשעבר, אלאן נויהארט.
 1-2	הדוגמה	_	_	_	_	_	_	_	_
 1	ה	ה	DET	DET	PronType=Art	2	det:def	_	_
 2	דוגמה	דוגמה	NOUN	NOUN	Gender=Fem|Number=Sing	15	nsubj:cop	_	_
@@ -6167,14 +6167,14 @@
 27	של	של	PART	PART	Case=Gen	28	case:gen	_	_
 28	יו"ר	יו"ר	NOUN	NOUN	Abbr=Yes|Definite=Cons|Gender=Masc|Number=Sing	26	nmod:poss	_	_
 29	גאנט	גאנט	PROPN	PROPN	_	28	compound:smixut	_	_
-30	לשעבר	לשעבר	ADV	ADV	_	28	advmod	_	_
+30	לשעבר	לשעבר	ADV	ADV	_	28	advmod	_	SpaceAfter=No
 31	,	_	PUNCT	PUNCT	_	28	punct	_	_
 32	אלאן	אלאן	PROPN	PROPN	_	28	appos	_	_
-33	נויהארט	נויהארט	PROPN	PROPN	_	32	flat:name	_	_
+33	נויהארט	נויהארט	PROPN	PROPN	_	32	flat:name	_	SpaceAfter=No
 34	.	_	PUNCT	PUNCT	_	15	punct	_	_
 
 # sent_id = 179
-# text = הדבר סייע להכניס את הספר לרשימת רבי - המכר של " ניו יורק טיימס " , מעמד שבדרך כלל גורר בעקבותיו מכירת עשרות אלפי עותקים נוספים .
+# text = הדבר סייע להכניס את הספר לרשימת רבי - המכר של "ניו יורק טיימס", מעמד שבדרך כלל גורר בעקבותיו מכירת עשרות אלפי עותקים נוספים.
 1-2	הדבר	_	_	_	_	_	_	_	_
 1	ה	ה	DET	DET	PronType=Art	2	det:def	_	_
 2	דבר	דבר	NOUN	NOUN	Gender=Masc|Number=Sing	3	nsubj	_	_
@@ -6193,11 +6193,11 @@
 12	ה	ה	DET	DET	PronType=Art	13	det:def	_	_
 13	מכר	מכר	NOUN	NOUN	Gender=Masc|Number=Sing	9	compound:smixut	_	_
 14	של	של	PART	PART	Case=Gen	16	case:gen	_	_
-15	"	_	PUNCT	PUNCT	_	16	punct	_	_
+15	"	_	PUNCT	PUNCT	_	16	punct	_	SpaceAfter=No
 16	ניו	ניו	PROPN	PROPN	_	9	nmod	_	_
 17	יורק	יורק	PROPN	PROPN	_	16	flat:name	_	_
-18	טיימס	טיימס	PROPN	PROPN	_	16	flat:name	_	_
-19	"	_	PUNCT	PUNCT	_	16	punct	_	_
+18	טיימס	טיימס	PROPN	PROPN	_	16	flat:name	_	SpaceAfter=No
+19	"	_	PUNCT	PUNCT	_	16	punct	_	SpaceAfter=No
 20	,	_	PUNCT	PUNCT	_	9	punct	_	_
 21	מעמד	מעמד	NOUN	NOUN	Gender=Masc|Number=Sing	9	appos	_	_
 22-24	שבדרך	_	_	_	_	_	_	_	_
@@ -6213,37 +6213,37 @@
 30	עשרות	עשר	NUM	NUM	Definite=Cons|Gender=Fem|Number=Plur	31	nummod	_	_
 31	אלפי	אלף	NUM	NUM	Definite=Cons|Gender=Masc|Number=Plur	32	nummod	_	_
 32	עותקים	עותק	NOUN	NOUN	Gender=Masc|Number=Plur	29	compound:smixut	_	_
-33	נוספים	נוסף	ADJ	ADJ	Gender=Masc|Number=Plur	32	amod	_	_
+33	נוספים	נוסף	ADJ	ADJ	Gender=Masc|Number=Plur	32	amod	_	SpaceAfter=No
 34	.	_	PUNCT	PUNCT	_	3	punct	_	_
 
 # sent_id = 180
-# text = עצה מספר 2 .
+# text = עצה מספר 2.
 1	עצה	עצה	NOUN	NOUN	Gender=Fem|Number=Sing	0	root	_	_
 2	מספר	מספר	NOUN	NOUN	Gender=Masc|HebSource=ConvUncertainLabel|Number=Sing	1	nmod	_	_
-3	2	_	NUM	NUM	_	2	nummod	_	_
+3	2	_	NUM	NUM	_	2	nummod	_	SpaceAfter=No
 4	.	_	PUNCT	PUNCT	_	1	punct	_	_
 
 # sent_id = 181
-# text = לך להיות זמר אופרה או ביולוג מולקולרי .
+# text = לך להיות זמר אופרה או ביולוג מולקולרי.
 1	לך	הלך	VERB	VERB	Gender=Masc|HebBinyan=PAAL|Mood=Imp|Number=Sing|Person=2|Voice=Act	0	root	_	_
 2	להיות	היה	VERB	VERB	Polarity=Pos|VerbForm=Inf|VerbType=Cop	1	xcomp	_	_
 3	זמר	זמר	NOUN	NOUN	Definite=Cons|Gender=Masc|Number=Sing	2	obj	_	_
 4	אופרה	אופרה	NOUN	NOUN	Gender=Fem|Number=Sing	3	compound:smixut	_	_
 5	או	או	CCONJ	CCONJ	_	6	cc	_	_
 6	ביולוג	ביולוג	NOUN	NOUN	Gender=Masc|Number=Sing	3	conj	_	_
-7	מולקולרי	מולקולרי	ADJ	ADJ	Gender=Masc|Number=Sing	6	amod	_	_
+7	מולקולרי	מולקולרי	ADJ	ADJ	Gender=Masc|Number=Sing	6	amod	_	SpaceAfter=No
 8	.	_	PUNCT	PUNCT	_	1	punct	_	_
 
 # sent_id = 182
-# text = בספר " צדקה מתחילה מבית " התלוננה תרזה אודנדל על מחזוריות הפילנטרופיה .
+# text = בספר "צדקה מתחילה מבית" התלוננה תרזה אודנדל על מחזוריות הפילנטרופיה.
 1-3	בספר	_	_	_	_	_	_	_	_
 1	ב	ב	ADP	ADP	_	3	case	_	_
 2	ה_	ה	DET	DET	PronType=Art	3	det:def	_	_
 3	ספר	ספר	NOUN	NOUN	Gender=Masc|Number=Sing	10	obl	_	_
-4	"	_	PUNCT	PUNCT	_	6	punct	_	_
+4	"	_	PUNCT	PUNCT	_	6	punct	_	SpaceAfter=No
 5	צדקה	צדקה	NOUN	NOUN	Gender=Fem|Number=Sing	6	nsubj	_	_
 6	מתחילה	התחיל	VERB	VERB	Gender=Fem|HebBinyan=HIFIL|Number=Sing|Person=1,2,3|VerbForm=Part|Voice=Act	3	appos	_	_
-7-8	מבית	_	_	_	_	_	_	_	_
+7-8	מבית	_	_	_	_	_	_	_	SpaceAfter=No
 7	מ	מ	ADP	ADP	_	8	case	_	_
 8	בית	בית	NOUN	NOUN	Gender=Masc|Number=Sing	6	iobj	_	_
 9	"	_	PUNCT	PUNCT	_	6	punct	_	_
@@ -6252,13 +6252,13 @@
 12	אודנדל	אודנדל	PROPN	PROPN	_	11	flat:name	_	_
 13	על	על	ADP	ADP	_	14	case	_	_
 14	מחזוריות	מחזוריות	NOUN	NOUN	Definite=Cons|Gender=Fem|Number=Sing	10	iobj	_	_
-15-16	הפילנטרופיה	_	_	_	_	_	_	_	_
+15-16	הפילנטרופיה	_	_	_	_	_	_	_	SpaceAfter=No
 15	ה	ה	DET	DET	PronType=Art	16	det:def	_	_
 16	פילנטרופיה	פילנתרופיה	NOUN	NOUN	Gender=Fem|Number=Sing	14	compound:smixut	_	_
 17	.	_	PUNCT	PUNCT	_	10	punct	_	_
 
 # sent_id = 183
-# text = חלק נכבד מתרומותיהן של קרנות ( ושל חברות ואנשים עשירים ) מגיע לבסוף לנקודת ההתחלה שלהן : לדרגים העליונים של החברה , למוזיאונים , לאולמות קונצרטים ולתיאטראות קהילתיים , שסוג האנשים היכול להרשות לעצמו לתרום תרומות צדקה הוא המנהל אותם ופוקד אותם .
+# text = חלק נכבד מתרומותיהן של קרנות (ושל חברות ואנשים עשירים) מגיע לבסוף לנקודת ההתחלה שלהן: לדרגים העליונים של החברה, למוזיאונים, לאולמות קונצרטים ולתיאטראות קהילתיים, שסוג האנשים היכול להרשות לעצמו לתרום תרומות צדקה הוא המנהל אותם ופוקד אותם.
 1	חלק	חלק	NOUN	NOUN	Gender=Masc|Number=Sing	17	nsubj	_	_
 2	נכבד	נכבד	ADJ	ADJ	Gender=Masc|Number=Sing	1	amod	_	_
 3-6	מתרומותיהן	_	_	_	_	_	_	_	_
@@ -6268,7 +6268,7 @@
 6	_הן	הוא	PRON	PRON	Case=Gen|Gender=Fem|Number=Plur|Person=3|PronType=Prs	4	nmod:poss	_	_
 7	של	של	PART	PART	Case=Gen	4	dep	_	_
 8	קרנות	קרן	NOUN	NOUN	Gender=Fem|HebSource=ConvUncertainHead|Number=Plur	4	dep	_	_
-9	(	_	PUNCT	PUNCT	_	12	punct	_	_
+9	(	_	PUNCT	PUNCT	_	12	punct	_	SpaceAfter=No
 10-11	ושל	_	_	_	_	_	_	_	_
 10	ו	ו	CCONJ	CCONJ	_	13	cc	_	_
 11	של	של	PART	PART	Case=Gen	12	case:gen	_	_
@@ -6276,7 +6276,7 @@
 13-14	ואנשים	_	_	_	_	_	_	_	_
 13	ו	ו	CCONJ	CCONJ	_	14	cc	_	_
 14	אנשים	איש	NOUN	NOUN	Gender=Masc|Number=Plur	12	conj	_	_
-15	עשירים	עשיר	ADJ	ADJ	Gender=Masc|Number=Plur	14	amod	_	_
+15	עשירים	עשיר	ADJ	ADJ	Gender=Masc|Number=Plur	14	amod	_	SpaceAfter=No
 16	)	_	PUNCT	PUNCT	_	12	punct	_	_
 17	מגיע	הגיע	VERB	VERB	Gender=Masc|HebBinyan=HIFIL|Number=Sing|Person=1,2,3|VerbForm=Part|Voice=Act	0	root	_	_
 18	לבסוף	לבסוף	ADV	ADV	_	17	advmod	_	_
@@ -6286,7 +6286,7 @@
 21-22	ההתחלה	_	_	_	_	_	_	_	_
 21	ה	ה	DET	DET	PronType=Art	22	det:def	_	_
 22	התחלה	התחלה	NOUN	NOUN	Gender=Fem|Number=Sing	20	compound:smixut	_	_
-23-24	שלהן	_	_	_	_	_	_	_	_
+23-24	שלהן	_	_	_	_	_	_	_	SpaceAfter=No
 23	של_	של	ADP	ADP	Case=Gen	24	case:gen	_	_
 24	_הן	הוא	PRON	PRON	Gender=Fem|Number=Plur|Person=3|PronType=Prs	20	nmod:poss	_	_
 25	:	_	PUNCT	PUNCT	_	20	punct	_	_
@@ -6298,11 +6298,11 @@
 29	ה	ה	DET	DET	PronType=Art	30	det:def	_	_
 30	עליונים	עליון	ADJ	ADJ	Gender=Masc|Number=Plur	28	amod	_	_
 31	של	של	PART	PART	Case=Gen	33	case:gen	_	_
-32-33	החברה	_	_	_	_	_	_	_	_
+32-33	החברה	_	_	_	_	_	_	_	SpaceAfter=No
 32	ה	ה	DET	DET	PronType=Art	33	det:def	_	_
 33	חברה	חברה	NOUN	NOUN	Gender=Fem|Number=Sing	28	nmod	_	_
 34	,	_	PUNCT	PUNCT	_	28	punct	_	_
-35-36	למוזיאונים	_	_	_	_	_	_	_	_
+35-36	למוזיאונים	_	_	_	_	_	_	_	SpaceAfter=No
 35	ל	ל	ADP	ADP	_	36	case	_	_
 36	מוזיאונים	מוזיאון	NOUN	NOUN	Gender=Masc|Number=Plur	28	conj	_	_
 37	,	_	PUNCT	PUNCT	_	28	punct	_	_
@@ -6314,7 +6314,7 @@
 41	ו	ו	CCONJ	CCONJ	_	43	cc	_	_
 42	ל	ל	ADP	ADP	_	43	case	_	_
 43	תיאטראות	תיאטרון	NOUN	NOUN	Gender=Masc|Number=Plur	28	conj	_	_
-44	קהילתיים	קהילתי	ADJ	ADJ	Gender=Masc|Number=Plur	43	amod	_	_
+44	קהילתיים	קהילתי	ADJ	ADJ	Gender=Masc|Number=Plur	43	amod	_	SpaceAfter=No
 45	,	_	PUNCT	PUNCT	_	43	punct	_	_
 46-47	שסוג	_	_	_	_	_	_	_	_
 46	ש	ש	SCONJ	SCONJ	_	60	mark	_	_
@@ -6342,13 +6342,13 @@
 63-64	ופוקד	_	_	_	_	_	_	_	_
 63	ו	ו	CCONJ	CCONJ	_	64	cc	_	_
 64	פוקד	פקד	VERB	VERB	Gender=Masc|HebBinyan=PAAL|Number=Sing|Person=1,2,3|VerbForm=Part|Voice=Act	60	conj	_	_
-65-66	אותם	_	_	_	_	_	_	_	_
+65-66	אותם	_	_	_	_	_	_	_	SpaceAfter=No
 65	את_	את	PART	PART	Case=Acc	66	case:acc	_	_
 66	_הם	הוא	PRON	PRON	Gender=Masc|Number=Plur|Person=3|PronType=Prs	64	obj	_	_
 67	.	_	PUNCT	PUNCT	_	17	punct	_	_
 
 # sent_id = 184
-# text = 51 % מכספי הקרנות מופנים לפעילויות תרבותיות .
+# text = 51 % מכספי הקרנות מופנים לפעילויות תרבותיות.
 1	51	_	NUM	NUM	_	2	nummod	_	_
 2	%	%	NOUN	NOUN	Gender=Masc|Number=Plur,Sing	7	nsubj	_	_
 3-4	מכספי	_	_	_	_	_	_	_	_
@@ -6361,11 +6361,11 @@
 8-9	לפעילויות	_	_	_	_	_	_	_	_
 8	ל	ל	ADP	ADP	_	9	case	_	_
 9	פעילויות	פעילות	NOUN	NOUN	Gender=Fem|Number=Plur	7	iobj	_	_
-10	תרבותיות	תרבותי	ADJ	ADJ	Gender=Fem|Number=Plur	9	amod	_	_
+10	תרבותיות	תרבותי	ADJ	ADJ	Gender=Fem|Number=Plur	9	amod	_	SpaceAfter=No
 11	.	_	PUNCT	PUNCT	_	7	punct	_	_
 
 # sent_id = 185
-# text = לדעת אנשים העשויים לחשוב על קדימויות חברתיות נאצלות יותר מאשר הקמת סביבה תומכת לאופרה , זה שיעור גבוה מאוד .
+# text = לדעת אנשים העשויים לחשוב על קדימויות חברתיות נאצלות יותר מאשר הקמת סביבה תומכת לאופרה, זה שיעור גבוה מאוד.
 1-2	לדעת	_	_	_	_	_	_	_	_
 1	ל	ל	ADP	ADP	_	2	case	_	_
 2	דעת	דעה	NOUN	NOUN	Definite=Cons|Gender=Fem|Number=Sing	20	parataxis	_	_
@@ -6383,22 +6383,22 @@
 13	הקמת	הקמה	NOUN	NOUN	Definite=Cons|Gender=Fem|Number=Sing	10	advmod	_	_
 14	סביבה	סביבה	NOUN	NOUN	Gender=Fem|Number=Sing	13	compound:smixut	_	_
 15	תומכת	תומך	ADJ	ADJ	Gender=Fem|Number=Sing	14	amod	_	_
-16-17	לאופרה	_	_	_	_	_	_	_	_
+16-17	לאופרה	_	_	_	_	_	_	_	SpaceAfter=No
 16	ל	ל	ADP	ADP	_	17	case	_	_
 17	אופרה	אופרה	NOUN	NOUN	Gender=Fem|Number=Sing	14	nmod	_	_
 18	,	_	PUNCT	PUNCT	_	20	punct	_	_
 19	זה	זה	PRON	PRON	Gender=Masc|Number=Sing|Person=3	20	nsubj	_	_
 20	שיעור	שיעור	NOUN	NOUN	Gender=Masc|Number=Sing	0	root	_	_
 21	גבוה	גבוה	ADJ	ADJ	Gender=Masc|Number=Sing	20	amod	_	_
-22	מאוד	מאוד	ADV	ADV	_	21	advmod	_	_
+22	מאוד	מאוד	ADV	ADV	_	21	advmod	_	SpaceAfter=No
 23	.	_	PUNCT	PUNCT	_	20	punct	_	_
 
 # sent_id = 186
-# text = למרבה המזל , כשליש מהכסף מועבר לפרויקטים שהתועלת בהם קונקרטית יותר , כגון שירותי בריאות או מחקרים בתחומי הרפואה או מדעי הטבע .
+# text = למרבה המזל, כשליש מהכסף מועבר לפרויקטים שהתועלת בהם קונקרטית יותר, כגון שירותי בריאות או מחקרים בתחומי הרפואה או מדעי הטבע.
 1-2	למרבה	_	_	_	_	_	_	_	_
 1	ל	ל	ADP	ADP	_	4	case	_	_
 2	מרבה	_	DET	DET	Definite=Cons	4	det	_	_
-3-4	המזל	_	_	_	_	_	_	_	_
+3-4	המזל	_	_	_	_	_	_	_	SpaceAfter=No
 3	ה	ה	DET	DET	PronType=Art	4	det:def	_	_
 4	מזל	מזל	NOUN	NOUN	Gender=Masc|Number=Sing	11	obl	_	_
 5	,	_	PUNCT	PUNCT	_	11	punct	_	_
@@ -6421,7 +6421,7 @@
 17	בהם	ב	ADP	ADP	_	18	case	_	_
 18	_הם	הוא	PRON	PRON	Gender=Masc|Number=Plur|Person=3|PronType=Prs	16	nmod	_	_
 19	קונקרטית	קונקרטי	ADJ	ADJ	Gender=Fem|Number=Sing	13	acl:relcl	_	_
-20	יותר	יותר	ADV	ADV	_	19	advmod	_	_
+20	יותר	יותר	ADV	ADV	_	19	advmod	_	SpaceAfter=No
 21	,	_	PUNCT	PUNCT	_	13	punct	_	_
 22	כגון	כגון	ADP	ADP	_	23	case	_	_
 23	שירותי	שירות	NOUN	NOUN	Definite=Cons|Gender=Masc|Number=Plur	13	nmod	_	_
@@ -6436,13 +6436,13 @@
 30	רפואה	רפואה	NOUN	NOUN	Gender=Fem|Number=Sing	28	compound:smixut	_	_
 31	או	או	CCONJ	CCONJ	_	32	cc	_	_
 32	מדעי	מדע	NOUN	NOUN	Definite=Cons|Gender=Masc|Number=Plur	30	conj	_	_
-33-34	הטבע	_	_	_	_	_	_	_	_
+33-34	הטבע	_	_	_	_	_	_	_	SpaceAfter=No
 33	ה	ה	DET	DET	PronType=Art	34	det:def	_	_
 34	טבע	טבע	NOUN	NOUN	Gender=Masc|Number=Sing	32	compound:smixut	_	_
 35	.	_	PUNCT	PUNCT	_	11	punct	_	_
 
 # sent_id = 187
-# text = קצת יותר משליש מושקע בשטח ההפקר הגדול שבו מתחרים על תשומת הלב רעיונות ותוכניות במדעי החברה ובתחום המדיניות הציבורית .
+# text = קצת יותר משליש מושקע בשטח ההפקר הגדול שבו מתחרים על תשומת הלב רעיונות ותוכניות במדעי החברה ובתחום המדיניות הציבורית.
 1	קצת	קצת	ADV	ADV	HebSource=ConvUncertainHead	4	dep	_	_
 2	יותר	יותר	ADV	ADV	_	4	dep	_	_
 3-4	משליש	_	_	_	_	_	_	_	_
@@ -6485,18 +6485,18 @@
 30-31	המדיניות	_	_	_	_	_	_	_	_
 30	ה	ה	DET	DET	PronType=Art	31	det:def	_	_
 31	מדיניות	מדיניות	NOUN	NOUN	Gender=Fem|Number=Sing	29	compound:smixut	_	_
-32-33	הציבורית	_	_	_	_	_	_	_	_
+32-33	הציבורית	_	_	_	_	_	_	_	SpaceAfter=No
 32	ה	ה	DET	DET	PronType=Art	33	det:def	_	_
 33	ציבורית	ציבורי	ADJ	ADJ	Gender=Fem|Number=Sing	31	amod	_	_
 34	.	_	PUNCT	PUNCT	_	5	punct	_	_
 
 # sent_id = 188
-# text = בתוככי אזור זה , שבירתו היא ואשינגטון , העצות הבאות הן הישימות ביותר .
+# text = בתוככי אזור זה, שבירתו היא ואשינגטון, העצות הבאות הן הישימות ביותר.
 1-2	בתוככי	_	_	_	_	_	_	_	_
 1	ב	בתוככי	ADP	ADP	_	2	case	_	_
 2	תוככי	_	NOUN	NOUN	Definite=Cons	19	obl	_	_
 3	אזור	אזור	NOUN	NOUN	Gender=Masc|Number=Sing	2	compound:smixut	_	_
-4	זה	זה	PRON	PRON	Gender=Masc|Number=Sing|Person=3|PronType=Dem	3	amod	_	_
+4	זה	זה	PRON	PRON	Gender=Masc|Number=Sing|Person=3|PronType=Dem	3	amod	_	SpaceAfter=No
 5	,	_	PUNCT	PUNCT	_	2	punct	_	_
 6-9	שבירתו	_	_	_	_	_	_	_	_
 6	ש	ש	SCONJ	SCONJ	_	11	mark	_	_
@@ -6504,7 +6504,7 @@
 8	_של_	של	ADP	ADP	_	9	case:gen	_	_
 9	_הוא	הוא	PRON	PRON	Case=Gen|Gender=Masc|Number=Sing|Person=3|PronType=Prs	7	nmod:poss	_	_
 10	היא	הוא	VERB	VERB	Gender=Fem|Number=Sing|Person=3|Polarity=Pos|VerbForm=Part|VerbType=Cop	11	cop	_	_
-11	ואשינגטון	ואשינגטון	PROPN	PROPN	_	2	acl:relcl	_	_
+11	ואשינגטון	ואשינגטון	PROPN	PROPN	_	2	acl:relcl	_	SpaceAfter=No
 12	,	_	PUNCT	PUNCT	_	19	punct	_	_
 13-14	העצות	_	_	_	_	_	_	_	_
 13	ה	ה	DET	DET	PronType=Art	14	det:def	_	_
@@ -6516,18 +6516,18 @@
 18-19	הישימות	_	_	_	_	_	_	_	_
 18	ה	ה	DET	DET	PronType=Art	19	det:def	_	_
 19	ישימות	ישים	ADJ	ADJ	Gender=Fem|Number=Plur	0	root	_	_
-20	ביותר	ביותר	ADV	ADV	_	19	advmod	_	_
+20	ביותר	ביותר	ADV	ADV	_	19	advmod	_	SpaceAfter=No
 21	.	_	PUNCT	PUNCT	_	19	punct	_	_
 
 # sent_id = 189
-# text = עצה מספר 3 .
+# text = עצה מספר 3.
 1	עצה	עצה	NOUN	NOUN	Gender=Fem|Number=Sing	0	root	_	_
 2	מספר	מספר	NOUN	NOUN	Gender=Masc|HebSource=ConvUncertainLabel|Number=Sing	1	nmod	_	_
-3	3	_	NUM	NUM	_	2	nummod	_	_
+3	3	_	NUM	NUM	_	2	nummod	_	SpaceAfter=No
 4	.	_	PUNCT	PUNCT	_	1	punct	_	_
 
 # sent_id = 190
-# text = הייה מודע להשלכות המרובות של עבודתך .
+# text = הייה מודע להשלכות המרובות של עבודתך.
 1	הייה	היה	VERB	VERB	Gender=Masc|Mood=Imp|Number=Sing|Person=2|Polarity=Pos|VerbType=Cop	2	aux	_	_
 2	מודע	מודע	ADJ	ADJ	Gender=Masc|Number=Sing	0	root	_	_
 3-5	להשלכות	_	_	_	_	_	_	_	_
@@ -6538,15 +6538,15 @@
 6	ה	ה	DET	DET	PronType=Art	7	det:def	_	_
 7	מרובות	מרובה	ADJ	ADJ	Gender=Fem|Number=Plur	5	amod	_	_
 8	של	של	PART	PART	Case=Gen	9	case:gen	_	_
-9-11	עבודתך	_	_	_	_	_	_	_	_
+9-11	עבודתך	_	_	_	_	_	_	_	SpaceAfter=No
 9	עבודה_	עבודה	NOUN	NOUN	Definite=Def|Gender=Fem|Number=Sing	5	nmod	_	_
 10	_של_	של	ADP	ADP	_	11	case:gen	_	_
 11	_אתה	הוא	PRON	PRON	Case=Gen|Gender=Masc|Number=Sing|Person=2|PronType=Prs	9	nmod:poss	_	_
 12	.	_	PUNCT	PUNCT	_	2	punct	_	_
 
 # sent_id = 191
-# text = " אתה מתבונן בנושא שיהיה בעל ערך לגיטימי למחקר , ובו בזמן יכבוש את דמיונו של פקיד התוכנית " , אומר וורן מילר , איש מדעי המדינה באוניברסיטת אריזונה .
-1	"	_	PUNCT	PUNCT	_	3	punct	_	_
+# text = "אתה מתבונן בנושא שיהיה בעל ערך לגיטימי למחקר, ובו בזמן יכבוש את דמיונו של פקיד התוכנית", אומר וורן מילר, איש מדעי המדינה באוניברסיטת אריזונה.
+1	"	_	PUNCT	PUNCT	_	3	punct	_	SpaceAfter=No
 2	אתה	הוא	PRON	PRON	Gender=Masc|Number=Sing|Person=2|PronType=Prs	3	nsubj	_	_
 3	מתבונן	התבונן	VERB	VERB	Gender=Masc|HebBinyan=HITPAEL|Number=Sing|Person=1,2,3|VerbForm=Part	31	iobj	_	_
 4-5	בנושא	_	_	_	_	_	_	_	_
@@ -6558,7 +6558,7 @@
 8	בעל	בעל	NOUN	NOUN	Definite=Cons|Gender=Masc|Number=Sing	5	acl:relcl	_	_
 9	ערך	ערך	NOUN	NOUN	Gender=Masc|Number=Sing	8	compound:smixut	_	_
 10	לגיטימי	לגיטימי	ADJ	ADJ	Gender=Masc|Number=Sing	9	amod	_	_
-11-12	למחקר	_	_	_	_	_	_	_	_
+11-12	למחקר	_	_	_	_	_	_	_	SpaceAfter=No
 11	ל	ל	ADP	ADP	_	12	case	_	_
 12	מחקר	מחקר	NOUN	NOUN	Gender=Masc|Number=Sing	9	nmod	_	_
 13	,	_	PUNCT	PUNCT	_	8	punct	_	_
@@ -6578,14 +6578,14 @@
 24	_הוא	הוא	PRON	PRON	Case=Gen|Gender=Masc|Number=Sing|Person=3|PronType=Prs	22	nmod:poss	_	_
 25	של	של	PART	PART	Case=Gen	26	case:gen	_	_
 26	פקיד	פקיד	NOUN	NOUN	Definite=Cons|Gender=Masc|Number=Sing	22	nmod:poss	_	_
-27-28	התוכנית	_	_	_	_	_	_	_	_
+27-28	התוכנית	_	_	_	_	_	_	_	SpaceAfter=No
 27	ה	ה	DET	DET	PronType=Art	28	det:def	_	_
 28	תוכנית	תוכנית	NOUN	NOUN	Gender=Fem|Number=Sing	26	compound:smixut	_	_
-29	"	_	PUNCT	PUNCT	_	3	punct	_	_
+29	"	_	PUNCT	PUNCT	_	3	punct	_	SpaceAfter=No
 30	,	_	PUNCT	PUNCT	_	31	punct	_	_
 31	אומר	אמר	VERB	VERB	Gender=Masc|HebBinyan=PAAL|Number=Sing|Person=1,2,3|VerbForm=Part|Voice=Act	0	root	_	_
 32	וורן	וורן	PROPN	PROPN	_	31	nsubj	_	_
-33	מילר	מילר	PROPN	PROPN	_	32	flat:name	_	_
+33	מילר	מילר	PROPN	PROPN	_	32	flat:name	_	SpaceAfter=No
 34	,	_	PUNCT	PUNCT	_	32	punct	_	_
 35	איש	איש	NOUN	NOUN	Definite=Cons|Gender=Masc|Number=Sing	32	appos	_	_
 36	מדעי	מדע	NOUN	NOUN	Definite=Cons|Gender=Masc|Number=Plur	35	compound:smixut	_	_
@@ -6595,11 +6595,11 @@
 39-40	באוניברסיטת	_	_	_	_	_	_	_	_
 39	ב	ב	ADP	ADP	_	40	case	_	_
 40	אוניברסיטת	אוניברסיטה	NOUN	NOUN	Definite=Cons|Gender=Fem|Number=Sing	35	nmod	_	_
-41	אריזונה	אריזונה	PROPN	PROPN	_	40	flat:name	_	_
+41	אריזונה	אריזונה	PROPN	PROPN	_	40	flat:name	_	SpaceAfter=No
 42	.	_	PUNCT	PUNCT	_	31	punct	_	_
 
 # sent_id = 192
-# text = במשך עשרות שנים שימש מילר מגייס מענקים מרכזי לפרויקט חקר הבחירות הארציות , מחקר על התנהגות מצביעים שבעקבותיו נכתב ב1960 החיבור הקלאסי " המצביע האמריקאי " .
+# text = במשך עשרות שנים שימש מילר מגייס מענקים מרכזי לפרויקט חקר הבחירות הארציות, מחקר על התנהגות מצביעים שבעקבותיו נכתב ב1960 החיבור הקלאסי " המצביע האמריקאי ".
 1	במשך	במשך	ADP	ADP	_	3	case	_	_
 2	עשרות	עשר	NUM	NUM	Definite=Cons|Gender=Fem|Number=Plur	3	nummod	_	_
 3	שנים	שנה	NOUN	NOUN	Gender=Fem|Number=Plur	4	obl	_	_
@@ -6615,7 +6615,7 @@
 12-13	הבחירות	_	_	_	_	_	_	_	_
 12	ה	ה	DET	DET	PronType=Art	13	det:def	_	_
 13	בחירות	בחירות	NOUN	NOUN	Gender=Fem|Number=Plur	11	compound:smixut	_	_
-14-15	הארציות	_	_	_	_	_	_	_	_
+14-15	הארציות	_	_	_	_	_	_	_	SpaceAfter=No
 14	ה	ה	DET	DET	PronType=Art	15	det:def	_	_
 15	ארציות	ארצי	ADJ	ADJ	Gender=Fem|Number=Plur	13	amod	_	_
 16	,	_	PUNCT	PUNCT	_	10	punct	_	_
@@ -6644,11 +6644,11 @@
 34-35	האמריקאי	_	_	_	_	_	_	_	_
 34	ה	ה	DET	DET	PronType=Art	35	det:def	_	_
 35	אמריקאי	אמריקני	ADJ	ADJ	Gender=Masc|Number=Sing	33	amod	_	_
-36	"	_	PUNCT	PUNCT	_	33	punct	_	_
+36	"	_	PUNCT	PUNCT	_	33	punct	_	SpaceAfter=No
 37	.	_	PUNCT	PUNCT	_	4	punct	_	_
 
 # sent_id = 193
-# text = מאז המשיך במחקר והגדיל את מאגר הנתונים שלו .
+# text = מאז המשיך במחקר והגדיל את מאגר הנתונים שלו.
 1	מאז	מאז	ADV	ADV	_	2	advmod	_	_
 2	המשיך	המשיך	VERB	VERB	Gender=Masc|HebBinyan=HIFIL|Number=Sing|Person=3|Tense=Past|Voice=Act	0	root	_	_
 3-5	במחקר	_	_	_	_	_	_	_	_
@@ -6663,30 +6663,30 @@
 10-11	הנתונים	_	_	_	_	_	_	_	_
 10	ה	ה	DET	DET	PronType=Art	11	det:def	_	_
 11	נתונים	נתון	NOUN	NOUN	Gender=Masc|Number=Plur	9	compound:smixut	_	_
-12-13	שלו	_	_	_	_	_	_	_	_
+12-13	שלו	_	_	_	_	_	_	_	SpaceAfter=No
 12	של_	של	ADP	ADP	Case=Gen	13	case:gen	_	_
 13	_הוא	הוא	PRON	PRON	Gender=Masc|Number=Sing|Person=3|PronType=Prs	9	nmod:poss	_	_
 14	.	_	PUNCT	PUNCT	_	2	punct	_	_
 
 # sent_id = 194
-# text = עצה מספר 4 .
+# text = עצה מספר 4.
 1	עצה	עצה	NOUN	NOUN	Gender=Fem|Number=Sing	0	root	_	_
 2	מספר	מספר	NOUN	NOUN	Gender=Masc|HebSource=ConvUncertainLabel|Number=Sing	1	nmod	_	_
-3	4	_	NUM	NUM	_	2	nummod	_	_
+3	4	_	NUM	NUM	_	2	nummod	_	SpaceAfter=No
 4	.	_	PUNCT	PUNCT	_	1	punct	_	_
 
 # sent_id = 195
-# text = תבטיח להציל את העולם .
+# text = תבטיח להציל את העולם.
 1	תבטיח	הבטיח	VERB	VERB	Gender=Masc|HebBinyan=HIFIL|Number=Sing|Person=2|Tense=Fut|Voice=Act	0	root	_	_
 2	להציל	הציל	VERB	VERB	HebBinyan=HIFIL|VerbForm=Inf|Voice=Act	1	xcomp	_	_
 3	את	את	PART	PART	Case=Acc	5	case:acc	_	_
-4-5	העולם	_	_	_	_	_	_	_	_
+4-5	העולם	_	_	_	_	_	_	_	SpaceAfter=No
 4	ה	ה	DET	DET	PronType=Art	5	det:def	_	_
 5	עולם	עולם	NOUN	NOUN	Gender=Masc|Number=Sing	2	obj	_	_
 6	.	_	PUNCT	PUNCT	_	1	punct	_	_
 
 # sent_id = 196
-# text = על פי כל הדיווחים חלה בעשורים האחרונים ירידה תלולה בתמיכה בעבודות מחקר במדעי החברה שאין להן יישום מעשי מידי .
+# text = על פי כל הדיווחים חלה בעשורים האחרונים ירידה תלולה בתמיכה בעבודות מחקר במדעי החברה שאין להן יישום מעשי מידי.
 1	על	על	ADP	ADP	_	5	case	_	_
 2	פי	פה	NOUN	NOUN	Definite=Cons|Gender=Masc|Number=Sing	1	fixed	_	_
 3	כל	כול	DET	DET	Definite=Cons	5	det	_	_
@@ -6725,11 +6725,11 @@
 27	_הן	הוא	PRON	PRON	Gender=Fem|Number=Plur|Person=3|PronType=Prs	25	iobj	_	_
 28	יישום	יישום	NOUN	NOUN	Gender=Masc|Number=Sing	25	nsubj	_	_
 29	מעשי	מעשי	ADJ	ADJ	Gender=Masc|Number=Sing	28	amod	_	_
-30	מידי	מיידי	ADJ	ADJ	Gender=Masc|Number=Sing	28	amod	_	_
+30	מידי	מיידי	ADJ	ADJ	Gender=Masc|Number=Sing	28	amod	_	SpaceAfter=No
 31	.	_	PUNCT	PUNCT	_	6	punct	_	_
 
 # sent_id = 197
-# text = מילר זוכר שבשנות ה05 וה06 הוא יכול היה להסתמך על סיוע מקרנות פורד ורוקפלר .
+# text = מילר זוכר שבשנות ה05 וה06 הוא יכול היה להסתמך על סיוע מקרנות פורד ורוקפלר.
 1	מילר	מילר	PROPN	PROPN	_	2	nsubj	_	_
 2	זוכר	זכר	VERB	VERB	Gender=Masc|HebBinyan=PAAL|Number=Sing|Person=1,2,3|VerbForm=Part|Voice=Act	0	root	_	_
 3-5	שבשנות	_	_	_	_	_	_	_	_
@@ -6753,13 +6753,13 @@
 17	מ	מ	ADP	ADP	_	18	case	_	_
 18	קרנות	קרן	NOUN	NOUN	Definite=Cons|Gender=Fem|Number=Plur	16	nmod	_	_
 19	פורד	פורד	PROPN	PROPN	_	18	compound:smixut	_	_
-20-21	ורוקפלר	_	_	_	_	_	_	_	_
+20-21	ורוקפלר	_	_	_	_	_	_	_	SpaceAfter=No
 20	ו	ו	CCONJ	CCONJ	_	21	cc	_	_
 21	רוקפלר	רוקפלר	PROPN	PROPN	_	19	conj	_	_
 22	.	_	PUNCT	PUNCT	_	2	punct	_	_
 
 # sent_id = 198
-# text = ניסיונו האחרון של מילר להשיג כספים מקרן פורד היה בתחילת שנות ה07 .
+# text = ניסיונו האחרון של מילר להשיג כספים מקרן פורד היה בתחילת שנות ה07.
 1-3	ניסיונו	_	_	_	_	_	_	_	_
 1	ניסיון_	ניסיון	NOUN	NOUN	Definite=Def|Gender=Masc|Number=Sing	13	nsubj	_	_
 2	_של_	של	ADP	ADP	_	3	case:gen	_	_
@@ -6780,13 +6780,13 @@
 14	ב	ב	ADP	ADP	_	15	case	_	_
 15	תחילת	תחילה	NOUN	NOUN	Definite=Cons|Gender=Fem|Number=Sing	13	obl	_	_
 16	שנות	שנה	NOUN	NOUN	Definite=Cons|Gender=Fem|Number=Plur	15	compound:smixut	_	_
-17-18	ה07	_	_	_	_	_	_	_	_
+17-18	ה07	_	_	_	_	_	_	_	SpaceAfter=No
 17	ה	ה	DET	DET	PronType=Art	18	det:def	_	_
 18	07	_	NUM	NUM	_	16	compound:smixut	_	_
 19	.	_	PUNCT	PUNCT	_	13	punct	_	_
 
 # sent_id = 199
-# text = אז הוא גילה עניין בגורמים המשפיעים על שיעור המצביעים , ופקיד התוכנית גילה עניין בשיעור המצביעים הנמוך בקרב בני מיעוטים .
+# text = אז הוא גילה עניין בגורמים המשפיעים על שיעור המצביעים, ופקיד התוכנית גילה עניין בשיעור המצביעים הנמוך בקרב בני מיעוטים.
 1	אז	אז	ADV	ADV	_	3	advmod	_	_
 2	הוא	הוא	PRON	PRON	Gender=Masc|Number=Sing|Person=3|PronType=Prs	3	nsubj	_	_
 3	גילה	גילה	VERB	VERB	Gender=Masc|HebBinyan=PIEL|Number=Sing|Person=3|Tense=Past|Voice=Act	0	root	_	_
@@ -6800,7 +6800,7 @@
 9	משפיעים	השפיע	VERB	VERB	Gender=Masc|HebBinyan=HIFIL|Number=Plur|Person=1,2,3|VerbForm=Part|Voice=Act	7	acl:relcl	_	_
 10	על	על	ADP	ADP	_	11	case	_	_
 11	שיעור	שיעור	NOUN	NOUN	Definite=Cons|Gender=Masc|Number=Sing	9	iobj	_	_
-12-13	המצביעים	_	_	_	_	_	_	_	_
+12-13	המצביעים	_	_	_	_	_	_	_	SpaceAfter=No
 12	ה	ה	DET	DET	PronType=Art	13	det:def	_	_
 13	מצביעים	מצביע	NOUN	NOUN	Gender=Masc|Number=Plur	11	compound:smixut	_	_
 14	,	_	PUNCT	PUNCT	_	3	punct	_	_
@@ -6823,22 +6823,22 @@
 26	נמוך	נמוך	ADJ	ADJ	Gender=Masc|Number=Sing	22	amod	_	_
 27	בקרב	בקרב	ADP	ADP	_	28	case	_	_
 28	בני	בן	NOUN	NOUN	Definite=Cons|Gender=Masc|Number=Plur	22	nmod	_	_
-29	מיעוטים	מיעוט	NOUN	NOUN	Gender=Masc|Number=Plur	28	compound:smixut	_	_
+29	מיעוטים	מיעוט	NOUN	NOUN	Gender=Masc|Number=Plur	28	compound:smixut	_	SpaceAfter=No
 30	.	_	PUNCT	PUNCT	_	3	punct	_	_
 
 # sent_id = 200
-# text = נראה היה שזה זיווג טוב .
+# text = נראה היה שזה זיווג טוב.
 1	נראה	נראה	VERB	VERB	Gender=Masc|HebBinyan=NIFAL|Number=Sing|Person=1,2,3|VerbForm=Part|Voice=Mid	0	root	_	_
 2	היה	היה	VERB	VERB	Gender=Masc|Number=Sing|Person=3|Polarity=Pos|Tense=Past|VerbType=Cop	1	aux	_	_
 3-4	שזה	_	_	_	_	_	_	_	_
 3	ש	ש	SCONJ	SCONJ	_	5	mark	_	_
 4	זה	זה	PRON	PRON	Gender=Masc|Number=Sing|Person=3	5	nsubj	_	_
 5	זיווג	זיווג	NOUN	NOUN	Gender=Masc|Number=Sing	1	ccomp	_	_
-6	טוב	טוב	ADJ	ADJ	Gender=Masc|Number=Sing	5	amod	_	_
+6	טוב	טוב	ADJ	ADJ	Gender=Masc|Number=Sing	5	amod	_	SpaceAfter=No
 7	.	_	PUNCT	PUNCT	_	1	punct	_	_
 
 # sent_id = 201
-# text = מילר הדגיש שיעד המחקר יהיה איתור מחסומים המונעים מבני מיעוטים להצביע , דבר שלדעתו עשוי היה להיות צעד ראשון לקראת העלאת שיעור ההצבעה .
+# text = מילר הדגיש שיעד המחקר יהיה איתור מחסומים המונעים מבני מיעוטים להצביע, דבר שלדעתו עשוי היה להיות צעד ראשון לקראת העלאת שיעור ההצבעה.
 1	מילר	מילר	PROPN	PROPN	_	2	nsubj	_	_
 2	הדגיש	הדגיש	VERB	VERB	Gender=Masc|HebBinyan=HIFIL|Number=Sing|Person=3|Tense=Past|Voice=Act	0	root	_	_
 3-4	שיעד	_	_	_	_	_	_	_	_
@@ -6857,7 +6857,7 @@
 12	מ	מ	ADP	ADP	_	13	case	_	_
 13	בני	בן	NOUN	NOUN	Definite=Cons|Gender=Masc|Number=Plur	11	iobj	_	_
 14	מיעוטים	מיעוט	NOUN	NOUN	Gender=Masc|Number=Plur	13	compound:smixut	_	_
-15	להצביע	הצביע	VERB	VERB	HebBinyan=HIFIL|VerbForm=Inf|Voice=Act	11	xcomp	_	_
+15	להצביע	הצביע	VERB	VERB	HebBinyan=HIFIL|VerbForm=Inf|Voice=Act	11	xcomp	_	SpaceAfter=No
 16	,	_	PUNCT	PUNCT	_	8	punct	_	_
 17	דבר	דבר	NOUN	NOUN	Gender=Masc|Number=Sing	8	appos	_	_
 18-22	שלדעתו	_	_	_	_	_	_	_	_
@@ -6874,27 +6874,27 @@
 28	לקראת	לקראת	ADP	ADP	_	29	case	_	_
 29	העלאת	העלאה	NOUN	NOUN	Definite=Cons|Gender=Fem|Number=Sing	26	nmod	_	_
 30	שיעור	שיעור	NOUN	NOUN	Definite=Cons|Gender=Masc|Number=Sing	29	compound:smixut	_	_
-31-32	ההצבעה	_	_	_	_	_	_	_	_
+31-32	ההצבעה	_	_	_	_	_	_	_	SpaceAfter=No
 31	ה	ה	DET	DET	PronType=Art	32	det:def	_	_
 32	הצבעה	הצבעה	NOUN	NOUN	Gender=Fem|Number=Sing	30	compound:smixut	_	_
 33	.	_	PUNCT	PUNCT	_	2	punct	_	_
 
 # sent_id = 202
-# text = אך זה לא היה מספיק טוב לקרן .
+# text = אך זה לא היה מספיק טוב לקרן.
 1	אך	אך	CCONJ	CCONJ	_	6	cc	_	_
 2	זה	זה	PRON	PRON	Gender=Masc|Number=Sing|Person=3	6	nsubj	_	_
 3	לא	לא	ADV	ADV	Polarity=Neg	6	advmod	_	_
 4	היה	היה	VERB	VERB	Gender=Masc|Number=Sing|Person=3|Polarity=Pos|Tense=Past|VerbType=Cop	6	aux	_	_
 5	מספיק	מספיק	ADV	ADV	_	6	advmod	_	_
 6	טוב	טוב	ADJ	ADJ	Gender=Masc|Number=Sing	0	root	_	_
-7-9	לקרן	_	_	_	_	_	_	_	_
+7-9	לקרן	_	_	_	_	_	_	_	SpaceAfter=No
 7	ל	ל	ADP	ADP	_	9	case	_	_
 8	ה_	ה	DET	DET	PronType=Art	9	det:def	_	_
 9	קרן	קרן	NOUN	NOUN	Gender=Fem|Number=Sing	6	advmod	_	_
 10	.	_	PUNCT	PUNCT	_	6	punct	_	_
 
 # sent_id = 203
-# text = קרן פורד רצתה להיות בטוחה שהמחקר יגדיר במפורש את הדרכים להעלאת שיעור המצביעים בקרב מיעוטים .
+# text = קרן פורד רצתה להיות בטוחה שהמחקר יגדיר במפורש את הדרכים להעלאת שיעור המצביעים בקרב מיעוטים.
 1	קרן	קרן	NOUN	NOUN	Definite=Cons|Gender=Fem|Number=Sing	3	nsubj	_	_
 2	פורד	פורד	PROPN	PROPN	_	1	flat:name	_	_
 3	רצתה	רצה	VERB	VERB	Gender=Fem|HebBinyan=PAAL|Number=Sing|Person=3|Tense=Past|Voice=Act	0	root	_	_
@@ -6918,11 +6918,11 @@
 17	ה	ה	DET	DET	PronType=Art	18	det:def	_	_
 18	מצביעים	מצביע	NOUN	NOUN	Gender=Masc|Number=Plur	16	compound:smixut	_	_
 19	בקרב	בקרב	ADP	ADP	_	20	case	_	_
-20	מיעוטים	מיעוט	NOUN	NOUN	Gender=Masc|Number=Plur	15	nmod	_	_
+20	מיעוטים	מיעוט	NOUN	NOUN	Gender=Masc|Number=Plur	15	nmod	_	SpaceAfter=No
 21	.	_	PUNCT	PUNCT	_	3	punct	_	_
 
 # sent_id = 204
-# text = מילר לא יכול היה להבטיח זאת במצפון נקי .
+# text = מילר לא יכול היה להבטיח זאת במצפון נקי.
 1	מילר	מילר	PROPN	PROPN	_	3	nsubj	_	_
 2	לא	לא	ADV	ADV	Polarity=Neg	3	advmod	_	_
 3	יכול	_	AUX	AUX	Gender=Masc|Number=Sing|Person=1,2,3|VerbForm=Part|VerbType=Mod	0	root	_	_
@@ -6932,11 +6932,11 @@
 7-8	במצפון	_	_	_	_	_	_	_	_
 7	ב	ב	ADP	ADP	_	8	case	_	_
 8	מצפון	מצפון	NOUN	NOUN	Gender=Masc|Number=Sing	5	obl	_	_
-9	נקי	נקי	ADJ	ADJ	Gender=Masc|Number=Sing	8	amod	_	_
+9	נקי	נקי	ADJ	ADJ	Gender=Masc|Number=Sing	8	amod	_	SpaceAfter=No
 10	.	_	PUNCT	PUNCT	_	3	punct	_	_
 
 # sent_id = 205
-# text = מאז 7791 מומן פרויקט חקר הבחירות הארציות על - ידי קרן המדע הארצית , התומכת הגדולה ביותר במדעי חברה בסיסיים .
+# text = מאז 7791 מומן פרויקט חקר הבחירות הארציות על - ידי קרן המדע הארצית, התומכת הגדולה ביותר במדעי חברה בסיסיים.
 1-2	מאז	_	_	_	_	_	_	_	_
 1	מ	מ	ADP	ADP	_	3	case	_	_
 2	אז	אז	ADV	ADV	_	1	fixed	_	_
@@ -6957,7 +6957,7 @@
 15-16	המדע	_	_	_	_	_	_	_	_
 15	ה	ה	DET	DET	PronType=Art	16	det:def	_	_
 16	מדע	מדע	NOUN	NOUN	Gender=Masc|Number=Sing	14	compound:smixut	_	_
-17-18	הארצית	_	_	_	_	_	_	_	_
+17-18	הארצית	_	_	_	_	_	_	_	SpaceAfter=No
 17	ה	ה	DET	DET	PronType=Art	18	det:def	_	_
 18	ארצית	ארצי	ADJ	ADJ	Gender=Fem|Number=Sing	14	amod	_	_
 19	,	_	PUNCT	PUNCT	_	14	punct	_	_
@@ -6972,27 +6972,27 @@
 25	ב	ב	ADP	ADP	_	26	case	_	_
 26	מדעי	מדע	NOUN	NOUN	Definite=Cons|Gender=Masc|Number=Plur	21	nmod	_	_
 27	חברה	חברה	NOUN	NOUN	Gender=Fem|Number=Sing	26	compound:smixut	_	_
-28	בסיסיים	בסיסי	ADJ	ADJ	Gender=Masc|Number=Plur	26	amod	_	_
+28	בסיסיים	בסיסי	ADJ	ADJ	Gender=Masc|Number=Plur	26	amod	_	SpaceAfter=No
 29	.	_	PUNCT	PUNCT	_	4	punct	_	_
 
 # sent_id = 206
-# text = עצה מספר 5 .
+# text = עצה מספר 5.
 1	עצה	עצה	NOUN	NOUN	Gender=Fem|Number=Sing	0	root	_	_
 2	מספר	מספר	NOUN	NOUN	Gender=Masc|HebSource=ConvUncertainLabel|Number=Sing	1	nmod	_	_
-3	5	_	NUM	NUM	_	2	nummod	_	_
+3	5	_	NUM	NUM	_	2	nummod	_	SpaceAfter=No
 4	.	_	PUNCT	PUNCT	_	1	punct	_	_
 
 # sent_id = 207
-# text = הייה קטליזטור לשינוי .
+# text = הייה קטליזטור לשינוי.
 1	הייה	היה	VERB	VERB	Gender=Masc|Mood=Imp|Number=Sing|Person=2|Polarity=Pos|VerbType=Cop	0	root	_	_
 2	קטליזטור	קטליזאטור	NOUN	NOUN	Gender=Masc|Number=Sing	1	nsubj	_	_
-3-4	לשינוי	_	_	_	_	_	_	_	_
+3-4	לשינוי	_	_	_	_	_	_	_	SpaceAfter=No
 3	ל	ל	ADP	ADP	_	4	case	_	_
 4	שינוי	שינוי	NOUN	NOUN	Gender=Masc|Number=Sing	2	nmod	_	_
 5	.	_	PUNCT	PUNCT	_	1	punct	_	_
 
 # sent_id = 208
-# text = יש אנשים המתקשים להבטיח בפרצוף פוקר שהם יציעו פתרון לבעיה חברתית מרכזית .
+# text = יש אנשים המתקשים להבטיח בפרצוף פוקר שהם יציעו פתרון לבעיה חברתית מרכזית.
 1	יש	יש	VERB	VERB	HebExistential=True	0	root	_	_
 2	אנשים	איש	NOUN	NOUN	Gender=Masc|Number=Plur	1	nsubj	_	_
 3-4	המתקשים	_	_	_	_	_	_	_	_
@@ -7012,18 +7012,18 @@
 13	ל	ל	ADP	ADP	_	14	case	_	_
 14	בעיה	בעיה	NOUN	NOUN	Gender=Fem|Number=Sing	12	nmod	_	_
 15	חברתית	חברתי	ADJ	ADJ	Gender=Fem|Number=Sing	14	amod	_	_
-16	מרכזית	מרכזי	ADJ	ADJ	Gender=Fem|Number=Sing	14	amod	_	_
+16	מרכזית	מרכזי	ADJ	ADJ	Gender=Fem|Number=Sing	14	amod	_	SpaceAfter=No
 17	.	_	PUNCT	PUNCT	_	1	punct	_	_
 
 # sent_id = 209
-# text = לאנשים אלה מומלץ ליהפך לקטליזטורים : לקבץ יחד אנשים רבים היכולים להבטיח פתרונות או שלפחות יכולים היו , אילו סגרו אותם במרכז ועידות במשך ימים , להציע פתרון .
+# text = לאנשים אלה מומלץ ליהפך לקטליזטורים: לקבץ יחד אנשים רבים היכולים להבטיח פתרונות או שלפחות יכולים היו, אילו סגרו אותם במרכז ועידות במשך ימים, להציע פתרון.
 1-2	לאנשים	_	_	_	_	_	_	_	_
 1	ל	ל	ADP	ADP	_	2	case	_	_
 2	אנשים	איש	NOUN	NOUN	Gender=Masc|Number=Plur	4	obl	_	_
 3	אלה	אלה	PRON	PRON	Gender=Masc|Number=Plur|Person=3|PronType=Dem	2	amod	_	_
 4	מומלץ	מומלץ	AUX	AUX	Gender=Masc|Number=Sing|Tense=Past|VerbType=Mod	0	root	_	_
 5	ליהפך	נהפך	VERB	VERB	HebBinyan=NIFAL|VerbForm=Inf|Voice=Mid	4	xcomp	_	_
-6-7	לקטליזטורים	_	_	_	_	_	_	_	_
+6-7	לקטליזטורים	_	_	_	_	_	_	_	SpaceAfter=No
 6	ל	ל	ADP	ADP	_	7	case	_	_
 7	קטליזטורים	קטליזאטור	NOUN	NOUN	Gender=Masc|Number=Plur	5	iobj	_	_
 8	:	_	PUNCT	PUNCT	_	5	punct	_	_
@@ -7041,7 +7041,7 @@
 18	ש	ש	SCONJ	SCONJ	_	20	mark	_	_
 19	לפחות	לפחות	ADV	ADV	_	20	advmod	_	_
 20	יכולים	יכול	VERB	VERB	VerbForm=Part	14	conj	_	_
-21	היו	היה	VERB	VERB	Gender=Fem,Masc|Number=Plur|Person=3|Polarity=Pos|Tense=Past|VerbType=Cop	20	aux	_	_
+21	היו	היה	VERB	VERB	Gender=Fem,Masc|Number=Plur|Person=3|Polarity=Pos|Tense=Past|VerbType=Cop	20	aux	_	SpaceAfter=No
 22	,	_	PUNCT	PUNCT	_	24	punct	_	_
 23	אילו	אילו	CCONJ	CCONJ	_	24	mark	_	_
 24	סגרו	סגר	VERB	VERB	Gender=Fem,Masc|HebBinyan=PAAL|Number=Plur|Person=3|Tense=Past|Voice=Act	20	parataxis	_	_
@@ -7053,14 +7053,14 @@
 28	מרכז	מרכז	NOUN	NOUN	Definite=Cons|Gender=Masc|Number=Sing	24	obl	_	_
 29	ועידות	ועידה	NOUN	NOUN	Gender=Fem|Number=Plur	28	compound:smixut	_	_
 30	במשך	במשך	ADP	ADP	_	31	case	_	_
-31	ימים	יום	NOUN	NOUN	Gender=Masc|Number=Plur	24	obl	_	_
+31	ימים	יום	NOUN	NOUN	Gender=Masc|Number=Plur	24	obl	_	SpaceAfter=No
 32	,	_	PUNCT	PUNCT	_	24	punct	_	_
 33	להציע	הציע	VERB	VERB	HebBinyan=HIFIL|VerbForm=Inf|Voice=Act	20	xcomp	_	_
-34	פתרון	פתרון	NOUN	NOUN	Gender=Masc|Number=Sing	33	obj	_	_
+34	פתרון	פתרון	NOUN	NOUN	Gender=Masc|Number=Sing	33	obj	_	SpaceAfter=No
 35	.	_	PUNCT	PUNCT	_	4	punct	_	_
 
 # sent_id = 210
-# text = הקרנות אוהבות יותר ויותר סימנים מוחשיים כאלה להשפעה שיש לכנסים ולהתוועדויות .
+# text = הקרנות אוהבות יותר ויותר סימנים מוחשיים כאלה להשפעה שיש לכנסים ולהתוועדויות.
 1-2	הקרנות	_	_	_	_	_	_	_	_
 1	ה	ה	DET	DET	PronType=Art	2	det:def	_	_
 2	קרנות	קרן	NOUN	NOUN	Gender=Fem|Number=Plur	3	nsubj	_	_
@@ -7085,14 +7085,14 @@
 17-18	לכנסים	_	_	_	_	_	_	_	_
 17	ל	ל	ADP	ADP	_	18	case	_	_
 18	כנסים	כנס	NOUN	NOUN	Gender=Masc|Number=Plur	16	iobj	_	_
-19-21	ולהתוועדויות	_	_	_	_	_	_	_	_
+19-21	ולהתוועדויות	_	_	_	_	_	_	_	SpaceAfter=No
 19	ו	ו	CCONJ	CCONJ	_	21	cc	_	_
 20	ל	ל	ADP	ADP	_	21	case	_	_
 21	התוועדויות	התוועדות	NOUN	NOUN	Gender=Fem|Number=Plur	18	conj	_	_
 22	.	_	PUNCT	PUNCT	_	3	punct	_	_
 
 # sent_id = 211
-# text = בעיקר הן אוהבות לאסוף אנשים שאילולא כן אפשר שלא היו נפגשים לעולם : אקדמאים ופוליטיקאים , ביורוקרטים ונבחרי ציבור , פנאטים של השמאל ופנאטים של הימין .
+# text = בעיקר הן אוהבות לאסוף אנשים שאילולא כן אפשר שלא היו נפגשים לעולם: אקדמאים ופוליטיקאים, ביורוקרטים ונבחרי ציבור, פנאטים של השמאל ופנאטים של הימין.
 1	בעיקר	בעיקר	ADV	ADV	_	3	advmod	_	_
 2	הן	הוא	PRON	PRON	Gender=Fem|Number=Plur|Person=3|PronType=Prs	3	nsubj	_	_
 3	אוהבות	אהב	VERB	VERB	Gender=Fem|HebBinyan=PAAL|Number=Plur|Person=1,2,3|VerbForm=Part|Voice=Act	0	root	_	_
@@ -7108,10 +7108,10 @@
 11	לא	לא	ADV	ADV	Polarity=Neg	13	advmod	_	_
 12	היו	היה	VERB	VERB	Gender=Fem,Masc|Number=Plur|Person=3|Polarity=Pos|Tense=Past|VerbType=Cop	13	aux	_	_
 13	נפגשים	נפגש	VERB	VERB	Gender=Masc|HebBinyan=NIFAL|Number=Plur|Person=1,2,3|VerbForm=Part|Voice=Mid	9	ccomp	_	_
-14	לעולם	לעולם	ADV	ADV	_	13	advmod	_	_
+14	לעולם	לעולם	ADV	ADV	_	13	advmod	_	SpaceAfter=No
 15	:	_	PUNCT	PUNCT	_	5	punct	_	_
 16	אקדמאים	אקדמאי	NOUN	NOUN	Gender=Masc|Number=Plur	5	appos	_	_
-17-18	ופוליטיקאים	_	_	_	_	_	_	_	_
+17-18	ופוליטיקאים	_	_	_	_	_	_	_	SpaceAfter=No
 17	ו	ו	CCONJ	CCONJ	_	18	cc	_	_
 18	פוליטיקאים	פוליטיקאי	NOUN	NOUN	Gender=Masc|Number=Plur	16	conj	_	_
 19	,	_	PUNCT	PUNCT	_	16	punct	_	_
@@ -7119,7 +7119,7 @@
 21-22	ונבחרי	_	_	_	_	_	_	_	_
 21	ו	ו	CCONJ	CCONJ	_	22	cc	_	_
 22	נבחרי	נבחר	NOUN	NOUN	Definite=Cons|Gender=Masc|Number=Plur	20	conj	_	_
-23	ציבור	ציבור	NOUN	NOUN	Gender=Masc|Number=Sing	22	compound:smixut	_	_
+23	ציבור	ציבור	NOUN	NOUN	Gender=Masc|Number=Sing	22	compound:smixut	_	SpaceAfter=No
 24	,	_	PUNCT	PUNCT	_	16	punct	_	_
 25	פנאטים	פנאטי	ADJ	ADJ	Gender=Masc|HebSource=ConvUncertainHead|Number=Plur	16	dep	_	_
 26	של	של	PART	PART	Case=Gen	28	case:gen	_	_
@@ -7130,14 +7130,14 @@
 29	ו	ו	CCONJ	CCONJ	_	30	cc	_	_
 30	פנאטים	פנאטי	ADJ	ADJ	Gender=Masc|Number=Plur	25	conj	_	_
 31	של	של	PART	PART	Case=Gen	33	case	_	_
-32-33	הימין	_	_	_	_	_	_	_	_
+32-33	הימין	_	_	_	_	_	_	_	SpaceAfter=No
 32	ה	ה	DET	DET	PronType=Art	33	det:def	_	_
 33	ימין	ימין	NOUN	NOUN	Gender=Masc|Number=Sing	30	obl	_	_
 34	.	_	PUNCT	PUNCT	_	3	punct	_	_
 
 # sent_id = 212
-# text = וזכרו : אפשר שפקיד התוכנית של הקרן יצטרף גם הוא למסע ; הקפידו איפוא בבחירת האתר .
-1-2	וזכרו	_	_	_	_	_	_	_	_
+# text = וזכרו: אפשר שפקיד התוכנית של הקרן יצטרף גם הוא למסע; הקפידו איפוא בבחירת האתר.
+1-2	וזכרו	_	_	_	_	_	_	_	SpaceAfter=No
 1	ו	ו	CCONJ	CCONJ	_	18	cc	_	_
 2	זכרו	זכר	VERB	VERB	Gender=Fem,Masc|HebBinyan=PAAL|Mood=Imp|Number=Plur|Person=2|Voice=Act	0	root	_	_
 3	:	_	PUNCT	PUNCT	_	4	punct	_	_
@@ -7155,7 +7155,7 @@
 12	יצטרף	הצטרף	VERB	VERB	Gender=Masc|HebBinyan=HITPAEL|Number=Sing|Person=3|Tense=Fut	4	ccomp	_	_
 13	גם	גם	ADV	ADV	_	14	det	_	_
 14	הוא	הוא	PRON	PRON	Gender=Masc|Number=Sing|Person=3|PronType=Prs	12	dep	_	_
-15-17	למסע	_	_	_	_	_	_	_	_
+15-17	למסע	_	_	_	_	_	_	_	SpaceAfter=No
 15	ל	ל	ADP	ADP	_	17	case	_	_
 16	ה_	ה	DET	DET	PronType=Art	17	det:def	_	_
 17	מסע	מסע	NOUN	NOUN	Gender=Masc|Number=Sing	12	iobj	_	_
@@ -7165,13 +7165,13 @@
 21-22	בבחירת	_	_	_	_	_	_	_	_
 21	ב	ב	ADP	ADP	_	22	case	_	_
 22	בחירת	בחירה	NOUN	NOUN	Definite=Cons|Gender=Fem|Number=Sing	19	iobj	_	_
-23-24	האתר	_	_	_	_	_	_	_	_
+23-24	האתר	_	_	_	_	_	_	_	SpaceAfter=No
 23	ה	ה	DET	DET	PronType=Art	24	det:def	_	_
 24	אתר	אתר	NOUN	NOUN	Gender=Masc|Number=Sing	22	compound:smixut	_	_
 25	.	_	PUNCT	PUNCT	_	2	punct	_	_
 
 # sent_id = 213
-# text = אומרים שמרכז הוועידות והלימודים של קרן רוקפלר בבלאגיו שבאיטליה הוא מקום טוב לחישול קונסנזוס על בעיות דחופות של העולם .
+# text = אומרים שמרכז הוועידות והלימודים של קרן רוקפלר בבלאגיו שבאיטליה הוא מקום טוב לחישול קונסנזוס על בעיות דחופות של העולם.
 1	אומרים	אמר	VERB	VERB	Gender=Masc|HebBinyan=PAAL|Number=Plur|Person=1,2,3|VerbForm=Part|Voice=Act	0	root	_	_
 2-3	שמרכז	_	_	_	_	_	_	_	_
 2	ש	ש	SCONJ	SCONJ	_	18	mark	_	_
@@ -7204,13 +7204,13 @@
 24	בעיות	בעיה	NOUN	NOUN	Gender=Fem|Number=Plur	22	nmod	_	_
 25	דחופות	דחוף	ADJ	ADJ	Gender=Fem|Number=Plur	24	amod	_	_
 26	של	של	PART	PART	Case=Gen	28	case:gen	_	_
-27-28	העולם	_	_	_	_	_	_	_	_
+27-28	העולם	_	_	_	_	_	_	_	SpaceAfter=No
 27	ה	ה	DET	DET	PronType=Art	28	det:def	_	_
 28	עולם	עולם	NOUN	NOUN	Gender=Masc|Number=Sing	24	nmod:poss	_	_
 29	.	_	PUNCT	PUNCT	_	1	punct	_	_
 
 # sent_id = 214
-# text = גם אם לא ייווצר קונסנסוס חדש מאלכימיה זו , קרוב לוודאי שייצא כרך של ניירות .
+# text = גם אם לא ייווצר קונסנסוס חדש מאלכימיה זו, קרוב לוודאי שייצא כרך של ניירות.
 1	גם	גם	ADV	ADV	_	4	advmod	_	_
 2	אם	אם	SCONJ	SCONJ	_	4	mark	_	_
 3	לא	לא	ADV	ADV	Polarity=Neg	4	advmod	_	_
@@ -7220,7 +7220,7 @@
 7-8	מאלכימיה	_	_	_	_	_	_	_	_
 7	מ	מ	ADP	ADP	_	8	case	_	_
 8	אלכימיה	אלכימיה	NOUN	NOUN	Gender=Fem|Number=Sing	4	iobj	_	_
-9	זו	זו	PRON	PRON	Gender=Fem|Number=Sing|Person=3|PronType=Dem	8	amod	_	_
+9	זו	זו	PRON	PRON	Gender=Fem|Number=Sing|Person=3|PronType=Dem	8	amod	_	SpaceAfter=No
 10	,	_	PUNCT	PUNCT	_	11	punct	_	_
 11	קרוב	קרוב	ADJ	ADJ	Gender=Masc|Number=Sing	0	root	_	_
 12-13	לוודאי	_	_	_	_	_	_	_	_
@@ -7231,11 +7231,11 @@
 15	ייצא	ייצא	VERB	VERB	Gender=Masc|HebBinyan=PIEL|Number=Sing|Person=3|Tense=Past|Voice=Act	11	ccomp	_	_
 16	כרך	כרך	NOUN	NOUN	Gender=Masc|Number=Sing	15	nsubj	_	_
 17	של	של	PART	PART	Case=Gen	18	case:gen	_	_
-18	ניירות	נייר	NOUN	NOUN	Gender=Masc|Number=Plur	16	nmod:poss	_	_
+18	ניירות	נייר	NOUN	NOUN	Gender=Masc|Number=Plur	16	nmod:poss	_	SpaceAfter=No
 19	.	_	PUNCT	PUNCT	_	11	punct	_	_
 
 # sent_id = 215
-# text = בקרב אקדמאים שאינם מוזמנים לוועידות אלה שוררת ציניות רבה באשר למטר כרכי המאמרים והניירות המונפקים בחסות קרנות .
+# text = בקרב אקדמאים שאינם מוזמנים לוועידות אלה שוררת ציניות רבה באשר למטר כרכי המאמרים והניירות המונפקים בחסות קרנות.
 1	בקרב	בקרב	ADP	ADP	_	2	case	_	_
 2	אקדמאים	אקדמאי	NOUN	NOUN	Gender=Masc|Number=Plur	9	obl	_	_
 3-4	שאינם	_	_	_	_	_	_	_	_
@@ -7267,11 +7267,11 @@
 23-24	בחסות	_	_	_	_	_	_	_	_
 23	ב	ב	ADP	ADP	_	24	case	_	_
 24	חסות	חסות	NOUN	NOUN	Definite=Cons|Gender=Fem|Number=Sing	22	obl	_	_
-25	קרנות	קרן	NOUN	NOUN	Gender=Fem|Number=Plur	24	compound:smixut	_	_
+25	קרנות	קרן	NOUN	NOUN	Gender=Fem|Number=Plur	24	compound:smixut	_	SpaceAfter=No
 26	.	_	PUNCT	PUNCT	_	9	punct	_	_
 
 # sent_id = 216
-# text = אין זה סביר שעל שולחנות עיתונאים ומעצבי מדיניות רובצים כל כרכי " אמריקן אקונומיק ריוויו " של שלוש השנים האחרונות , אך בהחלט הגיוני שיש להם כמה כרכים המספקים מידע בנושא נתון במינונים קטנים וחזקים .
+# text = אין זה סביר שעל שולחנות עיתונאים ומעצבי מדיניות רובצים כל כרכי "אמריקן אקונומיק ריוויו" של שלוש השנים האחרונות, אך בהחלט הגיוני שיש להם כמה כרכים המספקים מידע בנושא נתון במינונים קטנים וחזקים.
 1	אין	_	ADV	ADV	Polarity=Neg	3	advmod	_	_
 2	זה	זה	PRON	PRON	Gender=Masc|Number=Sing|Person=3	3	nsubj	_	_
 3	סביר	סביר	AUX	AUX	Gender=Masc|Number=Sing|Tense=Past|VerbType=Mod	0	root	_	_
@@ -7287,17 +7287,17 @@
 11	רובצים	רבץ	VERB	VERB	Gender=Masc|HebBinyan=PAAL|Number=Plur|Person=1,2,3|VerbForm=Part|Voice=Act	3	ccomp	_	_
 12	כל	כול	DET	DET	Definite=Cons	13	det	_	_
 13	כרכי	כרך	NOUN	NOUN	Definite=Cons|Gender=Masc|Number=Plur	11	nsubj	_	_
-14	"	_	PUNCT	PUNCT	_	15	punct	_	_
+14	"	_	PUNCT	PUNCT	_	15	punct	_	SpaceAfter=No
 15	אמריקן	אמריקן	PROPN	PROPN	_	13	compound:smixut	_	_
 16	אקונומיק	אקונומיק	PROPN	PROPN	_	15	flat:name	_	_
-17	ריוויו	ריווי	PROPN	PROPN	_	15	flat:name	_	_
+17	ריוויו	ריווי	PROPN	PROPN	_	15	flat:name	_	SpaceAfter=No
 18	"	_	PUNCT	PUNCT	_	15	punct	_	_
 19	של	של	PART	PART	Case=Gen	22	case:gen	_	_
 20	שלוש	שלוש	NUM	NUM	Definite=Cons|Gender=Fem|Number=Sing	22	nummod	_	_
 21-22	השנים	_	_	_	_	_	_	_	_
 21	ה	ה	DET	DET	PronType=Art	22	det:def	_	_
 22	שנים	שנה	NOUN	NOUN	Gender=Fem|Number=Plur	13	nmod:poss	_	_
-23-24	האחרונות	_	_	_	_	_	_	_	_
+23-24	האחרונות	_	_	_	_	_	_	_	SpaceAfter=No
 23	ה	ה	DET	DET	PronType=Art	24	det:def	_	_
 24	אחרונות	אחרון	ADJ	ADJ	Gender=Fem|Number=Plur	22	amod	_	_
 25	,	_	PUNCT	PUNCT	_	3	punct	_	_
@@ -7324,26 +7324,26 @@
 41	ב	ב	ADP	ADP	_	42	case	_	_
 42	מינונים	מינון	NOUN	NOUN	Gender=Masc|Number=Plur	37	nmod	_	_
 43	קטנים	קטן	ADJ	ADJ	Gender=Masc|Number=Plur	42	amod	_	_
-44-45	וחזקים	_	_	_	_	_	_	_	_
+44-45	וחזקים	_	_	_	_	_	_	_	SpaceAfter=No
 44	ו	ו	CCONJ	CCONJ	_	45	cc	_	_
 45	חזקים	חזק	ADJ	ADJ	Gender=Masc|Number=Plur	43	conj	_	_
 46	.	_	PUNCT	PUNCT	_	3	punct	_	_
 
 # sent_id = 217
-# text = עצה מספר 6 .
+# text = עצה מספר 6.
 1	עצה	עצה	NOUN	NOUN	Gender=Fem|Number=Sing	0	root	_	_
 2	מספר	מספר	NOUN	NOUN	Gender=Masc|HebSource=ConvUncertainLabel|Number=Sing	1	nmod	_	_
-3	6	_	NUM	NUM	_	2	nummod	_	_
+3	6	_	NUM	NUM	_	2	nummod	_	SpaceAfter=No
 4	.	_	PUNCT	PUNCT	_	1	punct	_	_
 
 # sent_id = 218
-# text = ערוך בדיקה מחודשת , נוקבת וקטלנית , לדוגמות ליברליות עייפות .
+# text = ערוך בדיקה מחודשת, נוקבת וקטלנית, לדוגמות ליברליות עייפות.
 1	ערוך	ערך	VERB	VERB	Gender=Masc|HebBinyan=PAAL|Mood=Imp|Number=Sing|Person=2|Voice=Act	0	root	_	_
 2	בדיקה	בדיקה	NOUN	NOUN	Gender=Fem|Number=Sing	1	obj	_	_
-3	מחודשת	מחודש	ADJ	ADJ	Gender=Fem|Number=Sing	2	amod	_	_
+3	מחודשת	מחודש	ADJ	ADJ	Gender=Fem|Number=Sing	2	amod	_	SpaceAfter=No
 4	,	_	PUNCT	PUNCT	_	2	punct	_	_
 5	נוקבת	נקב	VERB	VERB	Gender=Fem|HebBinyan=PAAL|Number=Sing|Person=1,2,3|VerbForm=Part|Voice=Act	2	amod	_	_
-6-7	וקטלנית	_	_	_	_	_	_	_	_
+6-7	וקטלנית	_	_	_	_	_	_	_	SpaceAfter=No
 6	ו	ו	CCONJ	CCONJ	_	7	cc	_	_
 7	קטלנית	קטלני	ADJ	ADJ	Gender=Fem|Number=Sing	5	conj	_	_
 8	,	_	PUNCT	PUNCT	_	1	punct	_	_
@@ -7351,11 +7351,11 @@
 9	ל	ל	ADP	ADP	_	10	case	_	_
 10	דוגמות	דוגמה	NOUN	NOUN	Gender=Fem|Number=Plur	1	obl	_	_
 11	ליברליות	ליברלי	ADJ	ADJ	Gender=Fem|Number=Plur	10	amod	_	_
-12	עייפות	עייף	ADJ	ADJ	Gender=Fem|Number=Plur	10	amod	_	_
+12	עייפות	עייף	ADJ	ADJ	Gender=Fem|Number=Plur	10	amod	_	SpaceAfter=No
 13	.	_	PUNCT	PUNCT	_	1	punct	_	_
 
 # sent_id = 219
-# text = זה כ02 שנה מתאמצת חבורת שמרנים , ביניהם אירווינג קריסטול , להשיג סובסידיה פילנטרופית להוגים רבים יותר מהימין .
+# text = זה כ02 שנה מתאמצת חבורת שמרנים, ביניהם אירווינג קריסטול, להשיג סובסידיה פילנטרופית להוגים רבים יותר מהימין.
 1	זה	זה	PRON	PRON	Gender=Masc|Number=Sing|Person=3|PronType=Dem	4	advmod	_	_
 2-3	כ02	_	_	_	_	_	_	_	_
 2	כ	כ	ADP	ADP	_	4	advmod	_	_
@@ -7363,13 +7363,13 @@
 4	שנה	שנה	NOUN	NOUN	Gender=Fem|Number=Sing	5	dep	_	_
 5	מתאמצת	התאמץ	VERB	VERB	Gender=Fem|HebBinyan=HITPAEL|Number=Sing|Person=1,2,3|VerbForm=Part	0	root	_	_
 6	חבורת	חבורה	NOUN	NOUN	Definite=Cons|Gender=Fem|Number=Sing	5	nsubj	_	_
-7	שמרנים	שמרן	NOUN	NOUN	Gender=Masc|Number=Plur	6	compound:smixut	_	_
+7	שמרנים	שמרן	NOUN	NOUN	Gender=Masc|Number=Plur	6	compound:smixut	_	SpaceAfter=No
 8	,	_	PUNCT	PUNCT	_	10	punct	_	_
 9-10	ביניהם	_	_	_	_	_	_	_	_
 9	ביניהם	בין	ADP	ADP	_	10	case	_	_
 10	_הם	הוא	PRON	PRON	Gender=Masc|Number=Plur|Person=3|PronType=Prs	6	appos	_	_
 11	אירווינג	אירווינג	PROPN	PROPN	_	10	nsubj	_	_
-12	קריסטול	קריסטול	PROPN	PROPN	_	11	flat:name	_	_
+12	קריסטול	קריסטול	PROPN	PROPN	_	11	flat:name	_	SpaceAfter=No
 13	,	_	PUNCT	PUNCT	_	10	punct	_	_
 14	להשיג	השיג	VERB	VERB	HebBinyan=HIFIL|VerbForm=Inf|Voice=Act	5	xcomp	_	_
 15	סובסידיה	סובסידיה	NOUN	NOUN	Gender=Fem|Number=Sing	14	obj	_	_
@@ -7379,14 +7379,14 @@
 18	הוגים	הוגה	NOUN	NOUN	Gender=Masc|Number=Plur	15	nmod	_	_
 19	רבים	רב	ADJ	ADJ	Gender=Masc|Number=Plur	18	amod	_	_
 20	יותר	יותר	ADV	ADV	_	19	advmod	_	_
-21-23	מהימין	_	_	_	_	_	_	_	_
+21-23	מהימין	_	_	_	_	_	_	_	SpaceAfter=No
 21	מ	מ	ADP	ADP	_	23	case	_	_
 22	ה	ה	DET	DET	PronType=Art	23	det:def	_	_
 23	ימין	ימין	NOUN	NOUN	Gender=Masc|Number=Sing	18	nmod	_	_
 24	.	_	PUNCT	PUNCT	_	5	punct	_	_
 
 # sent_id = 220
-# text = הם סבורים שיש אירוניה בכך שמענקי קרנות באים בדרך כלל מטיפוסים שמרניים , אך הקרן לובשת לעיתים קרובות חזות של שמאלה מהמרכז בהנהגת הפילנטרופואידים ( המונח שטבע דווייט מקדונלד בקרן פורד ) , שבסופו של דבר מנהלים אותם .
+# text = הם סבורים שיש אירוניה בכך שמענקי קרנות באים בדרך כלל מטיפוסים שמרניים, אך הקרן לובשת לעיתים קרובות חזות של שמאלה מהמרכז בהנהגת הפילנטרופואידים (המונח שטבע דווייט מקדונלד בקרן פורד), שבסופו של דבר מנהלים אותם.
 1	הם	הוא	PRON	PRON	Gender=Masc|Number=Plur|Person=3|PronType=Prs	2	nsubj	_	_
 2	סבורים	סבר	VERB	VERB	Gender=Masc|HebBinyan=PAAL|Number=Plur|Person=1,2,3|VerbForm=Part|Voice=Act	0	root	_	_
 3-4	שיש	_	_	_	_	_	_	_	_
@@ -7408,7 +7408,7 @@
 15-16	מטיפוסים	_	_	_	_	_	_	_	_
 15	מ	מ	ADP	ADP	_	16	case	_	_
 16	טיפוסים	טיפוס	NOUN	NOUN	Gender=Masc|Number=Plur	11	iobj	_	_
-17	שמרניים	שמרני	ADJ	ADJ	Gender=Masc|Number=Plur	16	amod	_	_
+17	שמרניים	שמרני	ADJ	ADJ	Gender=Masc|Number=Plur	16	amod	_	SpaceAfter=No
 18	,	_	PUNCT	PUNCT	_	11	punct	_	_
 19	אך	אך	CCONJ	CCONJ	_	22	cc	_	_
 20-21	הקרן	_	_	_	_	_	_	_	_
@@ -7430,7 +7430,7 @@
 33-34	הפילנטרופואידים	_	_	_	_	_	_	_	_
 33	ה	_	DET	DET	PronType=Art	34	det:def	_	_
 34	פילנטרופואידים	_	NOUN	NOUN	_	32	compound:smixut	_	_
-35	(	_	PUNCT	PUNCT	_	37	punct	_	_
+35	(	_	PUNCT	PUNCT	_	37	punct	_	SpaceAfter=No
 36-37	המונח	_	_	_	_	_	_	_	_
 36	ה	ה	DET	DET	PronType=Art	37	det:def	_	_
 37	מונח	מונח	NOUN	NOUN	Gender=Masc|Number=Sing	34	appos	_	_
@@ -7442,8 +7442,8 @@
 42-43	בקרן	_	_	_	_	_	_	_	_
 42	ב	ב	ADP	ADP	_	43	case	_	_
 43	קרן	קרן	NOUN	NOUN	Definite=Cons|Gender=Fem|Number=Sing	39	obl	_	_
-44	פורד	פורד	PROPN	PROPN	_	43	flat:name	_	_
-45	)	_	PUNCT	PUNCT	_	37	punct	_	_
+44	פורד	פורד	PROPN	PROPN	_	43	flat:name	_	SpaceAfter=No
+45	)	_	PUNCT	PUNCT	_	37	punct	_	SpaceAfter=No
 46	,	_	PUNCT	PUNCT	_	34	punct	_	_
 47-51	שבסופו	_	_	_	_	_	_	_	_
 47	ש	ש	SCONJ	SCONJ	_	54	mark	_	_
@@ -7454,13 +7454,13 @@
 52	של	של	PART	PART	Case=Gen	53	case:gen	_	_
 53	דבר	דבר	NOUN	NOUN	Gender=Masc|Number=Sing	49	nmod:poss	_	_
 54	מנהלים	ניהל	VERB	VERB	Gender=Masc|HebBinyan=PIEL|Number=Plur|Person=1,2,3|VerbForm=Part|Voice=Act	34	acl:relcl	_	_
-55-56	אותם	_	_	_	_	_	_	_	_
+55-56	אותם	_	_	_	_	_	_	_	SpaceAfter=No
 55	את_	את	PART	PART	Case=Acc	56	case:acc	_	_
 56	_הם	הוא	PRON	PRON	Gender=Masc|Number=Plur|Person=3|PronType=Prs	54	obj	_	_
 57	.	_	PUNCT	PUNCT	_	2	punct	_	_
 
 # sent_id = 221
-# text = קריסטול וחבריו השמרנים עשו שני דברים : ראשית , הם עודדו חברות לתעל את הפילנטרופיה שלהן ליוצאים מן הכלל של כלל זה , כמו קרן גון מ .
+# text = קריסטול וחבריו השמרנים עשו שני דברים: ראשית, הם עודדו חברות לתעל את הפילנטרופיה שלהן ליוצאים מן הכלל של כלל זה, כמו קרן גון מ.
 1	קריסטול	קריסטול	PROPN	PROPN	_	8	nsubj	_	_
 2-5	וחבריו	_	_	_	_	_	_	_	_
 2	ו	ו	CCONJ	CCONJ	_	3	cc	_	_
@@ -7472,9 +7472,9 @@
 7	שמרנים	שמרן	ADJ	ADJ	Gender=Masc|Number=Plur	3	amod	_	_
 8	עשו	עשה	VERB	VERB	Gender=Fem,Masc|HebBinyan=PAAL|Number=Plur|Person=3|Tense=Past|Voice=Act	0	root	_	_
 9	שני	שניים	NUM	NUM	Definite=Cons|Gender=Masc|Number=Plur	10	nummod	_	_
-10	דברים	דבר	NOUN	NOUN	Gender=Masc|Number=Plur	8	obj	_	_
+10	דברים	דבר	NOUN	NOUN	Gender=Masc|Number=Plur	8	obj	_	SpaceAfter=No
 11	:	_	PUNCT	PUNCT	_	15	punct	_	_
-12	ראשית	ראשית	ADV	ADV	_	15	advmod	_	_
+12	ראשית	ראשית	ADV	ADV	_	15	advmod	_	SpaceAfter=No
 13	,	_	PUNCT	PUNCT	_	15	punct	_	_
 14	הם	הוא	PRON	PRON	Gender=Masc|Number=Plur|Person=3|PronType=Prs	15	nsubj	_	_
 15	עודדו	עודד	VERB	VERB	Gender=Fem,Masc|HebBinyan=PIEL|Number=Plur|Person=3|Tense=Past|Voice=Act	10	appos	_	_
@@ -7497,17 +7497,17 @@
 28	כלל	כלל	NOUN	NOUN	Gender=Masc|Number=Sing	25	nmod	_	_
 29	של	של	PART	PART	Case=Gen	30	case	_	_
 30	כלל	כלל	NOUN	NOUN	Gender=Masc|Number=Sing	25	nmod	_	_
-31	זה	זה	PRON	PRON	Gender=Masc|Number=Sing|Person=3|PronType=Dem	30	amod	_	_
+31	זה	זה	PRON	PRON	Gender=Masc|Number=Sing|Person=3|PronType=Dem	30	amod	_	SpaceAfter=No
 32	,	_	PUNCT	PUNCT	_	25	punct	_	_
 33	כמו	כמו	ADP	ADP	_	34	case	_	_
 34	קרן	קרן	NOUN	NOUN	Definite=Cons|Gender=Fem|Number=Sing	25	nmod	_	_
 35	גון	גוון	NOUN	NOUN	Gender=Masc|Number=Sing	34	flat:name	_	_
-36	מ	מ	PROPN	PROPN	_	35	flat:name	_	_
+36	מ	מ	PROPN	PROPN	_	35	flat:name	_	SpaceAfter=No
 37	.	_	PUNCT	PUNCT	_	8	punct	_	_
 
 # sent_id = 222
-# text = שנית , הם עודדו את היוצאים מן הכלל להפעיל השפעה מודעת יותר על עיצוב מדיניות בדרג ארצי .
-1	שנית	שנית	ADV	ADV	_	4	advmod	_	_
+# text = שנית, הם עודדו את היוצאים מן הכלל להפעיל השפעה מודעת יותר על עיצוב מדיניות בדרג ארצי.
+1	שנית	שנית	ADV	ADV	_	4	advmod	_	SpaceAfter=No
 2	,	_	PUNCT	PUNCT	_	4	punct	_	_
 3	הם	הוא	PRON	PRON	Gender=Masc|Number=Plur|Person=3|PronType=Prs	4	nsubj	_	_
 4	עודדו	עודד	VERB	VERB	Gender=Fem,Masc|HebBinyan=PIEL|Number=Plur|Person=3|Tense=Past|Voice=Act	0	root	_	_
@@ -7529,11 +7529,11 @@
 18-19	בדרג	_	_	_	_	_	_	_	_
 18	ב	ב	ADP	ADP	_	19	case	_	_
 19	דרג	דרג	NOUN	NOUN	Gender=Masc|Number=Sing	16	nmod	_	_
-20	ארצי	ארצי	ADJ	ADJ	Gender=Masc|Number=Sing	19	amod	_	_
+20	ארצי	ארצי	ADJ	ADJ	Gender=Masc|Number=Sing	19	amod	_	SpaceAfter=No
 21	.	_	PUNCT	PUNCT	_	4	punct	_	_
 
 # sent_id = 223
-# text = אנשים במרכז אותה תנועה מדגישים כי לא היתה זו מזימה של הימין .
+# text = אנשים במרכז אותה תנועה מדגישים כי לא היתה זו מזימה של הימין.
 1	אנשים	איש	NOUN	NOUN	Gender=Masc|Number=Plur	6	nsubj	_	_
 2-3	במרכז	_	_	_	_	_	_	_	_
 2	ב	ב	ADP	ADP	_	3	case	_	_
@@ -7547,14 +7547,14 @@
 10	זו	זו	PRON	PRON	Gender=Fem|Number=Sing|Person=3|PronType=Dem	11	nsubj	_	_
 11	מזימה	מזימה	NOUN	NOUN	Gender=Fem|Number=Sing	6	ccomp	_	_
 12	של	של	PART	PART	Case=Gen	14	case:gen	_	_
-13-14	הימין	_	_	_	_	_	_	_	_
+13-14	הימין	_	_	_	_	_	_	_	SpaceAfter=No
 13	ה	ה	DET	DET	PronType=Art	14	det:def	_	_
 14	ימין	ימין	NOUN	NOUN	Gender=Masc|Number=Sing	11	nmod:poss	_	_
 15	.	_	PUNCT	PUNCT	_	6	punct	_	_
 
 # sent_id = 224
-# text = " איש לא אמר הבה ניצור אווירה שבה נוכל לבחור נשיא שמרן " , זוכר לזלי לנקובסקי , אחד השותפים למזימה .
-1	"	_	PUNCT	PUNCT	_	4	punct	_	_
+# text = "איש לא אמר הבה ניצור אווירה שבה נוכל לבחור נשיא שמרן", זוכר לזלי לנקובסקי, אחד השותפים למזימה.
+1	"	_	PUNCT	PUNCT	_	4	punct	_	SpaceAfter=No
 2	איש	איש	NOUN	NOUN	Gender=Masc|Number=Sing	4	nsubj	_	_
 3	לא	לא	ADV	ADV	Polarity=Neg	4	advmod	_	_
 4	אמר	אמר	VERB	VERB	Gender=Masc|HebBinyan=PAAL|Number=Sing|Person=3|Tense=Past|Voice=Act	17	iobj	_	_
@@ -7568,26 +7568,26 @@
 11	נוכל	יכול	AUX	AUX	Gender=Fem,Masc|Number=Plur|Person=1|Tense=Fut|VerbType=Mod	7	acl:relcl	_	_
 12	לבחור	בחר	VERB	VERB	HebBinyan=PAAL|VerbForm=Inf|Voice=Act	11	xcomp	_	_
 13	נשיא	נשיא	NOUN	NOUN	Gender=Masc|Number=Sing	12	obj	_	_
-14	שמרן	שמרן	ADJ	ADJ	Gender=Masc|Number=Sing	13	amod	_	_
-15	"	_	PUNCT	PUNCT	_	4	punct	_	_
+14	שמרן	שמרן	ADJ	ADJ	Gender=Masc|Number=Sing	13	amod	_	SpaceAfter=No
+15	"	_	PUNCT	PUNCT	_	4	punct	_	SpaceAfter=No
 16	,	_	PUNCT	PUNCT	_	17	punct	_	_
 17	זוכר	זכר	VERB	VERB	Gender=Masc|HebBinyan=PAAL|Number=Sing|Person=1,2,3|VerbForm=Part|Voice=Act	0	root	_	_
 18	לזלי	לזלי	PROPN	PROPN	_	17	nsubj	_	_
-19	לנקובסקי	לנקובסקי	PROPN	PROPN	_	18	flat:name	_	_
+19	לנקובסקי	לנקובסקי	PROPN	PROPN	_	18	flat:name	_	SpaceAfter=No
 20	,	_	PUNCT	PUNCT	_	18	punct	_	_
 21	אחד	אחד	NUM	NUM	Definite=Cons|Gender=Masc|Number=Sing	23	nummod	_	_
 22-23	השותפים	_	_	_	_	_	_	_	_
 22	ה	ה	DET	DET	PronType=Art	23	det:def	_	_
 23	שותפים	שותף	NOUN	NOUN	Gender=Masc|Number=Plur	18	appos	_	_
-24-26	למזימה	_	_	_	_	_	_	_	_
+24-26	למזימה	_	_	_	_	_	_	_	SpaceAfter=No
 24	ל	ל	ADP	ADP	_	26	case	_	_
 25	ה_	ה	DET	DET	PronType=Art	26	det:def	_	_
 26	מזימה	מזימה	NOUN	NOUN	Gender=Fem|Number=Sing	23	nmod	_	_
 27	.	_	PUNCT	PUNCT	_	17	punct	_	_
 
 # sent_id = 225
-# text = לנקובסקי , שניהל את קרן סמית - ריצרדסון וכיום מנהל את מכון הדסון , אומר כי הרעיון לא היה כל - כך לתת מענקים לחשיבה הימנית כשלעצמה , אלא לתגמל חלופות לכל החשיבה השמאלית שקיבלה עד אז תגמולים ומימון .
-1	לנקובסקי	לנקובסקי	PROPN	PROPN	_	17	nsubj	_	_
+# text = לנקובסקי, שניהל את קרן סמית - ריצרדסון וכיום מנהל את מכון הדסון, אומר כי הרעיון לא היה כל - כך לתת מענקים לחשיבה הימנית כשלעצמה, אלא לתגמל חלופות לכל החשיבה השמאלית שקיבלה עד אז תגמולים ומימון.
+1	לנקובסקי	לנקובסקי	PROPN	PROPN	_	17	nsubj	_	SpaceAfter=No
 2	,	_	PUNCT	PUNCT	_	1	punct	_	_
 3-4	שניהל	_	_	_	_	_	_	_	_
 3	ש	ש	SCONJ	SCONJ	_	4	mark	_	_
@@ -7603,7 +7603,7 @@
 12	מנהל	ניהל	VERB	VERB	Gender=Masc|HebBinyan=PIEL|Number=Sing|Person=1,2,3|VerbForm=Part|Voice=Act	4	conj	_	_
 13	את	את	PART	PART	Case=Acc	14	case:acc	_	_
 14	מכון	מכון	NOUN	NOUN	Definite=Cons|Gender=Masc|Number=Sing	12	obj	_	_
-15	הדסון	הדסון	PROPN	PROPN	_	14	flat:name	_	_
+15	הדסון	הדסון	PROPN	PROPN	_	14	flat:name	_	SpaceAfter=No
 16	,	_	PUNCT	PUNCT	_	17	punct	_	_
 17	אומר	אמר	VERB	VERB	Gender=Masc|HebBinyan=PAAL|Number=Sing|Person=1,2,3|VerbForm=Part|Voice=Act	0	root	_	_
 18	כי	כי	SCONJ	SCONJ	_	26	mark	_	_
@@ -7624,7 +7624,7 @@
 31-32	הימנית	_	_	_	_	_	_	_	_
 31	ה	ה	DET	DET	PronType=Art	32	det:def	_	_
 32	ימנית	ימני	ADJ	ADJ	Gender=Fem|Number=Sing	30	amod	_	_
-33-35	כשלעצמה	_	_	_	_	_	_	_	_
+33-35	כשלעצמה	_	_	_	_	_	_	_	SpaceAfter=No
 33	כש	כש	SCONJ	SCONJ	Case=Tem	35	case	_	_
 34	ל	ל	ADP	ADP	_	35	case	_	_
 35	עצמה	עצמו	PRON	PRON	Gender=Fem|Number=Sing|Person=3|PronType=Prs|Reflex=Yes	30	nmod	_	_
@@ -7647,13 +7647,13 @@
 48	עד	עד	ADP	ADP	_	49	case	_	_
 49	אז	אז	ADV	ADV	_	47	obl	_	_
 50	תגמולים	תגמול	NOUN	NOUN	Gender=Masc|Number=Plur	47	obj	_	_
-51-52	ומימון	_	_	_	_	_	_	_	_
+51-52	ומימון	_	_	_	_	_	_	_	SpaceAfter=No
 51	ו	ו	CCONJ	CCONJ	_	52	cc	_	_
 52	מימון	מימון	NOUN	NOUN	Gender=Masc|Number=Sing	50	conj	_	_
 53	.	_	PUNCT	PUNCT	_	17	punct	_	_
 
 # sent_id = 226
-# text = הוא וקריסטול והאחרים פשוט חשו ש"קיים מגוון שלם של נושאים הראויים לבדיקה " .
+# text = הוא וקריסטול והאחרים פשוט חשו ש"קיים מגוון שלם של נושאים הראויים לבדיקה ".
 1	הוא	הוא	PRON	PRON	Gender=Masc|Number=Sing|Person=3|PronType=Prs	8	nsubj	_	_
 2-3	וקריסטול	_	_	_	_	_	_	_	_
 2	ו	_	CCONJ	CCONJ	_	3	cc	_	_
@@ -7678,17 +7678,17 @@
 18-19	לבדיקה	_	_	_	_	_	_	_	_
 18	ל	ל	ADP	ADP	_	19	case	_	_
 19	בדיקה	בדיקה	NOUN	NOUN	Gender=Fem|Number=Sing	17	iobj	_	_
-20	"	_	PUNCT	PUNCT	_	11	punct	_	_
+20	"	_	PUNCT	PUNCT	_	11	punct	_	SpaceAfter=No
 21	.	_	PUNCT	PUNCT	_	8	punct	_	_
 
 # sent_id = 227
-# text = הם פשוט תהו , נזכר לנקובסקי , " למי יש רעיונות מעניינים ? " .
+# text = הם פשוט תהו, נזכר לנקובסקי, " למי יש רעיונות מעניינים? ".
 1	הם	הוא	PRON	PRON	Gender=Masc|Number=Plur|Person=3|PronType=Prs	3	nsubj	_	_
 2	פשוט	פשוט	ADV	ADV	_	3	advmod	_	_
-3	תהו	תהה	VERB	VERB	Gender=Fem,Masc|HebBinyan=PAAL|Number=Plur|Person=3|Tense=Past|Voice=Act	0	root	_	_
+3	תהו	תהה	VERB	VERB	Gender=Fem,Masc|HebBinyan=PAAL|Number=Plur|Person=3|Tense=Past|Voice=Act	0	root	_	SpaceAfter=No
 4	,	_	PUNCT	PUNCT	_	5	punct	_	_
 5	נזכר	נזכר	VERB	VERB	Gender=Masc|HebBinyan=NIFAL|Number=Sing|Person=1,2,3|VerbForm=Part|Voice=Mid	3	parataxis	_	_
-6	לנקובסקי	לנקובסקי	PROPN	PROPN	_	5	nsubj	_	_
+6	לנקובסקי	לנקובסקי	PROPN	PROPN	_	5	nsubj	_	SpaceAfter=No
 7	,	_	PUNCT	PUNCT	_	5	punct	_	_
 8	"	_	PUNCT	PUNCT	_	11	punct	_	_
 9-10	למי	_	_	_	_	_	_	_	_
@@ -7696,14 +7696,14 @@
 10	מי	מי	ADV	ADV	PronType=Int	11	iobj	_	_
 11	יש	יש	VERB	VERB	HebExistential=True	3	iobj	_	_
 12	רעיונות	רעיון	NOUN	NOUN	Gender=Masc|Number=Plur	11	nsubj	_	_
-13	מעניינים	מעניין	ADJ	ADJ	Gender=Masc|Number=Plur	12	amod	_	_
+13	מעניינים	מעניין	ADJ	ADJ	Gender=Masc|Number=Plur	12	amod	_	SpaceAfter=No
 14	?	_	PUNCT	PUNCT	_	11	punct	_	_
-15	"	_	PUNCT	PUNCT	_	11	punct	_	_
+15	"	_	PUNCT	PUNCT	_	11	punct	_	SpaceAfter=No
 16	.	_	PUNCT	PUNCT	_	3	punct	_	_
 
 # sent_id = 228
-# text = ובכן , התברר שבעלי הרעיונות המעניינים היו אנשים כמו רוברט בורק , מרטין פלדסטיין , צארלס מאריי ואלן בלום שגם הודות לתמיכה הפילנטרופית שקיבלו בשנות ה70 ואו בראשית שנות ה80 אין צורך להציגם בציבור .
-1	ובכן	ובכן	ADV	ADV	_	3	advmod	_	_
+# text = ובכן, התברר שבעלי הרעיונות המעניינים היו אנשים כמו רוברט בורק, מרטין פלדסטיין, צארלס מאריי ואלן בלום שגם הודות לתמיכה הפילנטרופית שקיבלו בשנות ה70 ואו בראשית שנות ה80 אין צורך להציגם בציבור.
+1	ובכן	ובכן	ADV	ADV	_	3	advmod	_	SpaceAfter=No
 2	,	_	PUNCT	PUNCT	_	3	punct	_	_
 3	התברר	התברר	VERB	VERB	Gender=Masc|HebBinyan=HITPAEL|Number=Sing|Person=3|Tense=Past	0	root	_	_
 4-5	שבעלי	_	_	_	_	_	_	_	_
@@ -7719,10 +7719,10 @@
 11	אנשים	איש	NOUN	NOUN	Gender=Masc|Number=Plur	3	ccomp	_	_
 12	כמו	כמו	ADP	ADP	_	13	case	_	_
 13	רוברט	רוברט	PROPN	PROPN	_	11	nmod	_	_
-14	בורק	בורק	PROPN	PROPN	_	13	flat:name	_	_
+14	בורק	בורק	PROPN	PROPN	_	13	flat:name	_	SpaceAfter=No
 15	,	_	PUNCT	PUNCT	_	13	punct	_	_
 16	מרטין	מרטין	PROPN	PROPN	_	13	conj	_	_
-17	פלדסטיין	פלדסטיין	PROPN	PROPN	_	16	flat:name	_	_
+17	פלדסטיין	פלדסטיין	PROPN	PROPN	_	16	flat:name	_	SpaceAfter=No
 18	,	_	PUNCT	PUNCT	_	13	punct	_	_
 19	צארלס	צארלס	PROPN	PROPN	_	13	conj	_	_
 20	מאריי	מאריי	PROPN	PROPN	_	19	flat:name	_	_
@@ -7765,14 +7765,14 @@
 47-48	להציגם	_	_	_	_	_	_	_	_
 47	להציגם	הציג	VERB	VERB	HebBinyan=HIFIL|VerbForm=Inf|Voice=Act	46	acl:inf	_	_
 48	_הם	הוא	PRON	PRON	Case=Acc|Gender=Masc|Number=Plur|Person=3|PronType=Prs	47	obj	_	_
-49-51	בציבור	_	_	_	_	_	_	_	_
+49-51	בציבור	_	_	_	_	_	_	_	SpaceAfter=No
 49	ב	ב	ADP	ADP	_	51	case	_	_
 50	ה_	ה	DET	DET	PronType=Art	51	det:def	_	_
 51	ציבור	ציבור	NOUN	NOUN	Gender=Masc|Number=Sing	47	obl	_	_
 52	.	_	PUNCT	PUNCT	_	3	punct	_	_
 
 # sent_id = 229
-# text = אם אתה משמיע באוזני השמרנים רמז לכך שקריסטול ושות הפכו את הקערה על פיה , ולכן כיום כסף ימני הוא החולש בכיפה בעולם הרעיונות , הם יפנו אותך לרשימת הקרנות הפילנטרופיות הגדולות ביותר , ויזכירו לך שמבין הקרנות השמרניות אולין , סמית - ריצרדסון , לינד והרי בראדלו , פיו , שרה סקאיף רק פיו כלולה ברשימת הגדולות .
+# text = אם אתה משמיע באוזני השמרנים רמז לכך שקריסטול ושות הפכו את הקערה על פיה, ולכן כיום כסף ימני הוא החולש בכיפה בעולם הרעיונות, הם יפנו אותך לרשימת הקרנות הפילנטרופיות הגדולות ביותר, ויזכירו לך שמבין הקרנות השמרניות אולין, סמית - ריצרדסון, לינד והרי בראדלו, פיו, שרה סקאיף רק פיו כלולה ברשימת הגדולות.
 1	אם	אם	SCONJ	SCONJ	_	3	mark	_	_
 2	אתה	הוא	PRON	PRON	Gender=Masc|Number=Sing|Person=2|PronType=Prs	3	nsubj	_	_
 3	משמיע	השמיע	VERB	VERB	Gender=Masc|HebBinyan=HIFIL|Number=Sing|Person=1,2,3|VerbForm=Part|Voice=Act	40	advcl	_	_
@@ -7796,7 +7796,7 @@
 16	ה	ה	DET	DET	PronType=Art	17	det:def	_	_
 17	קערה	קערה	NOUN	NOUN	Gender=Fem|Number=Sing	14	obj	_	_
 18	על	על	ADP	ADP	_	19	case	_	_
-19-21	פיה	_	_	_	_	_	_	_	_
+19-21	פיה	_	_	_	_	_	_	_	SpaceAfter=No
 19	פה_	פה	NOUN	NOUN	Definite=Def|Gender=Masc|Number=Sing	14	obl	_	_
 20	_של_	של	ADP	ADP	_	21	case:gen	_	_
 21	_היא	הוא	PRON	PRON	Case=Gen|Gender=Fem|Number=Sing|Person=3|PronType=Prs	19	nmod:poss	_	_
@@ -7818,7 +7818,7 @@
 34-35	בעולם	_	_	_	_	_	_	_	_
 34	ב	ב	ADP	ADP	_	35	case	_	_
 35	עולם	עולם	NOUN	NOUN	Definite=Cons|Gender=Masc|Number=Sing	30	obl	_	_
-36-37	הרעיונות	_	_	_	_	_	_	_	_
+36-37	הרעיונות	_	_	_	_	_	_	_	SpaceAfter=No
 36	ה	ה	DET	DET	PronType=Art	37	det:def	_	_
 37	רעיונות	רעיון	NOUN	NOUN	Gender=Masc|Number=Plur	35	compound:smixut	_	_
 38	,	_	PUNCT	PUNCT	_	40	punct	_	_
@@ -7839,7 +7839,7 @@
 49-50	הגדולות	_	_	_	_	_	_	_	_
 49	ה	ה	DET	DET	PronType=Art	50	det:def	_	_
 50	גדולות	גדול	ADJ	ADJ	Gender=Fem|Number=Plur	46	amod	_	_
-51	ביותר	ביותר	ADV	ADV	_	50	advmod	_	_
+51	ביותר	ביותר	ADV	ADV	_	50	advmod	_	SpaceAfter=No
 52	,	_	PUNCT	PUNCT	_	40	punct	_	_
 53-54	ויזכירו	_	_	_	_	_	_	_	_
 53	ו	ו	CCONJ	CCONJ	_	54	cc	_	_
@@ -7856,19 +7856,19 @@
 61-62	השמרניות	_	_	_	_	_	_	_	_
 61	ה	ה	DET	DET	PronType=Art	62	det:def	_	_
 62	שמרניות	שמרני	ADJ	ADJ	Gender=Fem|Number=Plur	60	amod	_	_
-63	אולין	אולין	PROPN	PROPN	_	60	nmod	_	_
+63	אולין	אולין	PROPN	PROPN	_	60	nmod	_	SpaceAfter=No
 64	,	_	PUNCT	PUNCT	_	63	punct	_	_
 65	סמית	סמית	PROPN	PROPN	_	63	conj	_	_
 66	-	_	PUNCT	PUNCT	_	65	flat:name	_	_
-67	ריצרדסון	ריצרדסון	PROPN	PROPN	_	65	flat:name	_	_
+67	ריצרדסון	ריצרדסון	PROPN	PROPN	_	65	flat:name	_	SpaceAfter=No
 68	,	_	PUNCT	PUNCT	_	63	punct	_	_
 69	לינד	לינד	PROPN	PROPN	_	63	conj	_	_
 70-71	והרי	_	_	_	_	_	_	_	_
 70	ו	ו	CCONJ	CCONJ	_	71	cc	_	_
 71	הרי	הרי	PROPN	PROPN	_	69	conj	_	_
-72	בראדלו	בראדלו	PROPN	PROPN	_	71	flat:name	_	_
+72	בראדלו	בראדלו	PROPN	PROPN	_	71	flat:name	_	SpaceAfter=No
 73	,	_	PUNCT	PUNCT	_	63	punct	_	_
-74	פיו	פה	PROPN	PROPN	_	63	conj	_	_
+74	פיו	פה	PROPN	PROPN	_	63	conj	_	SpaceAfter=No
 75	,	_	PUNCT	PUNCT	_	63	punct	_	_
 76	שרה	שרה	PROPN	PROPN	_	63	conj	_	_
 77	סקאיף	סקאיף	PROPN	PROPN	_	76	flat:name	_	_
@@ -7878,24 +7878,24 @@
 81-82	ברשימת	_	_	_	_	_	_	_	_
 81	ב	ב	ADP	ADP	_	82	case	_	_
 82	רשימת	רשימה	NOUN	NOUN	Definite=Cons|Gender=Fem|Number=Sing	80	iobj	_	_
-83-84	הגדולות	_	_	_	_	_	_	_	_
+83-84	הגדולות	_	_	_	_	_	_	_	SpaceAfter=No
 83	ה	ה	DET	DET	PronType=Art	84	det:def	_	_
 84	גדולות	גדולות	NOUN	NOUN	Gender=Fem|Number=Sing	82	compound:smixut	_	_
 85	.	_	PUNCT	PUNCT	_	40	punct	_	_
 
 # sent_id = 230
-# text = בהחלט נכון .
+# text = בהחלט נכון.
 1	בהחלט	בהחלט	ADV	ADV	_	2	advmod	_	_
-2	נכון	נכון	ADJ	ADJ	Gender=Masc|Number=Sing	0	root	_	_
+2	נכון	נכון	ADJ	ADJ	Gender=Masc|Number=Sing	0	root	_	SpaceAfter=No
 3	.	_	PUNCT	PUNCT	_	2	punct	_	_
 
 # sent_id = 231
-# text = ולא זו בלבד , אלא נכון גם שקרן מקארתור , הדוגמה השכיחה ביותר לליברליזם המבולבל של שנות ה60 , אכן ראויה לתיאור זה .
+# text = ולא זו בלבד, אלא נכון גם שקרן מקארתור, הדוגמה השכיחה ביותר לליברליזם המבולבל של שנות ה60, אכן ראויה לתיאור זה.
 1-2	ולא	_	_	_	_	_	_	_	_
 1	ו	ו	CCONJ	CCONJ	_	0	root	_	_
 2	לא	לא	ADV	ADV	HebSource=ConvUncertainHead|Polarity=Neg	1	dep	_	_
 3	זו	זו	PRON	PRON	Gender=Fem|Number=Sing|Person=3|PronType=Dem	2	fixed	_	_
-4	בלבד	בלבד	ADV	ADV	_	2	fixed	_	_
+4	בלבד	בלבד	ADV	ADV	_	2	fixed	_	SpaceAfter=No
 5	,	_	PUNCT	PUNCT	_	1	punct	_	_
 6	אלא	אלא	CCONJ	CCONJ	_	7	cc	_	_
 7	נכון	נכון	ADJ	ADJ	Gender=Masc|Number=Sing	1	conj	_	_
@@ -7903,7 +7903,7 @@
 9-10	שקרן	_	_	_	_	_	_	_	_
 9	ש	ש	SCONJ	SCONJ	_	29	mark	_	_
 10	קרן	קרן	NOUN	NOUN	Definite=Cons|Gender=Fem|Number=Sing	29	nsubj	_	_
-11	מקארתור	מקארתור	PROPN	PROPN	_	10	flat:name	_	_
+11	מקארתור	מקארתור	PROPN	PROPN	_	10	flat:name	_	SpaceAfter=No
 12	,	_	PUNCT	PUNCT	_	10	punct	_	_
 13-14	הדוגמה	_	_	_	_	_	_	_	_
 13	ה	ה	DET	DET	PronType=Art	14	det:def	_	_
@@ -7921,7 +7921,7 @@
 22	מבולבל	מבולבל	ADJ	ADJ	Gender=Masc|Number=Sing	20	amod	_	_
 23	של	של	PART	PART	Case=Gen	24	case:gen	_	_
 24	שנות	שנה	NOUN	NOUN	Definite=Cons|Gender=Fem|Number=Plur	20	nmod:poss	_	_
-25-26	ה60	_	_	_	_	_	_	_	_
+25-26	ה60	_	_	_	_	_	_	_	SpaceAfter=No
 25	ה	ה	DET	DET	PronType=Art	26	det:def	_	_
 26	60	_	NUM	NUM	_	24	compound:smixut	_	_
 27	,	_	PUNCT	PUNCT	_	29	punct	_	_
@@ -7930,11 +7930,11 @@
 30-31	לתיאור	_	_	_	_	_	_	_	_
 30	ל	ל	ADP	ADP	_	31	case	_	_
 31	תיאור	תיאור	NOUN	NOUN	Gender=Masc|Number=Sing	29	iobj	_	_
-32	זה	זה	PRON	PRON	Gender=Masc|Number=Sing|Person=3|PronType=Dem	31	amod	_	_
+32	זה	זה	PRON	PRON	Gender=Masc|Number=Sing|Person=3|PronType=Dem	31	amod	_	SpaceAfter=No
 33	.	_	PUNCT	PUNCT	_	1	punct	_	_
 
 # sent_id = 232
-# text = לפני כמה שנים תרמה הקרן 82000 דולר לאוניברסיטת קיימברידג לניסיונו של סטיוון הוקינג לאחד את תיאוריית הקוונטים ותיאוריית היחסות של איינשטיין .
+# text = לפני כמה שנים תרמה הקרן 82000 דולר לאוניברסיטת קיימברידג לניסיונו של סטיוון הוקינג לאחד את תיאוריית הקוונטים ותיאוריית היחסות של איינשטיין.
 1	לפני	לפני	ADP	ADP	_	3	case	_	_
 2	כמה	כמה	DET	DET	Definite=Cons	3	det	_	_
 3	שנים	שנה	NOUN	NOUN	Gender=Fem|Number=Plur	4	obl	_	_
@@ -7969,11 +7969,11 @@
 26	ה	ה	DET	DET	PronType=Art	27	det:def	_	_
 27	יחסות	יחסות	NOUN	NOUN	Gender=Fem|Number=Sing	25	compound:smixut	_	_
 28	של	של	PART	PART	Case=Gen	29	case:gen	_	_
-29	איינשטיין	איינשטיין	PROPN	PROPN	_	25	nmod:poss	_	_
+29	איינשטיין	איינשטיין	PROPN	PROPN	_	25	nmod:poss	_	SpaceAfter=No
 30	.	_	PUNCT	PUNCT	_	4	punct	_	_
 
 # sent_id = 233
-# text = כיום היתה תיאוריה כזו בחזקת מציאה גם במחיר כפול .
+# text = כיום היתה תיאוריה כזו בחזקת מציאה גם במחיר כפול.
 1	כיום	כיום	ADV	ADV	_	8	advmod	_	_
 2	היתה	היה	VERB	VERB	Gender=Fem|Number=Sing|Person=3|Polarity=Pos|Tense=Past|VerbType=Cop	8	aux	_	_
 3	תיאוריה	תיאוריה	NOUN	NOUN	Gender=Fem|Number=Sing	8	nsubj	_	_
@@ -7989,11 +7989,11 @@
 11-12	במחיר	_	_	_	_	_	_	_	_
 11	ב	ב	ADP	ADP	_	12	case	_	_
 12	מחיר	מחיר	NOUN	NOUN	Gender=Masc|Number=Sing	8	nmod	_	_
-13	כפול	כפול	ADJ	ADJ	Gender=Masc|Number=Sing	12	amod	_	_
+13	כפול	כפול	ADJ	ADJ	Gender=Masc|Number=Sing	12	amod	_	SpaceAfter=No
 14	.	_	PUNCT	PUNCT	_	8	punct	_	_
 
 # sent_id = 234
-# text = אבל כמה כסף העניקה קרן מקארתור לפיסיקאים מבריקים המתעמקים בבעיה זו ואינם סובלים משיתוק טרגי בעקבות מחלה מנוונת חסרת רחמים ?
+# text = אבל כמה כסף העניקה קרן מקארתור לפיסיקאים מבריקים המתעמקים בבעיה זו ואינם סובלים משיתוק טרגי בעקבות מחלה מנוונת חסרת רחמים?
 1	אבל	אבל	CCONJ	CCONJ	_	4	cc	_	_
 2	כמה	כמה	DET	DET	Definite=Cons	3	det	_	_
 3	כסף	כסף	NOUN	NOUN	Gender=Masc|Number=Sing	4	obj	_	_
@@ -8023,13 +8023,13 @@
 22	מחלה	מחלה	NOUN	NOUN	Gender=Fem|Number=Sing	17	obl	_	_
 23	מנוונת	מנוון	ADJ	ADJ	Gender=Fem|Number=Sing	22	amod	_	_
 24	חסרת	חסר	ADJ	ADJ	Definite=Cons|Gender=Fem|Number=Sing	22	amod	_	_
-25	רחמים	רחמים	NOUN	NOUN	Gender=Masc|Number=Plur	24	compound:smixut	_	_
+25	רחמים	רחמים	NOUN	NOUN	Gender=Masc|Number=Plur	24	compound:smixut	_	SpaceAfter=No
 26	?	_	PUNCT	PUNCT	_	4	punct	_	_
 
 # sent_id = 235
-# text = עם זאת , גם הקרנות בעלות השמות הגדולים אינן בהכרח מעיינות החשיבה הליברלית הסטריאוטיפית כפי שלעתים קרובות מתארים אותן .
+# text = עם זאת, גם הקרנות בעלות השמות הגדולים אינן בהכרח מעיינות החשיבה הליברלית הסטריאוטיפית כפי שלעתים קרובות מתארים אותן.
 1	עם	עם	ADP	ADP	_	2	case	_	_
-2	זאת	זאת	PRON	PRON	Gender=Fem|Number=Sing|Person=3|PronType=Dem	14	nmod	_	_
+2	זאת	זאת	PRON	PRON	Gender=Fem|Number=Sing|Person=3|PronType=Dem	14	nmod	_	SpaceAfter=No
 3	,	_	PUNCT	PUNCT	_	14	punct	_	_
 4	גם	גם	ADV	ADV	_	6	det	_	_
 5-6	הקרנות	_	_	_	_	_	_	_	_
@@ -8061,13 +8061,13 @@
 24	עתים	עת	NOUN	NOUN	Gender=Fem|Number=Plur	23	fixed	_	_
 25	קרובות	קרוב	ADJ	ADJ	Gender=Fem|Number=Plur	23	fixed	_	_
 26	מתארים	תיאר	VERB	VERB	Gender=Masc|HebBinyan=PIEL|Number=Plur|Person=1,2,3|VerbForm=Part|Voice=Act	14	nmod	_	_
-27-28	אותן	_	_	_	_	_	_	_	_
+27-28	אותן	_	_	_	_	_	_	_	SpaceAfter=No
 27	את_	את	PART	PART	Case=Acc	28	case:acc	_	_
 28	_הן	הוא	PRON	PRON	Gender=Fem|Number=Plur|Person=3|PronType=Prs	26	obj	_	_
 29	.	_	PUNCT	PUNCT	_	14	punct	_	_
 
 # sent_id = 236
-# text = קרן רוקפלר אמנם מוכנה לחלק פה ושם 52000 דולר ללימוד " פמיניזם ותיאוריה מוסרית : מבוא לאתיקה לחברות פוסט - תעשייתיות " .
+# text = קרן רוקפלר אמנם מוכנה לחלק פה ושם 52000 דולר ללימוד " פמיניזם ותיאוריה מוסרית: מבוא לאתיקה לחברות פוסט - תעשייתיות ".
 1	קרן	קרן	NOUN	NOUN	Definite=Cons|Gender=Fem|Number=Sing	4	nsubj	_	_
 2	רוקפלר	רוקפלר	PROPN	PROPN	_	1	flat:name	_	_
 3	אמנם	אמנם	ADV	ADV	_	4	advmod	_	_
@@ -8087,7 +8087,7 @@
 15-16	ותיאוריה	_	_	_	_	_	_	_	_
 15	ו	ו	CCONJ	CCONJ	_	16	cc	_	_
 16	תיאוריה	תיאוריה	NOUN	NOUN	Gender=Fem|Number=Sing	14	conj	_	_
-17	מוסרית	מוסרי	ADJ	ADJ	Gender=Fem|Number=Sing	16	amod	_	_
+17	מוסרית	מוסרי	ADJ	ADJ	Gender=Fem|Number=Sing	16	amod	_	SpaceAfter=No
 18	:	_	PUNCT	PUNCT	_	14	punct	_	_
 19	מבוא	מבוא	NOUN	NOUN	Gender=Masc|Number=Sing	14	nmod	_	_
 20-21	לאתיקה	_	_	_	_	_	_	_	_
@@ -8099,11 +8099,11 @@
 24	פוסט	פוסט	ADV	ADV	Prefix=Yes	26	advmod	_	_
 25	-	_	PUNCT	PUNCT	_	26	punct	_	_
 26	תעשייתיות	תעשייתי	ADJ	ADJ	Gender=Fem|Number=Plur	23	amod	_	_
-27	"	_	PUNCT	PUNCT	_	14	punct	_	_
+27	"	_	PUNCT	PUNCT	_	14	punct	_	SpaceAfter=No
 28	.	_	PUNCT	PUNCT	_	4	punct	_	_
 
 # sent_id = 237
-# text = אבל אתה יכול לעיין בעשרות דפי דו"ח רוקפלר השנתי בלי למצוא פריט הוצאה שקל כל כך ללעוג לו .
+# text = אבל אתה יכול לעיין בעשרות דפי דו"ח רוקפלר השנתי בלי למצוא פריט הוצאה שקל כל כך ללעוג לו.
 1	אבל	אבל	CCONJ	CCONJ	_	3	cc	_	_
 2	אתה	הוא	PRON	PRON	Gender=Masc|Number=Sing|Person=2|PronType=Prs	3	nsubj	_	_
 3	יכול	_	AUX	AUX	Gender=Masc|Number=Sing|Person=1,2,3|VerbForm=Part|VerbType=Mod	0	root	_	_
@@ -8127,13 +8127,13 @@
 18	כל	כול	DET	DET	Definite=Cons	17	advmod	_	_
 19	כך	כך	ADV	ADV	_	18	fixed	_	_
 20	ללעוג	לעג	VERB	VERB	HebBinyan=PAAL|VerbForm=Inf|Voice=Act	17	xcomp	_	_
-21-22	לו	_	_	_	_	_	_	_	_
+21-22	לו	_	_	_	_	_	_	_	SpaceAfter=No
 21	לו	ל	ADP	ADP	_	22	case	_	_
 22	_הוא	הוא	PRON	PRON	Gender=Masc|Number=Sing|Person=3|PronType=Prs	20	iobj	_	_
 23	.	_	PUNCT	PUNCT	_	3	punct	_	_
 
 # sent_id = 238
-# text = אשר לקרן פורד שמרנים מתלוננים שמדיניות העדפת שחורים כקיזוז לאפליית העבר ( עצה מספר 7 , היה שחור ) שהיא נוקטת , היא שריד לליברליזם קדום .
+# text = אשר לקרן פורד שמרנים מתלוננים שמדיניות העדפת שחורים כקיזוז לאפליית העבר (עצה מספר 7, היה שחור) שהיא נוקטת, היא שריד לליברליזם קדום.
 1	אשר	אשר	SCONJ	SCONJ	_	3	case	_	_
 2-3	לקרן	_	_	_	_	_	_	_	_
 2	ל	ל	ADP	ADP	_	3	case	_	_
@@ -8155,29 +8155,29 @@
 15-16	העבר	_	_	_	_	_	_	_	_
 15	ה	ה	DET	DET	PronType=Art	16	det:def	_	_
 16	עבר	עבר	NOUN	NOUN	Gender=Masc|Number=Sing	14	compound:smixut	_	_
-17	(	_	PUNCT	PUNCT	_	23	punct	_	_
+17	(	_	PUNCT	PUNCT	_	23	punct	_	SpaceAfter=No
 18	עצה	עצה	NOUN	NOUN	Gender=Fem|Number=Sing	23	nsubj	_	_
 19	מספר	מספר	NOUN	NOUN	Gender=Masc|HebSource=ConvUncertainLabel|Number=Sing	18	nmod	_	_
-20	7	_	NUM	NUM	_	19	nummod	_	_
+20	7	_	NUM	NUM	_	19	nummod	_	SpaceAfter=No
 21	,	_	PUNCT	PUNCT	_	23	punct	_	_
 22	היה	היה	VERB	VERB	Gender=Masc|Mood=Imp|Number=Sing|Person=2|Polarity=Pos|VerbType=Cop	23	aux	_	_
-23	שחור	שחור	ADJ	ADJ	Gender=Masc|Number=Sing	8	appos	_	_
+23	שחור	שחור	ADJ	ADJ	Gender=Masc|Number=Sing	8	appos	_	SpaceAfter=No
 24	)	_	PUNCT	PUNCT	_	23	punct	_	_
 25-26	שהיא	_	_	_	_	_	_	_	_
 25	ש	ש	SCONJ	SCONJ	_	27	mark	_	_
 26	היא	הוא	PRON	PRON	Gender=Fem|Number=Sing|Person=3|PronType=Prs	27	nsubj	_	_
-27	נוקטת	נקט	VERB	VERB	Gender=Fem|HebBinyan=PAAL|Number=Sing|Person=1,2,3|VerbForm=Part|Voice=Act	8	acl:relcl	_	_
+27	נוקטת	נקט	VERB	VERB	Gender=Fem|HebBinyan=PAAL|Number=Sing|Person=1,2,3|VerbForm=Part|Voice=Act	8	acl:relcl	_	SpaceAfter=No
 28	,	_	PUNCT	PUNCT	_	30	punct	_	_
 29	היא	הוא	VERB	VERB	Gender=Fem|Number=Sing|Person=3|Polarity=Pos|VerbForm=Part|VerbType=Cop	30	cop	_	_
 30	שריד	שריד	NOUN	NOUN	Gender=Masc|Number=Sing	6	ccomp	_	_
 31-32	לליברליזם	_	_	_	_	_	_	_	_
 31	ל	ל	ADP	ADP	_	32	case	_	_
 32	ליברליזם	ליברליזם	NOUN	NOUN	Gender=Masc|Number=Sing	30	nmod	_	_
-33	קדום	קדום	ADJ	ADJ	Gender=Masc|Number=Sing	32	amod	_	_
+33	קדום	קדום	ADJ	ADJ	Gender=Masc|Number=Sing	32	amod	_	SpaceAfter=No
 34	.	_	PUNCT	PUNCT	_	6	punct	_	_
 
 # sent_id = 239
-# text = ואין ספק שחלק נכבד מבין 50 אלף הצקים שעליהם חותמת הקרן נמסר לקבוצות כמו " פראפראז " , כדי " לשרטט את מסלול המורשת השחורה באיסט סייד התחתית של ניו - יורק " .
+# text = ואין ספק שחלק נכבד מבין 50 אלף הצקים שעליהם חותמת הקרן נמסר לקבוצות כמו "פראפראז", כדי "לשרטט את מסלול המורשת השחורה באיסט סייד התחתית של ניו - יורק".
 1-2	ואין	_	_	_	_	_	_	_	_
 1	ו	ו	CCONJ	CCONJ	_	2	cc	_	_
 2	אין	אין	VERB	VERB	HebExistential=True	0	root	_	_
@@ -8205,12 +8205,12 @@
 19	ל	ל	ADP	ADP	_	20	case	_	_
 20	קבוצות	קבוצה	NOUN	NOUN	Gender=Fem|Number=Plur	18	iobj	_	_
 21	כמו	כמו	ADP	ADP	_	23	case	_	_
-22	"	_	PUNCT	PUNCT	_	23	punct	_	_
-23	פראפראז	פראפראז	PROPN	PROPN	_	20	nmod	_	_
-24	"	_	PUNCT	PUNCT	_	23	punct	_	_
+22	"	_	PUNCT	PUNCT	_	23	punct	_	SpaceAfter=No
+23	פראפראז	פראפראז	PROPN	PROPN	_	20	nmod	_	SpaceAfter=No
+24	"	_	PUNCT	PUNCT	_	23	punct	_	SpaceAfter=No
 25	,	_	PUNCT	PUNCT	_	18	punct	_	_
 26	כדי	_	ADP	ADP	_	28	case	_	_
-27	"	_	PUNCT	PUNCT	_	28	punct	_	_
+27	"	_	PUNCT	PUNCT	_	28	punct	_	SpaceAfter=No
 28	לשרטט	שרטט	VERB	VERB	HebBinyan=PIEL|VerbForm=Inf|Voice=Act	18	advcl	_	_
 29	את	את	PART	PART	Case=Acc	30	case:acc	_	_
 30	מסלול	מסלול	NOUN	NOUN	Definite=Cons|Gender=Masc|Number=Sing	28	obj	_	_
@@ -8231,21 +8231,21 @@
 41	של	של	PART	PART	Case=Gen	42	case:gen	_	_
 42	ניו	ניו	PROPN	PROPN	_	37	nmod:poss	_	_
 43	-	_	PUNCT	PUNCT	_	42	flat:name	_	_
-44	יורק	יורק	PROPN	PROPN	_	42	flat:name	_	_
-45	"	_	PUNCT	PUNCT	_	28	punct	_	_
+44	יורק	יורק	PROPN	PROPN	_	42	flat:name	_	SpaceAfter=No
+45	"	_	PUNCT	PUNCT	_	28	punct	_	SpaceAfter=No
 46	.	_	PUNCT	PUNCT	_	2	punct	_	_
 
 # sent_id = 240
-# text = עם זאת , " טובת הכלל " , הדו"ח הגדול על סעד שפרסמה קרן פורד ב9891 , סיפק תמיכה מנומקת ( בגיבוי קונסנזוס רחב להפתיע של שמות מפורסמים ) לתוכנית עבודה וסעד נוקשה ויקרה למדי , שאמנם הבטיחה מקומות עבודה , אבל גם קבעה שכל אדם ייזרק מרשימות מקבלי הסעד כעבור שנתיים .
+# text = עם זאת, "טובת הכלל", הדו"ח הגדול על סעד שפרסמה קרן פורד ב9891, סיפק תמיכה מנומקת (בגיבוי קונסנזוס רחב להפתיע של שמות מפורסמים) לתוכנית עבודה וסעד נוקשה ויקרה למדי, שאמנם הבטיחה מקומות עבודה, אבל גם קבעה שכל אדם ייזרק מרשימות מקבלי הסעד כעבור שנתיים.
 1	עם	עם	ADP	ADP	_	2	case	_	_
-2	זאת	זאת	PRON	PRON	Gender=Fem|Number=Sing|Person=3|PronType=Dem	23	obl	_	_
+2	זאת	זאת	PRON	PRON	Gender=Fem|Number=Sing|Person=3|PronType=Dem	23	obl	_	SpaceAfter=No
 3	,	_	PUNCT	PUNCT	_	23	punct	_	_
-4	"	_	PUNCT	PUNCT	_	5	punct	_	_
+4	"	_	PUNCT	PUNCT	_	5	punct	_	SpaceAfter=No
 5	טובת	טובה	NOUN	NOUN	Definite=Cons|Gender=Fem|Number=Sing	23	nsubj	_	_
-6-7	הכלל	_	_	_	_	_	_	_	_
+6-7	הכלל	_	_	_	_	_	_	_	SpaceAfter=No
 6	ה	ה	DET	DET	PronType=Art	7	det:def	_	_
 7	כלל	כלל	NOUN	NOUN	Gender=Masc|Number=Sing	5	compound:smixut	_	_
-8	"	_	PUNCT	PUNCT	_	5	punct	_	_
+8	"	_	PUNCT	PUNCT	_	5	punct	_	SpaceAfter=No
 9	,	_	PUNCT	PUNCT	_	5	punct	_	_
 10-11	הדו"ח	_	_	_	_	_	_	_	_
 10	ה	ה	DET	DET	PronType=Art	11	det:def	_	_
@@ -8260,14 +8260,14 @@
 17	פרסמה	פרסם	VERB	VERB	Gender=Fem|HebBinyan=PIEL|Number=Sing|Person=3|Tense=Past|Voice=Act	11	acl:relcl	_	_
 18	קרן	קרן	NOUN	NOUN	Definite=Cons|Gender=Fem|Number=Sing	17	nsubj	_	_
 19	פורד	פורד	PROPN	PROPN	_	18	flat:name	_	_
-20-21	ב9891	_	_	_	_	_	_	_	_
+20-21	ב9891	_	_	_	_	_	_	_	SpaceAfter=No
 20	ב	ב	ADP	ADP	_	21	case	_	_
 21	9891	_	NUM	NUM	_	17	obl	_	_
 22	,	_	PUNCT	PUNCT	_	23	punct	_	_
 23	סיפק	סיפק	VERB	VERB	Gender=Masc|HebBinyan=PIEL|Number=Sing|Person=3|Tense=Past|Voice=Act	0	root	_	_
 24	תמיכה	תמיכה	NOUN	NOUN	Gender=Fem|Number=Sing	23	obj	_	_
 25	מנומקת	מנומק	ADJ	ADJ	Gender=Fem|Number=Sing	24	amod	_	_
-26	(	_	PUNCT	PUNCT	_	28	punct	_	_
+26	(	_	PUNCT	PUNCT	_	28	punct	_	SpaceAfter=No
 27-28	בגיבוי	_	_	_	_	_	_	_	_
 27	ב	ב	ADP	ADP	_	28	case	_	_
 28	גיבוי	גיבוי	NOUN	NOUN	Definite=Cons|Gender=Masc|Number=Sing	24	appos	_	_
@@ -8276,7 +8276,7 @@
 31	להפתיע	הפתיע	ADV	ADV	_	30	advmod	_	_
 32	של	של	PART	PART	Case=Gen	33	case:gen	_	_
 33	שמות	שם	NOUN	NOUN	Gender=Masc|Number=Plur	29	nmod:poss	_	_
-34	מפורסמים	מפורסם	ADJ	ADJ	Gender=Masc|Number=Plur	33	amod	_	_
+34	מפורסמים	מפורסם	ADJ	ADJ	Gender=Masc|Number=Plur	33	amod	_	SpaceAfter=No
 35	)	_	PUNCT	PUNCT	_	28	punct	_	_
 36-37	לתוכנית	_	_	_	_	_	_	_	_
 36	ל	ל	ADP	ADP	_	37	case	_	_
@@ -8289,14 +8289,14 @@
 42-43	ויקרה	_	_	_	_	_	_	_	_
 42	ו	ו	CCONJ	CCONJ	_	43	cc	_	_
 43	יקרה	יקר	ADJ	ADJ	Gender=Fem|Number=Sing	41	conj	_	_
-44	למדי	למדי	ADV	ADV	_	43	advmod	_	_
+44	למדי	למדי	ADV	ADV	_	43	advmod	_	SpaceAfter=No
 45	,	_	PUNCT	PUNCT	_	37	punct	_	_
 46-47	שאמנם	_	_	_	_	_	_	_	_
 46	ש	ש	SCONJ	SCONJ	_	48	mark	_	_
 47	אמנם	אמנם	ADV	ADV	_	48	advmod	_	_
 48	הבטיחה	הבטיח	VERB	VERB	Gender=Fem|HebBinyan=HIFIL|Number=Sing|Person=3|Tense=Past|Voice=Act	37	acl:relcl	_	_
 49	מקומות	מקום	NOUN	NOUN	Definite=Cons|Gender=Masc|Number=Plur	48	obj	_	_
-50	עבודה	עבודה	NOUN	NOUN	Gender=Fem|Number=Sing	49	compound:smixut	_	_
+50	עבודה	עבודה	NOUN	NOUN	Gender=Fem|Number=Sing	49	compound:smixut	_	SpaceAfter=No
 51	,	_	PUNCT	PUNCT	_	48	punct	_	_
 52	אבל	אבל	CCONJ	CCONJ	_	54	cc	_	_
 53	גם	גם	ADV	ADV	_	54	advmod	_	_
@@ -8314,15 +8314,15 @@
 62	ה	ה	DET	DET	PronType=Art	63	det:def	_	_
 63	סעד	סעד	NOUN	NOUN	Gender=Masc|Number=Sing	61	compound:smixut	_	_
 64	כעבור	כעבור	ADP	ADP	_	65	case	_	_
-65	שנתיים	שנה	NOUN	NOUN	Gender=Fem|Number=Dual	58	obl	_	_
+65	שנתיים	שנה	NOUN	NOUN	Gender=Fem|Number=Dual	58	obl	_	SpaceAfter=No
 66	.	_	PUNCT	PUNCT	_	23	punct	_	_
 
 # sent_id = 241
-# text = נוסף על כל זה , אין זה משנה עד כמה גדול מספרן של הקרנות במרכז ומעט שמאלה ממנו .
+# text = נוסף על כל זה, אין זה משנה עד כמה גדול מספרן של הקרנות במרכז ומעט שמאלה ממנו.
 1	נוסף	נוסף	VERB	VERB	Gender=Masc|Number=Sing|Person=1,2,3|VerbForm=Part	4	case	_	_
 2	על	על	ADP	ADP	_	4	case	_	_
 3	כל	כול	DET	DET	Definite=Cons	4	det	_	_
-4	זה	זה	PRON	PRON	Gender=Masc|Number=Sing|Person=3	8	obl	_	_
+4	זה	זה	PRON	PRON	Gender=Masc|Number=Sing|Person=3	8	obl	_	SpaceAfter=No
 5	,	_	PUNCT	PUNCT	_	8	punct	_	_
 6	אין	_	ADV	ADV	Polarity=Neg	8	advmod	_	_
 7	זה	זה	PRON	PRON	Gender=Masc|Number=Sing|Person=3	8	nsubj	_	_
@@ -8346,13 +8346,13 @@
 21	ו	ו	CCONJ	CCONJ	HebSource=ConvUncertainHead	20	dep	_	_
 22	מעט	מעט	ADV	ADV	_	20	advmod	_	_
 23	שמאלה	שמאלה	ADV	ADV	HebSource=ConvUncertainHead	22	dep	_	_
-24-25	ממנו	_	_	_	_	_	_	_	_
+24-25	ממנו	_	_	_	_	_	_	_	SpaceAfter=No
 24	ממנו	מן	ADP	ADP	_	25	case	_	_
 25	_הוא	הוא	PRON	PRON	Gender=Masc|Number=Sing|Person=3|PronType=Prs	23	advmod	_	_
 26	.	_	PUNCT	PUNCT	_	8	punct	_	_
 
 # sent_id = 242
-# text = כאשר מגיעים הדברים למדיניות ציבורית , כסף שמרן מקבל יותר תמורת הדולר שלו .
+# text = כאשר מגיעים הדברים למדיניות ציבורית, כסף שמרן מקבל יותר תמורת הדולר שלו.
 1	כאשר	כאשר	SCONJ	SCONJ	_	2	mark	_	_
 2	מגיעים	הגיע	VERB	VERB	Gender=Masc|HebBinyan=HIFIL|Number=Plur|Person=1,2,3|VerbForm=Part|Voice=Act	11	advcl	_	_
 3-4	הדברים	_	_	_	_	_	_	_	_
@@ -8361,7 +8361,7 @@
 5-6	למדיניות	_	_	_	_	_	_	_	_
 5	ל	ל	ADP	ADP	_	6	case	_	_
 6	מדיניות	מדיניות	NOUN	NOUN	Gender=Fem|Number=Sing	2	iobj	_	_
-7	ציבורית	ציבורי	ADJ	ADJ	Gender=Fem|Number=Sing	6	amod	_	_
+7	ציבורית	ציבורי	ADJ	ADJ	Gender=Fem|Number=Sing	6	amod	_	SpaceAfter=No
 8	,	_	PUNCT	PUNCT	_	11	punct	_	_
 9	כסף	כסף	NOUN	NOUN	Gender=Masc|Number=Sing	11	nsubj	_	_
 10	שמרן	שמרן	ADJ	ADJ	Gender=Masc|Number=Sing	9	amod	_	_
@@ -8371,20 +8371,20 @@
 14-15	הדולר	_	_	_	_	_	_	_	_
 14	ה	ה	DET	DET	PronType=Art	15	det:def	_	_
 15	דולר	דולר	NOUN	NOUN	Gender=Masc|Number=Sing	11	obl	_	_
-16-17	שלו	_	_	_	_	_	_	_	_
+16-17	שלו	_	_	_	_	_	_	_	SpaceAfter=No
 16	של_	של	ADP	ADP	Case=Gen	17	case:gen	_	_
 17	_הוא	הוא	PRON	PRON	Gender=Masc|Number=Sing|Person=3|PronType=Prs	15	nmod:poss	_	_
 18	.	_	PUNCT	PUNCT	_	11	punct	_	_
 
 # sent_id = 243
-# text = די לתת מבט בצוותות החשיבה , הצינורות העיקריים בין הקרנות לבין הדיון הציבורי .
+# text = די לתת מבט בצוותות החשיבה, הצינורות העיקריים בין הקרנות לבין הדיון הציבורי.
 1	די	די	ADV	ADV	_	0	root	_	_
 2	לתת	נתן	VERB	VERB	HebBinyan=PAAL|VerbForm=Inf|Voice=Act	1	xcomp	_	_
 3	מבט	מבט	NOUN	NOUN	Gender=Masc|Number=Sing	2	obj	_	_
 4-5	בצוותות	_	_	_	_	_	_	_	_
 4	ב	ב	ADP	ADP	_	5	case	_	_
 5	צוותות	צוות	NOUN	NOUN	Definite=Cons|Gender=Masc|Number=Plur	2	iobj	_	_
-6-7	החשיבה	_	_	_	_	_	_	_	_
+6-7	החשיבה	_	_	_	_	_	_	_	SpaceAfter=No
 6	ה	ה	DET	DET	PronType=Art	7	det:def	_	_
 7	חשיבה	חשיבה	NOUN	NOUN	Gender=Fem|Number=Sing	5	compound:smixut	_	_
 8	,	_	PUNCT	PUNCT	_	5	punct	_	_
@@ -8402,13 +8402,13 @@
 17-18	הדיון	_	_	_	_	_	_	_	_
 17	ה	ה	DET	DET	PronType=Art	18	det:def	_	_
 18	דיון	דיון	NOUN	NOUN	Gender=Masc|Number=Sing	15	conj	_	_
-19-20	הציבורי	_	_	_	_	_	_	_	_
+19-20	הציבורי	_	_	_	_	_	_	_	SpaceAfter=No
 19	ה	ה	DET	DET	PronType=Art	20	det:def	_	_
 20	ציבורי	ציבורי	ADJ	ADJ	Gender=Masc|Number=Sing	18	amod	_	_
 21	.	_	PUNCT	PUNCT	_	1	punct	_	_
 
 # sent_id = 244
-# text = קרנות שמרניות נמנעו בתבונה מלהגביל את התמיכה הפיננסית שלהן לצוותות חשיבה שמרניים .
+# text = קרנות שמרניות נמנעו בתבונה מלהגביל את התמיכה הפיננסית שלהן לצוותות חשיבה שמרניים.
 1	קרנות	קרן	NOUN	NOUN	Gender=Fem|Number=Plur	3	nsubj	_	_
 2	שמרניות	שמרני	ADJ	ADJ	Gender=Fem|Number=Plur	1	amod	_	_
 3	נמנעו	נמנע	VERB	VERB	Gender=Fem,Masc|HebBinyan=NIFAL|Number=Plur|Person=3|Tense=Past|Voice=Mid	0	root	_	_
@@ -8432,11 +8432,11 @@
 15	ל	ל	ADP	ADP	_	16	case	_	_
 16	צוותות	צוות	NOUN	NOUN	Definite=Cons|Gender=Masc|Number=Plur	7	iobj	_	_
 17	חשיבה	חשיבה	NOUN	NOUN	Gender=Fem|Number=Sing	16	compound:smixut	_	_
-18	שמרניים	שמרני	ADJ	ADJ	Gender=Masc|Number=Plur	16	amod	_	_
+18	שמרניים	שמרני	ADJ	ADJ	Gender=Masc|Number=Plur	16	amod	_	SpaceAfter=No
 19	.	_	PUNCT	PUNCT	_	3	punct	_	_
 
 # sent_id = 245
-# text = בעוד הפורדים והרוקפלרים הפכו למקורות פחות מהימנים של תמיכה במחקר , נשאו תמיד מוסדות כמו ברוקינגס את עיניהם לקרנות שמרניות כדי למלא את החסר .
+# text = בעוד הפורדים והרוקפלרים הפכו למקורות פחות מהימנים של תמיכה במחקר, נשאו תמיד מוסדות כמו ברוקינגס את עיניהם לקרנות שמרניות כדי למלא את החסר.
 1	בעוד	בעוד	ADP	ADP	_	9	mark	_	_
 2-3	הפורדים	_	_	_	_	_	_	_	_
 2	ה	_	DET	DET	PronType=Art	3	det:def	_	_
@@ -8453,7 +8453,7 @@
 11	מהימנים	מהימן	ADJ	ADJ	Gender=Masc|Number=Plur	9	amod	_	_
 12	של	של	PART	PART	Case=Gen	13	case:gen	_	_
 13	תמיכה	תמיכה	NOUN	NOUN	Gender=Fem|Number=Sing	9	nmod:poss	_	_
-14-15	במחקר	_	_	_	_	_	_	_	_
+14-15	במחקר	_	_	_	_	_	_	_	SpaceAfter=No
 14	ב	ב	ADP	ADP	_	15	case	_	_
 15	מחקר	מחקר	NOUN	NOUN	Gender=Masc|Number=Sing	13	nmod	_	_
 16	,	_	PUNCT	PUNCT	_	17	punct	_	_
@@ -8474,36 +8474,36 @@
 29	כדי	_	ADP	ADP	_	30	case	_	_
 30	למלא	מילא	VERB	VERB	HebBinyan=PIEL|VerbForm=Inf|Voice=Act	17	advcl	_	_
 31	את	את	PART	PART	Case=Acc	33	case:acc	_	_
-32-33	החסר	_	_	_	_	_	_	_	_
+32-33	החסר	_	_	_	_	_	_	_	SpaceAfter=No
 32	ה	ה	DET	DET	PronType=Art	33	det:def	_	_
 33	חסר	חסר	NOUN	NOUN	Gender=Masc|Number=Sing	30	obj	_	_
 34	.	_	PUNCT	PUNCT	_	17	punct	_	_
 
 # sent_id = 246
-# text = עצה מספר 8 .
+# text = עצה מספר 8.
 1	עצה	עצה	NOUN	NOUN	Gender=Fem|Number=Sing	0	root	_	_
 2	מספר	מספר	NOUN	NOUN	Gender=Masc|HebSource=ConvUncertainLabel|Number=Sing	1	nmod	_	_
-3	8	_	NUM	NUM	_	2	nummod	_	_
+3	8	_	NUM	NUM	_	2	nummod	_	SpaceAfter=No
 4	.	_	PUNCT	PUNCT	_	1	punct	_	_
 
 # sent_id = 247
-# text = הייה שבשבת רוח של רוח התקופה .
+# text = הייה שבשבת רוח של רוח התקופה.
 1	הייה	היה	VERB	VERB	Gender=Masc|Mood=Imp|Number=Sing|Person=2|Polarity=Pos|VerbType=Cop	2	aux	_	_
 2	שבשבת	שבשבת	NOUN	NOUN	Definite=Cons|Gender=Fem|Number=Sing	0	root	_	_
 3	רוח	רוח	NOUN	NOUN	Gender=Fem|Number=Sing	2	compound:smixut	_	_
 4	של	של	PART	PART	Case=Gen	5	case:gen	_	_
 5	רוח	רוח	NOUN	NOUN	Definite=Cons|Gender=Fem|Number=Sing	2	nmod:poss	_	_
-6-7	התקופה	_	_	_	_	_	_	_	_
+6-7	התקופה	_	_	_	_	_	_	_	SpaceAfter=No
 6	ה	ה	DET	DET	PronType=Art	7	det:def	_	_
 7	תקופה	תקופה	NOUN	NOUN	Gender=Fem|Number=Sing	5	compound:smixut	_	_
 8	.	_	PUNCT	PUNCT	_	2	punct	_	_
 
 # sent_id = 248
-# text = כמו כל דבר אחר , נושאים הזוכים לסבסוד נכבד באים והולכים .
+# text = כמו כל דבר אחר, נושאים הזוכים לסבסוד נכבד באים והולכים.
 1	כמו	כמו	ADP	ADP	_	3	case	_	_
 2	כל	כול	DET	DET	Definite=Cons	3	det	_	_
 3	דבר	דבר	NOUN	NOUN	Gender=Masc|Number=Sing	12	parataxis	_	_
-4	אחר	אחר	ADJ	ADJ	Gender=Masc|Number=Sing	3	amod	_	_
+4	אחר	אחר	ADJ	ADJ	Gender=Masc|Number=Sing	3	amod	_	SpaceAfter=No
 5	,	_	PUNCT	PUNCT	_	12	punct	_	_
 6	נושאים	נושא	NOUN	NOUN	Gender=Masc|Number=Plur	12	nsubj	_	_
 7-8	הזוכים	_	_	_	_	_	_	_	_
@@ -8514,13 +8514,13 @@
 10	סבסוד	סבסוד	NOUN	NOUN	Gender=Masc|Number=Sing	8	obl	_	_
 11	נכבד	נכבד	ADJ	ADJ	Gender=Masc|Number=Sing	10	amod	_	_
 12	באים	בא	VERB	VERB	Gender=Masc|HebBinyan=PAAL|Number=Plur|Person=1,2,3|VerbForm=Part|Voice=Act	0	root	_	_
-13-14	והולכים	_	_	_	_	_	_	_	_
+13-14	והולכים	_	_	_	_	_	_	_	SpaceAfter=No
 13	ו	ו	CCONJ	CCONJ	_	14	cc	_	_
 14	הולכים	הלך	VERB	VERB	Gender=Masc|HebBinyan=PAAL|Number=Plur|Person=1,2,3|VerbForm=Part|Voice=Act	12	conj	_	_
 15	.	_	PUNCT	PUNCT	_	12	punct	_	_
 
 # sent_id = 249
-# text = בסוף שנות ה07 הרבו למשל לדבר בתחום היחסים הבין - לאומיים על " הדיאלוג בין צפון ודרום " ועל " תלות הדדית " , והרבה כסף הוקדש להגות על מדינות העולם השלישי .
+# text = בסוף שנות ה07 הרבו למשל לדבר בתחום היחסים הבין - לאומיים על "הדיאלוג בין צפון ודרום" ועל "תלות הדדית", והרבה כסף הוקדש להגות על מדינות העולם השלישי.
 1-2	בסוף	_	_	_	_	_	_	_	_
 1	ב	ב	ADP	ADP	_	2	case	_	_
 2	סוף	סוף	NOUN	NOUN	Definite=Cons|Gender=Masc|Number=Sing	6	obl	_	_
@@ -8543,23 +8543,23 @@
 15	-	_	PUNCT	PUNCT	_	16	punct	_	_
 16	לאומיים	לאומי	ADJ	ADJ	Gender=Masc|Number=Plur	12	amod	_	_
 17	על	על	ADP	ADP	_	20	case	_	_
-18	"	_	PUNCT	PUNCT	_	20	punct	_	_
+18	"	_	PUNCT	PUNCT	_	20	punct	_	SpaceAfter=No
 19-20	הדיאלוג	_	_	_	_	_	_	_	_
 19	ה	ה	DET	DET	PronType=Art	20	det:def	_	_
 20	דיאלוג	דיאלוג	NOUN	NOUN	Gender=Masc|Number=Sing	8	iobj	_	_
 21	בין	בין	ADP	ADP	_	22	case	_	_
 22	צפון	צפון	NOUN	NOUN	Gender=Masc|Number=Sing	20	nmod	_	_
-23-24	ודרום	_	_	_	_	_	_	_	_
+23-24	ודרום	_	_	_	_	_	_	_	SpaceAfter=No
 23	ו	ו	CCONJ	CCONJ	_	24	cc	_	_
 24	דרום	דרום	NOUN	NOUN	Gender=Masc|Number=Sing	22	conj	_	_
 25	"	_	PUNCT	PUNCT	_	20	punct	_	_
 26-27	ועל	_	_	_	_	_	_	_	_
 26	ו	ו	CCONJ	CCONJ	_	29	cc	_	_
 27	על	על	ADP	ADP	_	29	case	_	_
-28	"	_	PUNCT	PUNCT	_	29	punct	_	_
+28	"	_	PUNCT	PUNCT	_	29	punct	_	SpaceAfter=No
 29	תלות	תלות	NOUN	NOUN	Gender=Fem|Number=Sing	20	conj	_	_
-30	הדדית	הדדי	ADJ	ADJ	Gender=Fem|Number=Sing	29	amod	_	_
-31	"	_	PUNCT	PUNCT	_	29	punct	_	_
+30	הדדית	הדדי	ADJ	ADJ	Gender=Fem|Number=Sing	29	amod	_	SpaceAfter=No
+31	"	_	PUNCT	PUNCT	_	29	punct	_	SpaceAfter=No
 32	,	_	PUNCT	PUNCT	_	6	punct	_	_
 33-34	והרבה	_	_	_	_	_	_	_	_
 33	ו	ו	CCONJ	CCONJ	_	36	cc	_	_
@@ -8574,13 +8574,13 @@
 41-42	העולם	_	_	_	_	_	_	_	_
 41	ה	ה	DET	DET	PronType=Art	42	det:def	_	_
 42	עולם	עולם	NOUN	NOUN	Gender=Masc|Number=Sing	40	compound:smixut	_	_
-43-44	השלישי	_	_	_	_	_	_	_	_
+43-44	השלישי	_	_	_	_	_	_	_	SpaceAfter=No
 43	ה	ה	DET	DET	PronType=Art	44	det:def	_	_
 44	שלישי	שלישי	NUM	NUM	Gender=Masc|Number=Sing	42	amod	_	_
 45	.	_	PUNCT	PUNCT	_	6	punct	_	_
 
 # sent_id = 250
-# text = אז באו הפלישה לאפגניסטן ורונלד רייגן ונאום אימפריית הרשע .
+# text = אז באו הפלישה לאפגניסטן ורונלד רייגן ונאום אימפריית הרשע.
 1	אז	אז	ADV	ADV	_	2	advmod	_	_
 2	באו	בא	VERB	VERB	Gender=Fem,Masc|HebBinyan=PAAL|Number=Plur|Person=3|Tense=Past|Voice=Act	0	root	_	_
 3-4	הפלישה	_	_	_	_	_	_	_	_
@@ -8597,13 +8597,13 @@
 10	ו	ו	CCONJ	CCONJ	_	11	cc	_	_
 11	נאום	נאום	NOUN	NOUN	Definite=Cons|Gender=Masc|Number=Sing	4	conj	_	_
 12	אימפריית	אימפריה	NOUN	NOUN	Definite=Cons|Gender=Fem|Number=Sing	11	compound:smixut	_	_
-13-14	הרשע	_	_	_	_	_	_	_	_
+13-14	הרשע	_	_	_	_	_	_	_	SpaceAfter=No
 13	ה	ה	DET	DET	PronType=Art	14	det:def	_	_
 14	רשע	רשע	NOUN	NOUN	Gender=Masc|Number=Sing	12	compound:smixut	_	_
 15	.	_	PUNCT	PUNCT	_	2	punct	_	_
 
 # sent_id = 251
-# text = לפתע פתאום לא היה הנושא החם ביחסים הבין - לאומיים תלות הדדית גלובלית , אלא ביטחון לאומי .
+# text = לפתע פתאום לא היה הנושא החם ביחסים הבין - לאומיים תלות הדדית גלובלית, אלא ביטחון לאומי.
 1	לפתע	לפתע	ADV	ADV	_	16	advmod:phrase	_	_
 2	פתאום	פתאום	ADV	ADV	HebSource=ConvUncertainHead	1	dep	_	_
 3	לא	לא	ADV	ADV	Polarity=Neg	16	advmod	_	_
@@ -8625,15 +8625,15 @@
 15	לאומיים	לאומי	ADJ	ADJ	Gender=Masc|Number=Plur	11	amod	_	_
 16	תלות	תלות	NOUN	NOUN	Gender=Fem|Number=Sing	0	root	_	_
 17	הדדית	הדדי	ADJ	ADJ	Gender=Fem|Number=Sing	16	amod	_	_
-18	גלובלית	גלובלי	ADJ	ADJ	Gender=Fem|Number=Sing	16	amod	_	_
+18	גלובלית	גלובלי	ADJ	ADJ	Gender=Fem|Number=Sing	16	amod	_	SpaceAfter=No
 19	,	_	PUNCT	PUNCT	_	16	punct	_	_
 20	אלא	אלא	CCONJ	CCONJ	_	21	cc	_	_
 21	ביטחון	ביטחון	NOUN	NOUN	Gender=Masc|Number=Sing	16	conj	_	_
-22	לאומי	לאומי	ADJ	ADJ	Gender=Masc|Number=Sing	21	amod	_	_
+22	לאומי	לאומי	ADJ	ADJ	Gender=Masc|Number=Sing	21	amod	_	SpaceAfter=No
 23	.	_	PUNCT	PUNCT	_	16	punct	_	_
 
 # sent_id = 252
-# text = הקרנות הלא - שמרניות היו בעיקר אלה שפרסמו מחקרים לאין - ספור בשאלה כיצד לשמור על השלום .
+# text = הקרנות הלא - שמרניות היו בעיקר אלה שפרסמו מחקרים לאין - ספור בשאלה כיצד לשמור על השלום.
 1-2	הקרנות	_	_	_	_	_	_	_	_
 1	ה	ה	DET	DET	PronType=Art	2	det:def	_	_
 2	קרנות	קרן	NOUN	NOUN	Gender=Fem|Number=Plur	9	nsubj	_	_
@@ -8661,14 +8661,14 @@
 20	כיצד	כיצד	ADV	ADV	PronType=Int	21	advmod	_	_
 21	לשמור	שמר	VERB	VERB	HebBinyan=PAAL|VerbForm=Inf|Voice=Act	19	acl:inf	_	_
 22	על	על	ADP	ADP	_	24	case	_	_
-23-24	השלום	_	_	_	_	_	_	_	_
+23-24	השלום	_	_	_	_	_	_	_	SpaceAfter=No
 23	ה	ה	DET	DET	PronType=Art	24	det:def	_	_
 24	שלום	שלום	NOUN	NOUN	Gender=Masc|Number=Sing	21	iobj	_	_
 25	.	_	PUNCT	PUNCT	_	9	punct	_	_
 
 # sent_id = 253
-# text = עכשיו , כשהמלחמה הקרה חלפה , מנסים כולם למצוא משפטים ומטבעות לשון חדשים שילכדו את תשומת לבם של פקידי תוכניות .
-1	עכשיו	עכשיו	ADV	ADV	_	10	advmod	_	_
+# text = עכשיו, כשהמלחמה הקרה חלפה, מנסים כולם למצוא משפטים ומטבעות לשון חדשים שילכדו את תשומת לבם של פקידי תוכניות.
+1	עכשיו	עכשיו	ADV	ADV	_	10	advmod	_	SpaceAfter=No
 2	,	_	PUNCT	PUNCT	_	8	punct	_	_
 3-5	כשהמלחמה	_	_	_	_	_	_	_	_
 3	כש	כש	SCONJ	SCONJ	Case=Tem	8	mark	_	_
@@ -8677,7 +8677,7 @@
 6-7	הקרה	_	_	_	_	_	_	_	_
 6	ה	ה	DET	DET	PronType=Art	7	det:def	_	_
 7	קרה	קר	ADJ	ADJ	Gender=Fem|Number=Sing	5	amod	_	_
-8	חלפה	חלף	VERB	VERB	Gender=Fem|HebBinyan=PAAL|Number=Sing|Person=3|Tense=Past|Voice=Act	10	parataxis	_	_
+8	חלפה	חלף	VERB	VERB	Gender=Fem|HebBinyan=PAAL|Number=Sing|Person=3|Tense=Past|Voice=Act	10	parataxis	_	SpaceAfter=No
 9	,	_	PUNCT	PUNCT	_	8	punct	_	_
 10	מנסים	ניסה	VERB	VERB	Gender=Masc|HebBinyan=PIEL|Number=Plur|Person=1,2,3|VerbForm=Part|Voice=Act	0	root	_	_
 11	כולם	_	NOUN	NOUN	Gender=Masc|Number=Plur	10	nsubj	_	_
@@ -8699,18 +8699,18 @@
 24	_הם	הוא	PRON	PRON	Case=Gen|Gender=Masc|Number=Plur|Person=3|PronType=Prs	22	nmod:poss	_	_
 25	של	של	PART	PART	Case=Gen	26	case:gen	_	_
 26	פקידי	פקיד	NOUN	NOUN	Definite=Cons|Gender=Masc|Number=Plur	22	nmod:poss	_	_
-27	תוכניות	תוכנית	NOUN	NOUN	Gender=Fem|Number=Plur	26	compound:smixut	_	_
+27	תוכניות	תוכנית	NOUN	NOUN	Gender=Fem|Number=Plur	26	compound:smixut	_	SpaceAfter=No
 28	.	_	PUNCT	PUNCT	_	10	punct	_	_
 
 # sent_id = 254
-# text = עצה מספר 9 .
+# text = עצה מספר 9.
 1	עצה	עצה	NOUN	NOUN	Gender=Fem|Number=Sing	0	root	_	_
 2	מספר	מספר	NOUN	NOUN	Gender=Masc|HebSource=ConvUncertainLabel|Number=Sing	1	nmod	_	_
-3	9	_	NUM	NUM	_	2	nummod	_	_
+3	9	_	NUM	NUM	_	2	nummod	_	SpaceAfter=No
 4	.	_	PUNCT	PUNCT	_	1	punct	_	_
 
 # sent_id = 255
-# text = גייס והפקע לרשותך טרמינולוגיה קיימת .
+# text = גייס והפקע לרשותך טרמינולוגיה קיימת.
 1	גייס	גייס	VERB	VERB	Gender=Masc|HebBinyan=PIEL|Mood=Imp|Number=Sing|Person=2|Voice=Act	0	root	_	_
 2-3	והפקע	_	_	_	_	_	_	_	_
 2	ו	ו	CCONJ	CCONJ	_	3	cc	_	_
@@ -8719,11 +8719,11 @@
 4	ל	ל	ADP	ADP	_	5	case	_	_
 5	רשותך	רשות	NOUN	NOUN	_	3	obl	_	_
 6	טרמינולוגיה	טרמינולוגיה	NOUN	NOUN	_	3	obj	_	_
-7	קיימת	קיים	ADJ	ADJ	Gender=Fem|Number=Sing	6	amod	_	_
+7	קיימת	קיים	ADJ	ADJ	Gender=Fem|Number=Sing	6	amod	_	SpaceAfter=No
 8	.	_	PUNCT	PUNCT	_	1	punct	_	_
 
 # sent_id = 256
-# text = נראה שיעד המשחק הוא לחטוף " ביטחון לאומי " , נושא רב - שנתי עמיד , ולנווט אותו לתחום המומחיות שלך .
+# text = נראה שיעד המשחק הוא לחטוף "ביטחון לאומי", נושא רב - שנתי עמיד, ולנווט אותו לתחום המומחיות שלך.
 1	נראה	נראה	VERB	VERB	Gender=Masc|HebBinyan=NIFAL|Number=Sing|Person=1,2,3|VerbForm=Part|Voice=Mid	0	root	_	_
 2-3	שיעד	_	_	_	_	_	_	_	_
 2	ש	ש	SCONJ	SCONJ	_	7	mark	_	_
@@ -8733,16 +8733,16 @@
 5	משחק	משחק	NOUN	NOUN	Gender=Masc|Number=Sing	3	compound:smixut	_	_
 6	הוא	הוא	VERB	VERB	Gender=Masc|Number=Sing|Person=3|Polarity=Pos|VerbForm=Part|VerbType=Cop	7	cop	_	_
 7	לחטוף	חטף	VERB	VERB	HebBinyan=PAAL|VerbForm=Inf|Voice=Act	1	ccomp	_	_
-8	"	_	PUNCT	PUNCT	_	9	punct	_	_
+8	"	_	PUNCT	PUNCT	_	9	punct	_	SpaceAfter=No
 9	ביטחון	ביטחון	NOUN	NOUN	Gender=Masc|Number=Sing	7	obj	_	_
-10	לאומי	לאומי	ADJ	ADJ	Gender=Masc|Number=Sing	9	amod	_	_
-11	"	_	PUNCT	PUNCT	_	9	punct	_	_
+10	לאומי	לאומי	ADJ	ADJ	Gender=Masc|Number=Sing	9	amod	_	SpaceAfter=No
+11	"	_	PUNCT	PUNCT	_	9	punct	_	SpaceAfter=No
 12	,	_	PUNCT	PUNCT	_	9	punct	_	_
 13	נושא	נושא	NOUN	NOUN	Gender=Masc|Number=Sing	9	obj	_	_
 14	רב	רב	ADV	ADV	Prefix=Yes	16	advmod	_	_
 15	-	_	PUNCT	PUNCT	_	16	punct	_	_
 16	שנתי	שנתי	ADJ	ADJ	Gender=Masc|Number=Sing	13	amod	_	_
-17	עמיד	עמיד	ADJ	ADJ	Gender=Masc|Number=Sing	13	amod	_	_
+17	עמיד	עמיד	ADJ	ADJ	Gender=Masc|Number=Sing	13	amod	_	SpaceAfter=No
 18	,	_	PUNCT	PUNCT	_	7	punct	_	_
 19-20	ולנווט	_	_	_	_	_	_	_	_
 19	ו	ו	CCONJ	CCONJ	_	20	cc	_	_
@@ -8756,13 +8756,13 @@
 25-26	המומחיות	_	_	_	_	_	_	_	_
 25	ה	ה	DET	DET	PronType=Art	26	det:def	_	_
 26	מומחיות	מומחיות	NOUN	NOUN	Gender=Fem|Number=Sing	24	compound:smixut	_	_
-27-28	שלך	_	_	_	_	_	_	_	_
+27-28	שלך	_	_	_	_	_	_	_	SpaceAfter=No
 27	של_	_	ADP	ADP	Case=Gen	28	case:gen	_	_
 28	_אתה	הוא	PRON	PRON	Gender=Masc|Number=Sing|Person=2|PronType=Prs	24	nmod:poss	_	_
 29	.	_	PUNCT	PUNCT	_	1	punct	_	_
 
 # sent_id = 257
-# text = בעלי המודעות הסביבתית הכלל - עולמית מדגישים שכעת אי - אפשר כמעט להבדיל בין ביטחון לאומי לבין " ביטחון כדור הארץ " .
+# text = בעלי המודעות הסביבתית הכלל - עולמית מדגישים שכעת אי - אפשר כמעט להבדיל בין ביטחון לאומי לבין " ביטחון כדור הארץ ".
 1	בעלי	בעל	NOUN	NOUN	Definite=Cons|Gender=Masc|Number=Plur	10	nsubj	_	_
 2-3	המודעות	_	_	_	_	_	_	_	_
 2	ה	ה	DET	DET	PronType=Art	3	det:def	_	_
@@ -8794,11 +8794,11 @@
 25-26	הארץ	_	_	_	_	_	_	_	_
 25	ה	ה	DET	DET	PronType=Art	26	det:def	_	_
 26	ארץ	ארץ	NOUN	NOUN	Gender=Fem|Number=Sing	24	compound:smixut	_	_
-27	"	_	PUNCT	PUNCT	_	23	punct	_	_
+27	"	_	PUNCT	PUNCT	_	23	punct	_	SpaceAfter=No
 28	.	_	PUNCT	PUNCT	_	10	punct	_	_
 
 # sent_id = 258
-# text = הטיפוסים לובשי החליפות הכהות , השייכים לזרם מרכזי יותר , אומרים ששום מדינה אינה יכולה להיות בטוחה אם לא יהיה " מבנה ביטחון אירופי יציב " .
+# text = הטיפוסים לובשי החליפות הכהות, השייכים לזרם מרכזי יותר, אומרים ששום מדינה אינה יכולה להיות בטוחה אם לא יהיה " מבנה ביטחון אירופי יציב ".
 1-2	הטיפוסים	_	_	_	_	_	_	_	_
 1	ה	ה	DET	DET	PronType=Art	2	det:def	_	_
 2	טיפוסים	טיפוס	NOUN	NOUN	Gender=Masc|Number=Plur	16	nsubj	_	_
@@ -8806,7 +8806,7 @@
 4-5	החליפות	_	_	_	_	_	_	_	_
 4	ה	ה	DET	DET	PronType=Art	5	det:def	_	_
 5	חליפות	חליפה	NOUN	NOUN	Gender=Fem|Number=Plur	3	compound:smixut	_	_
-6-7	הכהות	_	_	_	_	_	_	_	_
+6-7	הכהות	_	_	_	_	_	_	_	SpaceAfter=No
 6	ה	ה	DET	DET	PronType=Art	7	det:def	_	_
 7	כהות	כהה	ADJ	ADJ	Gender=Fem|Number=Plur	5	amod	_	_
 8	,	_	PUNCT	PUNCT	_	2	punct	_	_
@@ -8817,7 +8817,7 @@
 11	ל	ל	ADP	ADP	_	12	case	_	_
 12	זרם	זרם	NOUN	NOUN	Gender=Masc|Number=Sing	10	iobj	_	_
 13	מרכזי	מרכזי	ADJ	ADJ	Gender=Masc|Number=Sing	12	amod	_	_
-14	יותר	יותר	ADV	ADV	_	13	advmod	_	_
+14	יותר	יותר	ADV	ADV	_	13	advmod	_	SpaceAfter=No
 15	,	_	PUNCT	PUNCT	_	16	punct	_	_
 16	אומרים	אמר	VERB	VERB	Gender=Masc|HebBinyan=PAAL|Number=Plur|Person=1,2,3|VerbForm=Part|Voice=Act	0	root	_	_
 17-18	ששום	_	_	_	_	_	_	_	_
@@ -8836,11 +8836,11 @@
 29	ביטחון	ביטחון	NOUN	NOUN	Gender=Masc|Number=Sing	28	compound:smixut	_	_
 30	אירופי	אירופי	ADJ	ADJ	Gender=Masc|Number=Sing	28	amod	_	_
 31	יציב	יציב	ADJ	ADJ	Gender=Masc|Number=Sing	28	amod	_	_
-32	"	_	PUNCT	PUNCT	_	28	punct	_	_
+32	"	_	PUNCT	PUNCT	_	28	punct	_	SpaceAfter=No
 33	.	_	PUNCT	PUNCT	_	16	punct	_	_
 
 # sent_id = 259
-# text = וכלכלנים בחבורת מקדמי המדיניות התעשייתית , יחד עם מחנכים בחבורת החינוך למצוינות , ניסו בעורמה לשים ידם על כספי מדיניות החוץ , בטענה שבעתיד יוגדר הביטחון הלאומי במונחים של כושר תחרות כלכלי , לא של עוצמה צבאית .
+# text = וכלכלנים בחבורת מקדמי המדיניות התעשייתית, יחד עם מחנכים בחבורת החינוך למצוינות, ניסו בעורמה לשים ידם על כספי מדיניות החוץ, בטענה שבעתיד יוגדר הביטחון הלאומי במונחים של כושר תחרות כלכלי, לא של עוצמה צבאית.
 1-2	וכלכלנים	_	_	_	_	_	_	_	_
 1	ו	ו	CCONJ	CCONJ	_	21	cc	_	_
 2	כלכלנים	כלכלן	NOUN	NOUN	Gender=Masc|Number=Plur	21	nsubj	_	_
@@ -8851,7 +8851,7 @@
 6-7	המדיניות	_	_	_	_	_	_	_	_
 6	ה	ה	DET	DET	PronType=Art	7	det:def	_	_
 7	מדיניות	מדיניות	NOUN	NOUN	Gender=Fem|Number=Sing	5	compound:smixut	_	_
-8-9	התעשייתית	_	_	_	_	_	_	_	_
+8-9	התעשייתית	_	_	_	_	_	_	_	SpaceAfter=No
 8	ה	ה	DET	DET	PronType=Art	9	det:def	_	_
 9	תעשייתית	תעשייתי	ADJ	ADJ	Gender=Fem|Number=Sing	7	amod	_	_
 10	,	_	PUNCT	PUNCT	_	2	punct	_	_
@@ -8864,7 +8864,7 @@
 16-17	החינוך	_	_	_	_	_	_	_	_
 16	ה	ה	DET	DET	PronType=Art	17	det:def	_	_
 17	חינוך	חינוך	NOUN	NOUN	Gender=Masc|Number=Sing	15	compound:smixut	_	_
-18-19	למצוינות	_	_	_	_	_	_	_	_
+18-19	למצוינות	_	_	_	_	_	_	_	SpaceAfter=No
 18	ל	ל	ADP	ADP	_	19	case	_	_
 19	מצוינות	מצוינות	NOUN	NOUN	Gender=Fem|Number=Sing	17	nmod	_	_
 20	,	_	PUNCT	PUNCT	_	21	punct	_	_
@@ -8880,7 +8880,7 @@
 28	על	על	ADP	ADP	_	29	case	_	_
 29	כספי	כסף	NOUN	NOUN	Definite=Cons|Gender=Masc|Number=Plur	24	iobj	_	_
 30	מדיניות	מדיניות	NOUN	NOUN	Definite=Cons|Gender=Fem|Number=Sing	29	compound:smixut	_	_
-31-32	החוץ	_	_	_	_	_	_	_	_
+31-32	החוץ	_	_	_	_	_	_	_	SpaceAfter=No
 31	ה	ה	DET	DET	PronType=Art	32	det:def	_	_
 32	חוץ	חוץ	NOUN	NOUN	Gender=Masc|Number=Sing	30	compound:smixut	_	_
 33	,	_	PUNCT	PUNCT	_	24	punct	_	_
@@ -8905,27 +8905,27 @@
 47	של	של	PART	PART	Case=Gen	48	case:gen	_	_
 48	כושר	כושר	NOUN	NOUN	Definite=Cons|Gender=Masc|Number=Sing	46	nmod	_	_
 49	תחרות	תחרות	NOUN	NOUN	Gender=Fem|Number=Sing	48	compound:smixut	_	_
-50	כלכלי	כלכלי	ADJ	ADJ	Gender=Masc|Number=Sing	48	amod	_	_
+50	כלכלי	כלכלי	ADJ	ADJ	Gender=Masc|Number=Sing	48	amod	_	SpaceAfter=No
 51	,	_	PUNCT	PUNCT	_	48	punct	_	_
 52	לא	לא	ADV	ADV	Polarity=Neg	54	case	_	_
 53	של	של	PART	PART	Case=Gen	52	case:gen	_	_
 54	עוצמה	עוצמה	NOUN	NOUN	Gender=Fem|Number=Sing	48	conj	_	_
-55	צבאית	צבאי	ADJ	ADJ	Gender=Fem|Number=Sing	54	amod	_	_
+55	צבאית	צבאי	ADJ	ADJ	Gender=Fem|Number=Sing	54	amod	_	SpaceAfter=No
 56	.	_	PUNCT	PUNCT	_	21	punct	_	_
 
 # sent_id = 260
-# text = לגבי אנשים אלה סדאם חוסיין הוא מטרד .
+# text = לגבי אנשים אלה סדאם חוסיין הוא מטרד.
 1	לגבי	לגבי	ADP	ADP	_	2	case	_	_
 2	אנשים	איש	NOUN	NOUN	Gender=Masc|Number=Plur	7	nmod	_	_
 3	אלה	אלה	PRON	PRON	Gender=Masc|Number=Plur|Person=3|PronType=Dem	2	amod	_	_
 4	סדאם	סדאם	PROPN	PROPN	_	7	nsubj:cop	_	_
 5	חוסיין	חוסיין	PROPN	PROPN	_	4	flat:name	_	_
 6	הוא	הוא	VERB	VERB	Gender=Masc|Number=Sing|Person=3|Polarity=Pos|VerbForm=Part|VerbType=Cop	7	cop	_	_
-7	מטרד	מטרד	NOUN	NOUN	Gender=Masc|Number=Sing	0	root	_	_
+7	מטרד	מטרד	NOUN	NOUN	Gender=Masc|Number=Sing	0	root	_	SpaceAfter=No
 8	.	_	PUNCT	PUNCT	_	7	punct	_	_
 
 # sent_id = 261
-# text = אבל סדאם חוסיין היה מתת - שמים לכל המומחים לפיקוח רב - צדדי על הנשק , הטוענים זה שנים שיש להפסיק את הזרמתו של נשק מתוחכם לדיקטטורים רברבנים בעולם השלישי .
+# text = אבל סדאם חוסיין היה מתת - שמים לכל המומחים לפיקוח רב - צדדי על הנשק, הטוענים זה שנים שיש להפסיק את הזרמתו של נשק מתוחכם לדיקטטורים רברבנים בעולם השלישי.
 1	אבל	אבל	CCONJ	CCONJ	_	7	cc	_	_
 2	סדאם	סדאם	PROPN	PROPN	_	7	nsubj	_	_
 3	חוסיין	חוסיין	PROPN	PROPN	_	2	flat:name	_	_
@@ -8946,7 +8946,7 @@
 15	-	_	PUNCT	PUNCT	_	16	punct	_	_
 16	צדדי	צדדי	ADJ	ADJ	Gender=Masc|Number=Sing	13	amod	_	_
 17	על	על	ADP	ADP	_	19	case	_	_
-18-19	הנשק	_	_	_	_	_	_	_	_
+18-19	הנשק	_	_	_	_	_	_	_	SpaceAfter=No
 18	ה	ה	DET	DET	PronType=Art	19	det:def	_	_
 19	נשק	נשק	NOUN	NOUN	Gender=Masc|Number=Sing	13	nmod	_	_
 20	,	_	PUNCT	PUNCT	_	11	punct	_	_
@@ -8975,13 +8975,13 @@
 38	ב	ב	ADP	ADP	_	40	case	_	_
 39	ה_	ה	DET	DET	PronType=Art	40	det:def	_	_
 40	עולם	עולם	NOUN	NOUN	Gender=Masc|Number=Sing	36	nmod	_	_
-41-42	השלישי	_	_	_	_	_	_	_	_
+41-42	השלישי	_	_	_	_	_	_	_	SpaceAfter=No
 41	ה	ה	DET	DET	PronType=Art	42	det:def	_	_
 42	שלישי	שלישי	NUM	NUM	Gender=Masc|Number=Sing	40	amod	_	_
 43	.	_	PUNCT	PUNCT	_	7	punct	_	_
 
 # sent_id = 262
-# text = מדובר בקומץ אנשים שניסו למשוך אליהם כספי מענקים בעת שהעולם המטיר דולרים עלאסטרטגיה גרעינית ופיקוח רב - צדדי על הנשק .
+# text = מדובר בקומץ אנשים שניסו למשוך אליהם כספי מענקים בעת שהעולם המטיר דולרים עלאסטרטגיה גרעינית ופיקוח רב - צדדי על הנשק.
 1	מדובר	דובר	VERB	VERB	Gender=Masc|HebBinyan=PUAL|Number=Sing|Person=1,2,3|VerbForm=Part|Voice=Pass	0	root	_	_
 2-3	בקומץ	_	_	_	_	_	_	_	_
 2	ב	ב	ADP	ADP	_	3	case	_	_
@@ -9016,13 +9016,13 @@
 25	-	_	PUNCT	PUNCT	_	26	punct	_	_
 26	צדדי	צדדי	ADJ	ADJ	Gender=Masc|Number=Sing	23	amod	_	_
 27	על	על	ADP	ADP	_	29	case	_	_
-28-29	הנשק	_	_	_	_	_	_	_	_
+28-29	הנשק	_	_	_	_	_	_	_	SpaceAfter=No
 28	ה	ה	DET	DET	PronType=Art	29	det:def	_	_
 29	נשק	נשק	NOUN	NOUN	Gender=Masc|Number=Sing	23	nmod	_	_
 30	.	_	PUNCT	PUNCT	_	1	punct	_	_
 
 # sent_id = 263
-# text = עובדה זו שימשה יסוד לתלונה שכיחה בתחום הפילנטרופיה : התמקדותם של קרנות וצוותות חשיבה במגמות אופנתיות גורמת לכך שהחברה בקושי ערוכה לגלים היסטוריים חדשים .
+# text = עובדה זו שימשה יסוד לתלונה שכיחה בתחום הפילנטרופיה: התמקדותם של קרנות וצוותות חשיבה במגמות אופנתיות גורמת לכך שהחברה בקושי ערוכה לגלים היסטוריים חדשים.
 1	עובדה	עובדה	NOUN	NOUN	Gender=Fem|Number=Sing	3	nsubj	_	_
 2	זו	זו	PRON	PRON	Gender=Fem|Number=Sing|Person=3|PronType=Dem	1	amod	_	_
 3	שימשה	שימש	VERB	VERB	Gender=Fem|HebBinyan=PIEL|Number=Sing|Person=3|Tense=Past|Voice=Act	0	root	_	_
@@ -9034,7 +9034,7 @@
 8-9	בתחום	_	_	_	_	_	_	_	_
 8	ב	ב	ADP	ADP	_	9	case	_	_
 9	תחום	תחום	NOUN	NOUN	Definite=Cons|Gender=Masc|Number=Sing	6	nmod	_	_
-10-11	הפילנטרופיה	_	_	_	_	_	_	_	_
+10-11	הפילנטרופיה	_	_	_	_	_	_	_	SpaceAfter=No
 10	ה	ה	DET	DET	PronType=Art	11	det:def	_	_
 11	פילנטרופיה	פילנתרופיה	NOUN	NOUN	Gender=Fem|Number=Sing	9	compound:smixut	_	_
 12	:	_	PUNCT	PUNCT	_	24	punct	_	_
@@ -9066,25 +9066,25 @@
 32	ל	ל	ADP	ADP	_	33	case	_	_
 33	גלים	גל	NOUN	NOUN	Gender=Masc|Number=Plur	31	advmod	_	_
 34	היסטוריים	היסטורי	ADJ	ADJ	Gender=Masc|Number=Plur	33	amod	_	_
-35	חדשים	חדש	ADJ	ADJ	Gender=Masc|Number=Plur	33	amod	_	_
+35	חדשים	חדש	ADJ	ADJ	Gender=Masc|Number=Plur	33	amod	_	SpaceAfter=No
 36	.	_	PUNCT	PUNCT	_	3	punct	_	_
 
 # sent_id = 264
-# text = גיימס אלן סמית , מחבר הספר " הברוקרים של הרעיונות : צוותות חשיבה ועלייתה של עלית מדיניות חדשה " , אומר כי ההתמקדות בבעיות מדיניות דוחקות , ודעיכת האמונה בערכו של מחקר בסיסי במדעי החברה , הותירו אותנו ללא מאגר נרחב של מומחים , שממנו ניתן לשאוב כאשר יתעורר הצורך .
+# text = גיימס אלן סמית, מחבר הספר "הברוקרים של הרעיונות: צוותות חשיבה ועלייתה של עלית מדיניות חדשה", אומר כי ההתמקדות בבעיות מדיניות דוחקות, ודעיכת האמונה בערכו של מחקר בסיסי במדעי החברה, הותירו אותנו ללא מאגר נרחב של מומחים, שממנו ניתן לשאוב כאשר יתעורר הצורך.
 1	גיימס	גיימס	PROPN	PROPN	_	27	nsubj	_	_
 2	אלן	אלן	PROPN	PROPN	_	1	flat:name	_	_
-3	סמית	סמית	PROPN	PROPN	_	1	flat:name	_	_
+3	סמית	סמית	PROPN	PROPN	_	1	flat:name	_	SpaceAfter=No
 4	,	_	PUNCT	PUNCT	_	1	punct	_	_
 5	מחבר	מחבר	NOUN	NOUN	Definite=Cons|Gender=Masc|Number=Sing	1	appos	_	_
 6-7	הספר	_	_	_	_	_	_	_	_
 6	ה	ה	DET	DET	PronType=Art	7	det:def	_	_
 7	ספר	ספר	NOUN	NOUN	Gender=Masc|Number=Sing	5	compound:smixut	_	_
-8	"	_	PUNCT	PUNCT	_	10	punct	_	_
+8	"	_	PUNCT	PUNCT	_	10	punct	_	SpaceAfter=No
 9-10	הברוקרים	_	_	_	_	_	_	_	_
 9	ה	ה	DET	DET	PronType=Art	10	det:def	_	_
 10	ברוקרים	ברוקר	NOUN	NOUN	Gender=Masc|Number=Plur	7	appos	_	_
 11	של	של	PART	PART	Case=Gen	13	case:gen	_	_
-12-13	הרעיונות	_	_	_	_	_	_	_	_
+12-13	הרעיונות	_	_	_	_	_	_	_	SpaceAfter=No
 12	ה	ה	DET	DET	PronType=Art	13	det:def	_	_
 13	רעיונות	רעיון	NOUN	NOUN	Gender=Masc|Number=Plur	10	nmod:poss	_	_
 14	:	_	PUNCT	PUNCT	_	10	punct	_	_
@@ -9098,8 +9098,8 @@
 21	של	של	PART	PART	Case=Gen	22	case:gen	_	_
 22	עלית	עלית	NOUN	NOUN	Definite=Cons|Gender=Fem|Number=Sing	18	nmod:poss	_	_
 23	מדיניות	מדיניות	NOUN	NOUN	Gender=Fem|Number=Sing	22	compound:smixut	_	_
-24	חדשה	חדש	ADJ	ADJ	Gender=Fem|Number=Sing	22	amod	_	_
-25	"	_	PUNCT	PUNCT	_	10	punct	_	_
+24	חדשה	חדש	ADJ	ADJ	Gender=Fem|Number=Sing	22	amod	_	SpaceAfter=No
+25	"	_	PUNCT	PUNCT	_	10	punct	_	SpaceAfter=No
 26	,	_	PUNCT	PUNCT	_	27	punct	_	_
 27	אומר	אמר	VERB	VERB	Gender=Masc|HebBinyan=PAAL|Number=Sing|Person=1,2,3|VerbForm=Part|Voice=Act	0	root	_	_
 28	כי	כי	SCONJ	SCONJ	_	52	mark	_	_
@@ -9110,7 +9110,7 @@
 31	ב	ב	ADP	ADP	_	32	case	_	_
 32	בעיות	בעיה	NOUN	NOUN	Definite=Cons|Gender=Fem|Number=Plur	30	nmod	_	_
 33	מדיניות	מדיניות	NOUN	NOUN	Gender=Fem|Number=Sing	32	compound:smixut	_	_
-34	דוחקות	דחק	VERB	VERB	Gender=Fem|HebBinyan=PAAL|Number=Plur|Person=1,2,3|VerbForm=Part|Voice=Act	32	amod	_	_
+34	דוחקות	דחק	VERB	VERB	Gender=Fem|HebBinyan=PAAL|Number=Plur|Person=1,2,3|VerbForm=Part|Voice=Act	32	amod	_	SpaceAfter=No
 35	,	_	PUNCT	PUNCT	_	30	punct	_	_
 36-37	ודעיכת	_	_	_	_	_	_	_	_
 36	ו	ו	CCONJ	CCONJ	_	37	cc	_	_
@@ -9129,7 +9129,7 @@
 47-48	במדעי	_	_	_	_	_	_	_	_
 47	ב	ב	ADP	ADP	_	48	case	_	_
 48	מדעי	מדע	NOUN	NOUN	Definite=Cons|Gender=Masc|Number=Plur	45	nmod	_	_
-49-50	החברה	_	_	_	_	_	_	_	_
+49-50	החברה	_	_	_	_	_	_	_	SpaceAfter=No
 49	ה	ה	DET	DET	PronType=Art	50	det:def	_	_
 50	חברה	חברה	NOUN	NOUN	Gender=Fem|Number=Sing	48	compound:smixut	_	_
 51	,	_	PUNCT	PUNCT	_	52	punct	_	_
@@ -9141,7 +9141,7 @@
 56	מאגר	מאגר	NOUN	NOUN	Gender=Masc|Number=Sing	52	obl	_	_
 57	נרחב	נרחב	ADJ	ADJ	Gender=Masc|Number=Sing	56	amod	_	_
 58	של	של	PART	PART	Case=Gen	59	case:gen	_	_
-59	מומחים	מומחה	NOUN	NOUN	Gender=Masc|Number=Plur	56	nmod:poss	_	_
+59	מומחים	מומחה	NOUN	NOUN	Gender=Masc|Number=Plur	56	nmod:poss	_	SpaceAfter=No
 60	,	_	PUNCT	PUNCT	_	56	punct	_	_
 61-63	שממנו	_	_	_	_	_	_	_	_
 61	ש	ש	SCONJ	SCONJ	_	64	mark	_	_
@@ -9151,21 +9151,21 @@
 65	לשאוב	שאב	VERB	VERB	HebBinyan=PAAL|VerbForm=Inf|Voice=Act	64	xcomp	_	_
 66	כאשר	כאשר	SCONJ	SCONJ	_	67	mark	_	_
 67	יתעורר	התעורר	VERB	VERB	Gender=Masc|HebBinyan=HITPAEL|Number=Sing|Person=3|Tense=Fut	64	advcl	_	_
-68-69	הצורך	_	_	_	_	_	_	_	_
+68-69	הצורך	_	_	_	_	_	_	_	SpaceAfter=No
 68	ה	ה	DET	DET	PronType=Art	69	det:def	_	_
 69	צורך	צורך	NOUN	NOUN	Gender=Masc|Number=Sing	67	nsubj	_	_
 70	.	_	PUNCT	PUNCT	_	27	punct	_	_
 
 # sent_id = 265
-# text = זה נכון .
+# text = זה נכון.
 1	זה	זה	PRON	PRON	Gender=Masc|Number=Sing|Person=3	2	nsubj	_	_
-2	נכון	נכון	ADJ	ADJ	Gender=Masc|Number=Sing	0	root	_	_
+2	נכון	נכון	ADJ	ADJ	Gender=Masc|Number=Sing	0	root	_	SpaceAfter=No
 3	.	_	PUNCT	PUNCT	_	2	punct	_	_
 
 # sent_id = 266
-# text = אחרי הכל , כמה מחקרים בחסות קרנות הוקדשו בתקופת האובססיה הממושכת למלחמה הקרה לניסיון לגלות באיזו מידה אדם כמו סדאם חוסיין עלול להיות מסוכן ?
+# text = אחרי הכל, כמה מחקרים בחסות קרנות הוקדשו בתקופת האובססיה הממושכת למלחמה הקרה לניסיון לגלות באיזו מידה אדם כמו סדאם חוסיין עלול להיות מסוכן?
 1	אחרי	אחרי	ADP	ADP	_	2	case	_	_
-2	הכל	הכיל	NOUN	NOUN	_	9	parataxis	_	_
+2	הכל	הכיל	NOUN	NOUN	_	9	parataxis	_	SpaceAfter=No
 3	,	_	PUNCT	PUNCT	_	9	punct	_	_
 4	כמה	כמה	DET	DET	Definite=Cons	5	det	_	_
 5	מחקרים	מחקר	NOUN	NOUN	Gender=Masc|Number=Plur	9	nsubj	_	_
@@ -9204,11 +9204,11 @@
 30	חוסיין	חוסיין	PROPN	PROPN	_	29	flat:name	_	_
 31	עלול	עלול	AUX	AUX	Gender=Masc|HebSource=ConvUncertainHead|Number=Sing|Person=1,2,3|VerbType=Mod	23	dep	_	_
 32	להיות	היה	VERB	VERB	Polarity=Pos|VerbForm=Inf|VerbType=Cop	31	xcomp	_	_
-33	מסוכן	מסוכן	ADJ	ADJ	Gender=Masc|Number=Sing	32	iobj	_	_
+33	מסוכן	מסוכן	ADJ	ADJ	Gender=Masc|Number=Sing	32	iobj	_	SpaceAfter=No
 34	?	_	PUNCT	PUNCT	_	9	punct	_	_
 
 # sent_id = 267
-# text = כמה מחקרים שאלו כיצד להפוך כלכלה סטליניסטית לכלכלת שוק חופשי ?
+# text = כמה מחקרים שאלו כיצד להפוך כלכלה סטליניסטית לכלכלת שוק חופשי?
 1	כמה	כמה	DET	DET	Definite=Cons	2	det	_	_
 2	מחקרים	מחקר	NOUN	NOUN	Gender=Masc|Number=Plur	3	nsubj	_	_
 3	שאלו	שאל	VERB	VERB	Gender=Fem,Masc|HebBinyan=PAAL|Number=Plur|Person=3|Tense=Past|Voice=Act	0	root	_	_
@@ -9220,11 +9220,11 @@
 8	ל	ל	ADP	ADP	_	9	case	_	_
 9	כלכלת	כלכלה	NOUN	NOUN	Definite=Cons|Gender=Fem|Number=Sing	5	iobj	_	_
 10	שוק	שוק	NOUN	NOUN	Gender=Masc|Number=Sing	9	compound:smixut	_	_
-11	חופשי	חופשי	ADJ	ADJ	Gender=Masc|Number=Sing	10	amod	_	_
+11	חופשי	חופשי	ADJ	ADJ	Gender=Masc|Number=Sing	10	amod	_	SpaceAfter=No
 12	?	_	PUNCT	PUNCT	_	3	punct	_	_
 
 # sent_id = 268
-# text = יש סימוכין לדעה שכיום אלו הן שתי הבעיות הדוחקות ביותר של העולם .
+# text = יש סימוכין לדעה שכיום אלו הן שתי הבעיות הדוחקות ביותר של העולם.
 1	יש	יש	VERB	VERB	HebExistential=True	0	root	_	_
 2	סימוכין	סימוכין	NOUN	NOUN	Gender=Masc|Number=Plur	1	nsubj	_	_
 3-5	לדעה	_	_	_	_	_	_	_	_
@@ -9245,17 +9245,17 @@
 14	דוחקות	דחק	VERB	VERB	Gender=Fem|HebBinyan=PAAL|Number=Plur|Person=1,2,3|VerbForm=Part|Voice=Act	12	amod	_	_
 15	ביותר	ביותר	ADV	ADV	_	14	advmod	_	_
 16	של	של	PART	PART	Case=Gen	18	case:gen	_	_
-17-18	העולם	_	_	_	_	_	_	_	_
+17-18	העולם	_	_	_	_	_	_	_	SpaceAfter=No
 17	ה	ה	DET	DET	PronType=Art	18	det:def	_	_
 18	עולם	עולם	NOUN	NOUN	Gender=Masc|Number=Sing	12	nmod:poss	_	_
 19	.	_	PUNCT	PUNCT	_	1	punct	_	_
 
 # sent_id = 269
-# text = אך אפשר לומר בביטחון , שאף לא דולר אחד מבין למעלה מ05 מיליארד הדולרים שהוציאו קרנות בין 9791 ל9891 לא הוקדש להבהרתן .
+# text = אך אפשר לומר בביטחון, שאף לא דולר אחד מבין למעלה מ05 מיליארד הדולרים שהוציאו קרנות בין 9791 ל9891 לא הוקדש להבהרתן.
 1	אך	אך	CCONJ	CCONJ	_	2	cc	_	_
 2	אפשר	אפשר	AUX	AUX	VerbType=Mod	0	root	_	_
 3	לומר	אמר	VERB	VERB	HebBinyan=PAAL|VerbForm=Inf|Voice=Act	2	xcomp	_	_
-4-5	בביטחון	_	_	_	_	_	_	_	_
+4-5	בביטחון	_	_	_	_	_	_	_	SpaceAfter=No
 4	ב	ב	ADP	ADP	_	5	case	_	_
 5	ביטחון	ביטחון	NOUN	NOUN	Gender=Masc|Number=Sing	3	obl	_	_
 6	,	_	PUNCT	PUNCT	_	3	punct	_	_
@@ -9285,7 +9285,7 @@
 25	9891	_	NUM	NUM	_	23	conj	_	_
 26	לא	לא	ADV	ADV	Polarity=Neg	27	advmod	_	_
 27	הוקדש	הוקדש	VERB	VERB	Gender=Masc|HebBinyan=HUFAL|Number=Sing|Person=3|Tense=Past|Voice=Pass	3	ccomp	_	_
-28-31	להבהרתן	_	_	_	_	_	_	_	_
+28-31	להבהרתן	_	_	_	_	_	_	_	SpaceAfter=No
 28	ל	ל	ADP	ADP	_	29	case	_	_
 29	הבהרה_	הבהרה	NOUN	NOUN	Definite=Def|Gender=Fem|Number=Sing	27	iobj	_	_
 30	_של_	של	ADP	ADP	_	31	case:gen	_	_
@@ -9293,7 +9293,7 @@
 32	.	_	PUNCT	PUNCT	_	2	punct	_	_
 
 # sent_id = 270
-# text = האם הכסף דוחף את הרעיונות או שמא זוכים הרעיונות לתמיכה כספית בזכות ערכם והחידוש שבהם ?
+# text = האם הכסף דוחף את הרעיונות או שמא זוכים הרעיונות לתמיכה כספית בזכות ערכם והחידוש שבהם?
 1	האם	האם	ADV	ADV	PronType=Int	4	aux:q	_	_
 2-3	הכסף	_	_	_	_	_	_	_	_
 2	ה	ה	DET	DET	PronType=Art	3	det:def	_	_
@@ -9322,14 +9322,14 @@
 20	ו	ו	CCONJ	CCONJ	_	22	cc	_	_
 21	ה	ה	DET	DET	PronType=Art	22	det:def	_	_
 22	חידוש	חידוש	NOUN	NOUN	Gender=Masc|Number=Sing	17	conj	_	_
-23-25	שבהם	_	_	_	_	_	_	_	_
+23-25	שבהם	_	_	_	_	_	_	_	SpaceAfter=No
 23	ש	ש	SCONJ	SCONJ	_	25	mark	_	_
 24	בהם	ב	ADP	ADP	_	25	case	_	_
 25	_הם	הוא	PRON	PRON	Gender=Masc|Number=Plur|Person=3|PronType=Prs	22	acl:relcl	_	_
 26	?	_	PUNCT	PUNCT	_	4	punct	_	_
 
 # sent_id = 271
-# text = כדי לענות על שאלות אלו עליך להשתקע קודם לכל באי - אלו הרהורים קוסמיים על טבעה של ההיסטוריה , ולהקדיש מחשבה לדיאלקטיקה הגליאנית , לתיאוריות על מקומו של האדם הגדול בהיסטוריה וכך הלאה .
+# text = כדי לענות על שאלות אלו עליך להשתקע קודם לכל באי - אלו הרהורים קוסמיים על טבעה של ההיסטוריה, ולהקדיש מחשבה לדיאלקטיקה הגליאנית, לתיאוריות על מקומו של האדם הגדול בהיסטוריה וכך הלאה.
 1	כדי	_	ADP	ADP	_	2	case	_	_
 2	לענות	ענה	VERB	VERB	VerbForm=Inf	7	advcl	_	_
 3	על	על	ADP	ADP	_	4	case	_	_
@@ -9356,7 +9356,7 @@
 20	_של_	של	ADP	ADP	_	21	case:gen	_	_
 21	_היא	הוא	PRON	PRON	Case=Gen|Gender=Fem|Number=Sing|Person=3|PronType=Prs	19	nmod:poss	_	_
 22	של	של	PART	PART	Case=Gen	24	case:gen	_	_
-23-24	ההיסטוריה	_	_	_	_	_	_	_	_
+23-24	ההיסטוריה	_	_	_	_	_	_	_	SpaceAfter=No
 23	ה	ה	DET	DET	PronType=Art	24	det:def	_	_
 24	היסטוריה	היסטוריה	NOUN	NOUN	Gender=Fem|Number=Sing	19	nmod:poss	_	_
 25	,	_	PUNCT	PUNCT	_	8	punct	_	_
@@ -9367,7 +9367,7 @@
 29-30	לדיאלקטיקה	_	_	_	_	_	_	_	_
 29	ל	ל	ADP	ADP	_	30	case	_	_
 30	דיאלקטיקה	דיאלקטיקה	NOUN	NOUN	Gender=Fem|Number=Sing	27	iobj	_	_
-31	הגליאנית	הגליאנית	ADJ	ADJ	_	30	amod	_	_
+31	הגליאנית	הגליאנית	ADJ	ADJ	_	30	amod	_	SpaceAfter=No
 32	,	_	PUNCT	PUNCT	_	30	punct	_	_
 33-34	לתיאוריות	_	_	_	_	_	_	_	_
 33	ל	ל	ADP	ADP	_	34	case	_	_
@@ -9391,11 +9391,11 @@
 47-48	וכך	_	_	_	_	_	_	_	_
 47	ו	ו	CCONJ	CCONJ	_	30	advmod	_	_
 48	כך	כך	ADV	ADV	_	47	fixed	_	_
-49	הלאה	הלאה	ADV	ADV	_	47	fixed	_	_
+49	הלאה	הלאה	ADV	ADV	_	47	fixed	_	SpaceAfter=No
 50	.	_	PUNCT	PUNCT	_	7	punct	_	_
 
 # sent_id = 272
-# text = וזה אינו מבצע מהסוג שיש לגשת אליו ללא מימון נכבד .
+# text = וזה אינו מבצע מהסוג שיש לגשת אליו ללא מימון נכבד.
 1-2	וזה	_	_	_	_	_	_	_	_
 1	ו	ו	CCONJ	CCONJ	_	4	cc	_	_
 2	זה	זה	PRON	PRON	Gender=Masc|Number=Sing|Person=3	4	nsubj	_	_
@@ -9414,11 +9414,11 @@
 12	_הוא	הוא	PRON	PRON	Gender=Masc|Number=Sing|Person=3|PronType=Prs	10	iobj	_	_
 13	ללא	ללא	ADP	ADP	_	14	case	_	_
 14	מימון	מימון	NOUN	NOUN	Gender=Masc|Number=Sing	10	obl	_	_
-15	נכבד	נכבד	ADJ	ADJ	Gender=Masc|Number=Sing	14	amod	_	_
+15	נכבד	נכבד	ADJ	ADJ	Gender=Masc|Number=Sing	14	amod	_	SpaceAfter=No
 16	.	_	PUNCT	PUNCT	_	4	punct	_	_
 
 # sent_id = 273
-# text = היכולת לחזות תוצאות בחירות בארצות הברית באמצעות סקרי דעת קהל עשויה להצטמצם בשנים הבאות עד למינימום .
+# text = היכולת לחזות תוצאות בחירות בארצות הברית באמצעות סקרי דעת קהל עשויה להצטמצם בשנים הבאות עד למינימום.
 1-2	היכולת	_	_	_	_	_	_	_	_
 1	ה	ה	DET	DET	PronType=Art	2	det:def	_	_
 2	יכולת	יכולת	NOUN	NOUN	Gender=Fem|Number=Sing	14	nsubj	_	_
@@ -9445,14 +9445,14 @@
 19	ה	ה	DET	DET	PronType=Art	20	det:def	_	_
 20	באות	בא	ADJ	ADJ	Gender=Fem|Number=Plur	18	amod	_	_
 21	עד	עד	ADP	ADP	_	24	case	_	_
-22-24	למינימום	_	_	_	_	_	_	_	_
+22-24	למינימום	_	_	_	_	_	_	_	SpaceAfter=No
 22	ל	ל	ADP	ADP	_	24	case	_	_
 23	ה_	ה	DET	DET	PronType=Art	24	det:def	_	_
 24	מינימום	מינימום	NOUN	NOUN	Gender=Masc|Number=Sing	15	obl	_	_
 25	.	_	PUNCT	PUNCT	_	14	punct	_	_
 
 # sent_id = 274
-# text = כישלונות חיזוי כבר נראו בכמה ממירוצי הבחירות של השבוע .
+# text = כישלונות חיזוי כבר נראו בכמה ממירוצי הבחירות של השבוע.
 1	כישלונות	כישלון	NOUN	NOUN	Definite=Cons|Gender=Masc|Number=Plur	4	nsubj	_	_
 2	חיזוי	חיזוי	NOUN	NOUN	Gender=Masc|Number=Sing	1	compound:smixut	_	_
 3	כבר	כבר	ADV	ADV	_	4	advmod	_	_
@@ -9467,13 +9467,13 @@
 9	ה	ה	DET	DET	PronType=Art	10	det:def	_	_
 10	בחירות	בחירות	NOUN	NOUN	Gender=Fem|Number=Plur	8	compound:smixut	_	_
 11	של	של	PART	PART	Case=Gen	13	case:gen	_	_
-12-13	השבוע	_	_	_	_	_	_	_	_
+12-13	השבוע	_	_	_	_	_	_	_	SpaceAfter=No
 12	ה	ה	DET	DET	PronType=Art	13	det:def	_	_
 13	שבוע	שבוע	NOUN	NOUN	Gender=Masc|Number=Sing	8	nmod:poss	_	_
 14	.	_	PUNCT	PUNCT	_	4	punct	_	_
 
 # sent_id = 275
-# text = האשמה אינה בשיטה או במדגם , אלא בשתי עובדות : ( 1 ) אמריקאים אינם מתעניינים ביותר בתהליך האלקטורלי , וגם אלה היודעים בעד מי היו רוצים להצביע אינם יודעים עד הרגע האחרון אם יטרחו להצביע .
+# text = האשמה אינה בשיטה או במדגם, אלא בשתי עובדות: (1) אמריקאים אינם מתעניינים ביותר בתהליך האלקטורלי, וגם אלה היודעים בעד מי היו רוצים להצביע אינם יודעים עד הרגע האחרון אם יטרחו להצביע.
 1-2	האשמה	_	_	_	_	_	_	_	_
 1	ה	ה	DET	DET	PronType=Art	2	det:def	_	_
 2	אשמה	אשמה	NOUN	NOUN	Gender=Fem|Number=Sing	6	nsubj	_	_
@@ -9483,7 +9483,7 @@
 5	ה_	ה	DET	DET	PronType=Art	6	det:def	_	_
 6	שיטה	שיטה	NOUN	NOUN	Gender=Fem|Number=Sing	0	root	_	_
 7	או	או	CCONJ	CCONJ	_	10	cc	_	_
-8-10	במדגם	_	_	_	_	_	_	_	_
+8-10	במדגם	_	_	_	_	_	_	_	SpaceAfter=No
 8	ב	ב	ADP	ADP	_	10	case	_	_
 9	ה_	ה	DET	DET	PronType=Art	10	det:def	_	_
 10	מדגם	מדגם	NOUN	NOUN	Gender=Masc|Number=Sing	6	conj	_	_
@@ -9492,10 +9492,10 @@
 13-14	בשתי	_	_	_	_	_	_	_	_
 13	ב	ב	ADP	ADP	_	15	case	_	_
 14	שתי	שתיים	NUM	NUM	Definite=Cons|Gender=Fem|Number=Plur	15	nummod	_	_
-15	עובדות	עובדה	NOUN	NOUN	Gender=Fem|Number=Plur	6	conj	_	_
+15	עובדות	עובדה	NOUN	NOUN	Gender=Fem|Number=Plur	6	conj	_	SpaceAfter=No
 16	:	_	PUNCT	PUNCT	_	22	punct	_	_
-17	(	_	PUNCT	PUNCT	_	18	punct	_	_
-18	1	_	NUM	NUM	_	22	parataxis	_	_
+17	(	_	PUNCT	PUNCT	_	18	punct	_	SpaceAfter=No
+18	1	_	NUM	NUM	_	22	parataxis	_	SpaceAfter=No
 19	)	_	PUNCT	PUNCT	_	18	punct	_	_
 20	אמריקאים	אמריקני	NOUN	NOUN	Gender=Masc|Number=Plur	22	nsubj	_	_
 21	אינם	אינו	VERB	VERB	Gender=Masc|Number=Plur|Person=3|Polarity=Neg|VerbForm=Part|VerbType=Cop	22	advmod	_	_
@@ -9505,7 +9505,7 @@
 24	ב	ב	ADP	ADP	_	26	case	_	_
 25	ה_	ה	DET	DET	PronType=Art	26	det:def	_	_
 26	תהליך	תהליך	NOUN	NOUN	Gender=Masc|Number=Sing	22	obl	_	_
-27-28	האלקטורלי	_	_	_	_	_	_	_	_
+27-28	האלקטורלי	_	_	_	_	_	_	_	SpaceAfter=No
 27	ה	ה	DET	DET	PronType=Art	28	det:def	_	_
 28	אלקטורלי	אלקטורלי	ADJ	ADJ	Gender=Masc|Number=Sing	26	amod	_	_
 29	,	_	PUNCT	PUNCT	_	22	punct	_	_
@@ -9532,11 +9532,11 @@
 46	אחרון	אחרון	ADJ	ADJ	Gender=Masc|Number=Sing	44	amod	_	_
 47	אם	אם	SCONJ	SCONJ	_	48	mark	_	_
 48	יטרחו	טרח	VERB	VERB	Gender=Fem,Masc|HebBinyan=PAAL|Number=Plur|Person=3|Tense=Fut|Voice=Act	41	advcl	_	_
-49	להצביע	הצביע	VERB	VERB	HebBinyan=HIFIL|VerbForm=Inf|Voice=Act	48	xcomp	_	_
+49	להצביע	הצביע	VERB	VERB	HebBinyan=HIFIL|VerbForm=Inf|Voice=Act	48	xcomp	_	SpaceAfter=No
 50	.	_	PUNCT	PUNCT	_	6	punct	_	_
 
 # sent_id = 276
-# text = רק 35 % מהם הצביעו ביום ג בבחירות לקונגרס ולמושלי המדינות .
+# text = רק 35 % מהם הצביעו ביום ג בבחירות לקונגרס ולמושלי המדינות.
 1	רק	רק	ADV	ADV	_	3	det	_	_
 2	35	_	NUM	NUM	_	3	nummod	_	_
 3	%	%	NOUN	NOUN	Gender=Masc|Number=Plur,Sing	6	nsubj	_	_
@@ -9560,15 +9560,15 @@
 16	ו	ו	CCONJ	CCONJ	_	18	cc	_	_
 17	ל	ל	ADP	ADP	_	18	case	_	_
 18	מושלי	מושל	NOUN	NOUN	Definite=Cons|Gender=Masc|Number=Plur	15	conj	_	_
-19-20	המדינות	_	_	_	_	_	_	_	_
+19-20	המדינות	_	_	_	_	_	_	_	SpaceAfter=No
 19	ה	ה	DET	DET	PronType=Art	20	det:def	_	_
 20	מדינות	מדינה	NOUN	NOUN	Gender=Fem|Number=Plur	18	compound:smixut	_	_
 21	.	_	PUNCT	PUNCT	_	6	punct	_	_
 
 # sent_id = 277
-# text = ( 2 ) תחנת הקלפי שוב אינה מקום ההצבעה ההכרחי היחיד .
-1	(	_	PUNCT	PUNCT	_	2	punct	_	_
-2	2	_	NUM	NUM	_	9	parataxis	_	_
+# text = (2) תחנת הקלפי שוב אינה מקום ההצבעה ההכרחי היחיד.
+1	(	_	PUNCT	PUNCT	_	2	punct	_	SpaceAfter=No
+2	2	_	NUM	NUM	_	9	parataxis	_	SpaceAfter=No
 3	)	_	PUNCT	PUNCT	_	2	punct	_	_
 4	תחנת	תחנה	NOUN	NOUN	Definite=Cons|Gender=Fem|Number=Sing	9	nsubj	_	_
 5-6	הקלפי	_	_	_	_	_	_	_	_
@@ -9583,13 +9583,13 @@
 12-13	ההכרחי	_	_	_	_	_	_	_	_
 12	ה	ה	DET	DET	PronType=Art	13	det:def	_	_
 13	הכרחי	הכרחי	ADJ	ADJ	Gender=Masc|Number=Sing	9	amod	_	_
-14-15	היחיד	_	_	_	_	_	_	_	_
+14-15	היחיד	_	_	_	_	_	_	_	SpaceAfter=No
 14	ה	ה	DET	DET	PronType=Art	15	det:def	_	_
 15	יחיד	יחיד	ADJ	ADJ	Gender=Masc|Number=Sing	9	amod	_	_
 16	.	_	PUNCT	PUNCT	_	9	punct	_	_
 
 # sent_id = 278
-# text = בקליפורניה הצביעו השנה לא פחות מ20 % מבעלי זכות הבחירה בדואר , לא מפני שהיו בארץ אחרת , או ביבשת אחרת , אלא מפני שהעדיפו את הנוחות הכרוכה במילוי טופסי ההצבעה בין כותלי ביתם .
+# text = בקליפורניה הצביעו השנה לא פחות מ20 % מבעלי זכות הבחירה בדואר, לא מפני שהיו בארץ אחרת, או ביבשת אחרת, אלא מפני שהעדיפו את הנוחות הכרוכה במילוי טופסי ההצבעה בין כותלי ביתם.
 1-2	בקליפורניה	_	_	_	_	_	_	_	_
 1	ב	ב	ADP	ADP	_	2	case	_	_
 2	קליפורניה	קליפורניה	PROPN	PROPN	_	3	obl	_	_
@@ -9608,7 +9608,7 @@
 13-14	הבחירה	_	_	_	_	_	_	_	_
 13	ה	ה	DET	DET	PronType=Art	14	det:def	_	_
 14	בחירה	בחירה	NOUN	NOUN	Gender=Fem|Number=Sing	12	compound:smixut	_	_
-15-17	בדואר	_	_	_	_	_	_	_	_
+15-17	בדואר	_	_	_	_	_	_	_	SpaceAfter=No
 15	ב	ב	ADP	ADP	_	17	case	_	_
 16	ה_	ה	DET	DET	PronType=Art	17	det:def	_	_
 17	דואר	דואר	NOUN	NOUN	Gender=Masc|Number=Sing	3	obl	_	_
@@ -9621,13 +9621,13 @@
 23-24	בארץ	_	_	_	_	_	_	_	_
 23	ב	ב	ADP	ADP	_	24	case	_	_
 24	ארץ	ארץ	NOUN	NOUN	Gender=Fem|Number=Sing	22	iobj	_	_
-25	אחרת	אחר	ADJ	ADJ	Gender=Fem|Number=Sing	24	amod	_	_
+25	אחרת	אחר	ADJ	ADJ	Gender=Fem|Number=Sing	24	amod	_	SpaceAfter=No
 26	,	_	PUNCT	PUNCT	_	24	punct	_	_
 27	או	או	CCONJ	CCONJ	_	29	cc	_	_
 28-29	ביבשת	_	_	_	_	_	_	_	_
 28	ב	ב	ADP	ADP	_	29	case	_	_
 29	יבשת	יבשת	NOUN	NOUN	Gender=Fem|Number=Sing	24	conj	_	_
-30	אחרת	אחר	ADJ	ADJ	Gender=Fem|Number=Sing	29	amod	_	_
+30	אחרת	אחר	ADJ	ADJ	Gender=Fem|Number=Sing	29	amod	_	SpaceAfter=No
 31	,	_	PUNCT	PUNCT	_	22	punct	_	_
 32	אלא	אלא	CCONJ	CCONJ	_	35	cc	_	_
 33	מפני	מפני	ADP	ADP	_	35	case	_	_
@@ -9650,14 +9650,14 @@
 45	הצבעה	הצבעה	NOUN	NOUN	Gender=Fem|Number=Sing	43	compound:smixut	_	_
 46	בין	בין	ADP	ADP	_	47	case	_	_
 47	כותלי	כותל	NOUN	NOUN	Definite=Cons	42	nmod	_	_
-48-50	ביתם	_	_	_	_	_	_	_	_
+48-50	ביתם	_	_	_	_	_	_	_	SpaceAfter=No
 48	בית_	בית	NOUN	NOUN	Definite=Def|Gender=Masc|Number=Sing	47	compound:smixut	_	_
 49	_של_	של	ADP	ADP	_	50	case:gen	_	_
 50	_הם	הוא	PRON	PRON	Case=Gen|Gender=Masc|Number=Plur|Person=3|PronType=Prs	48	nmod:poss	_	_
 51	.	_	PUNCT	PUNCT	_	3	punct	_	_
 
 # sent_id = 279
-# text = ייתכן מאוד שבהצבעה בקלפי היתה ידה של המועמדת הדמוקרטית למושל , דיאן פיינסטיין , על העליונה .
+# text = ייתכן מאוד שבהצבעה בקלפי היתה ידה של המועמדת הדמוקרטית למושל, דיאן פיינסטיין, על העליונה.
 1	ייתכן	ייתכן	AUX	AUX	VerbType=Mod	0	root	_	_
 2	מאוד	מאוד	ADV	ADV	_	1	advmod	_	_
 3-6	שבהצבעה	_	_	_	_	_	_	_	_
@@ -9681,22 +9681,22 @@
 17-18	הדמוקרטית	_	_	_	_	_	_	_	_
 17	ה	ה	DET	DET	PronType=Art	18	det:def	_	_
 18	דמוקרטית	דמוקרטי	ADJ	ADJ	Gender=Fem|Number=Sing	16	amod	_	_
-19-21	למושל	_	_	_	_	_	_	_	_
+19-21	למושל	_	_	_	_	_	_	_	SpaceAfter=No
 19	ל	ל	ADP	ADP	_	21	case	_	_
 20	ה_	ה	DET	DET	PronType=Art	21	det:def	_	_
 21	מושל	מושל	NOUN	NOUN	Gender=Masc|Number=Sing	16	iobj	_	_
 22	,	_	PUNCT	PUNCT	_	16	punct	_	_
 23	דיאן	דיאן	PROPN	PROPN	_	16	appos	_	_
-24	פיינסטיין	פיינסטיין	PROPN	PROPN	_	23	flat:name	_	_
+24	פיינסטיין	פיינסטיין	PROPN	PROPN	_	23	flat:name	_	SpaceAfter=No
 25	,	_	PUNCT	PUNCT	_	28	punct	_	_
 26	על	על	ADP	ADP	_	28	case	_	_
-27-28	העליונה	_	_	_	_	_	_	_	_
+27-28	העליונה	_	_	_	_	_	_	_	SpaceAfter=No
 27	ה	ה	DET	DET	PronType=Art	28	det:def	_	_
 28	עליונה	עליון	ADJ	ADJ	Gender=Fem|Number=Sing	1	ccomp	_	_
 29	.	_	PUNCT	PUNCT	_	1	punct	_	_
 
 # sent_id = 280
-# text = כנראה רק בזכות ההצבעה בדואר הצליח לבסוף הסנאטור פיט ווילסון לנצח , בהפרש קטן .
+# text = כנראה רק בזכות ההצבעה בדואר הצליח לבסוף הסנאטור פיט ווילסון לנצח, בהפרש קטן.
 1	כנראה	כנראה	ADV	ADV	_	9	advmod	_	_
 2	רק	רק	ADV	ADV	_	3	advmod	_	_
 3	בזכות	בזכות	ADP	ADP	_	5	case	_	_
@@ -9714,16 +9714,16 @@
 12	סנאטור	סנטור	NOUN	NOUN	Gender=Masc|Number=Sing	9	nsubj	_	_
 13	פיט	פיט	PROPN	PROPN	_	12	appos	_	_
 14	ווילסון	ווילסון	PROPN	PROPN	_	13	flat:name	_	_
-15	לנצח	ניצח	VERB	VERB	HebBinyan=PIEL|VerbForm=Inf|Voice=Act	9	xcomp	_	_
+15	לנצח	ניצח	VERB	VERB	HebBinyan=PIEL|VerbForm=Inf|Voice=Act	9	xcomp	_	SpaceAfter=No
 16	,	_	PUNCT	PUNCT	_	15	punct	_	_
 17-18	בהפרש	_	_	_	_	_	_	_	_
 17	ב	ב	ADP	ADP	_	18	case	_	_
 18	הפרש	הפרש	NOUN	NOUN	Gender=Masc|Number=Sing	15	iobj	_	_
-19	קטן	קטן	ADJ	ADJ	Gender=Masc|Number=Sing	18	amod	_	_
+19	קטן	קטן	ADJ	ADJ	Gender=Masc|Number=Sing	18	amod	_	SpaceAfter=No
 20	.	_	PUNCT	PUNCT	_	9	punct	_	_
 
 # sent_id = 281
-# text = משימתם של עורכי סקרים בשנים הבאות תהיה לברר תחילה האם הנשאל מתכוון להצביע , ובאם אין הוא מתכוון להצביע הייתכן שבכל זאת יצביע באמצעות הדואר .
+# text = משימתם של עורכי סקרים בשנים הבאות תהיה לברר תחילה האם הנשאל מתכוון להצביע, ובאם אין הוא מתכוון להצביע הייתכן שבכל זאת יצביע באמצעות הדואר.
 1-3	משימתם	_	_	_	_	_	_	_	_
 1	משימה_	משימה	NOUN	NOUN	Definite=Def|Gender=Fem|Number=Sing	12	nsubj	_	_
 2	_של_	של	ADP	ADP	_	3	case:gen	_	_
@@ -9746,7 +9746,7 @@
 16	ה	ה	DET	DET	PronType=Art	17	det:def	_	_
 17	נשאל	נשאל	VERB	VERB	Gender=Masc|HebBinyan=NIFAL|Number=Sing|Person=1,2,3|VerbForm=Part|Voice=Mid	18	nsubj	_	_
 18	מתכוון	התכוון	VERB	VERB	Gender=Masc|HebBinyan=HITPAEL|Number=Sing|Person=1,2,3|VerbForm=Part	13	dep	_	_
-19	להצביע	הצביע	VERB	VERB	HebBinyan=HIFIL|VerbForm=Inf|Voice=Act	18	xcomp	_	_
+19	להצביע	הצביע	VERB	VERB	HebBinyan=HIFIL|VerbForm=Inf|Voice=Act	18	xcomp	_	SpaceAfter=No
 20	,	_	PUNCT	PUNCT	_	18	punct	_	_
 21-22	ובאם	_	_	_	_	_	_	_	_
 21	ו	ו	CCONJ	CCONJ	_	25	cc	_	_
@@ -9765,18 +9765,18 @@
 32	זאת	זאת	PRON	PRON	Gender=Fem|Number=Sing|Person=3|PronType=Dem	30	fixed	_	_
 33	יצביע	הצביע	VERB	VERB	Gender=Masc|HebBinyan=HIFIL|Number=Sing|Person=3|Tense=Fut|Voice=Act	28	ccomp	_	_
 34	באמצעות	באמצעות	ADP	ADP	_	36	case	_	_
-35-36	הדואר	_	_	_	_	_	_	_	_
+35-36	הדואר	_	_	_	_	_	_	_	SpaceAfter=No
 35	ה	ה	DET	DET	PronType=Art	36	det:def	_	_
 36	דואר	דואר	NOUN	NOUN	Gender=Masc|Number=Sing	33	obl	_	_
 37	.	_	PUNCT	PUNCT	_	12	punct	_	_
 
 # sent_id = 282
-# text = לד"ר גון סילר , נשיא אוניברסיטת בוסטון שהתמודד על כהונת מושל מסצוסטס , היתה תיאוריה שלמה על אי - ההתאמה של סקרי דעת קהל למציאות האלקטורלית .
+# text = לד"ר גון סילר, נשיא אוניברסיטת בוסטון שהתמודד על כהונת מושל מסצוסטס, היתה תיאוריה שלמה על אי - ההתאמה של סקרי דעת קהל למציאות האלקטורלית.
 1-2	לד"ר	_	_	_	_	_	_	_	_
 1	ל	ל	ADP	ADP	_	2	case	_	_
 2	ד"ר	ד"ר	NOUN	NOUN	Abbr=Yes|Gender=Masc|Number=Sing	16	iobj	_	_
 3	גון	גוון	NOUN	NOUN	Gender=Masc|Number=Sing	2	appos	_	_
-4	סילר	סילר	PROPN	PROPN	_	3	flat:name	_	_
+4	סילר	סילר	PROPN	PROPN	_	3	flat:name	_	SpaceAfter=No
 5	,	_	PUNCT	PUNCT	_	2	punct	_	_
 6	נשיא	נשיא	NOUN	NOUN	Definite=Cons|Gender=Masc|Number=Sing	2	appos	_	_
 7	אוניברסיטת	אוניברסיטה	NOUN	NOUN	Definite=Cons|Gender=Fem|Number=Sing	6	compound:smixut	_	_
@@ -9787,7 +9787,7 @@
 11	על	על	ADP	ADP	_	12	case	_	_
 12	כהונת	כהונה	NOUN	NOUN	Definite=Cons|Gender=Fem|Number=Sing	10	iobj	_	_
 13	מושל	מושל	NOUN	NOUN	Definite=Cons|Gender=Masc|Number=Sing	12	compound:smixut	_	_
-14	מסצוסטס	מסצוסטס	PROPN	PROPN	_	13	compound:smixut	_	_
+14	מסצוסטס	מסצוסטס	PROPN	PROPN	_	13	compound:smixut	_	SpaceAfter=No
 15	,	_	PUNCT	PUNCT	_	16	punct	_	_
 16	היתה	היה	VERB	VERB	Gender=Fem|Number=Sing|Person=3|Polarity=Pos|Tense=Past|VerbType=Cop	0	root	_	_
 17	תיאוריה	תיאוריה	NOUN	NOUN	Gender=Fem|Number=Sing	16	nsubj	_	_
@@ -9806,13 +9806,13 @@
 28	ל	ל	ADP	ADP	_	30	case	_	_
 29	ה_	ה	DET	DET	PronType=Art	30	det:def	_	_
 30	מציאות	מציאות	NOUN	NOUN	Gender=Fem|Number=Sing	23	nmod	_	_
-31-32	האלקטורלית	_	_	_	_	_	_	_	_
+31-32	האלקטורלית	_	_	_	_	_	_	_	SpaceAfter=No
 31	ה	ה	DET	DET	PronType=Art	32	det:def	_	_
 32	אלקטורלית	אלקטורלי	ADJ	ADJ	Gender=Fem|Number=Sing	30	amod	_	_
 33	.	_	PUNCT	PUNCT	_	16	punct	_	_
 
 # sent_id = 283
-# text = הוא היה קורבן של אי - התאמה כזאת .
+# text = הוא היה קורבן של אי - התאמה כזאת.
 1	הוא	הוא	PRON	PRON	Gender=Masc|Number=Sing|Person=3|PronType=Prs	3	nsubj	_	_
 2	היה	היה	VERB	VERB	Gender=Masc|Number=Sing|Person=3|Polarity=Pos|Tense=Past|VerbType=Cop	3	aux	_	_
 3	קורבן	קורבן	NOUN	NOUN	Gender=Masc|Number=Sing	0	root	_	_
@@ -9820,14 +9820,14 @@
 5	אי	אי	ADV	ADV	HebSource=ConvUncertainHead|Prefix=Yes	7	dep	_	_
 6	-	_	PUNCT	PUNCT	_	7	punct	_	_
 7	התאמה	התאמה	NOUN	NOUN	Gender=Fem|Number=Sing	3	nmod:poss	_	_
-8-10	כזאת	_	_	_	_	_	_	_	_
+8-10	כזאת	_	_	_	_	_	_	_	SpaceAfter=No
 8	כ	כ	ADP	ADP	_	10	case	_	_
 9	ה_	ה	DET	DET	PronType=Art	10	det:def	_	_
 10	זאת	זאת	PRON	PRON	Gender=Fem|Number=Sing|Person=3|PronType=Dem	7	nmod	_	_
 11	.	_	PUNCT	PUNCT	_	3	punct	_	_
 
 # sent_id = 284
-# text = הסקרים חזו לו תבוסה ניצחת בבחירות המוקדמות של המפלגה הדמוקרטית , בחודש ספטמבר .
+# text = הסקרים חזו לו תבוסה ניצחת בבחירות המוקדמות של המפלגה הדמוקרטית, בחודש ספטמבר.
 1-2	הסקרים	_	_	_	_	_	_	_	_
 1	ה	ה	DET	DET	PronType=Art	2	det:def	_	_
 2	סקרים	סקר	NOUN	NOUN	Gender=Masc|Number=Plur	3	nsubj	_	_
@@ -9848,22 +9848,22 @@
 14-15	המפלגה	_	_	_	_	_	_	_	_
 14	ה	ה	DET	DET	PronType=Art	15	det:def	_	_
 15	מפלגה	מפלגה	NOUN	NOUN	Gender=Fem|Number=Sing	10	nmod	_	_
-16-17	הדמוקרטית	_	_	_	_	_	_	_	_
+16-17	הדמוקרטית	_	_	_	_	_	_	_	SpaceAfter=No
 16	ה	ה	DET	DET	PronType=Art	17	det:def	_	_
 17	דמוקרטית	דמוקרטי	ADJ	ADJ	Gender=Fem|Number=Sing	15	amod	_	_
 18	,	_	PUNCT	PUNCT	_	10	punct	_	_
 19-20	בחודש	_	_	_	_	_	_	_	_
 19	ב	ב	ADP	ADP	_	20	case	_	_
 20	חודש	חודש	NOUN	NOUN	Definite=Cons|Gender=Masc|Number=Sing	10	nmod	_	_
-21	ספטמבר	ספטמבר	PROPN	PROPN	_	20	compound:smixut	_	_
+21	ספטמבר	ספטמבר	PROPN	PROPN	_	20	compound:smixut	_	SpaceAfter=No
 22	.	_	PUNCT	PUNCT	_	3	punct	_	_
 
 # sent_id = 285
-# text = הוא הדהים את מפלגתו , את מדינתו ואת ארה"ב בניצחון .
+# text = הוא הדהים את מפלגתו, את מדינתו ואת ארה"ב בניצחון.
 1	הוא	הוא	PRON	PRON	Gender=Masc|Number=Sing|Person=3|PronType=Prs	2	nsubj	_	_
 2	הדהים	הדהים	VERB	VERB	Gender=Masc|HebBinyan=HIFIL|Number=Sing|Person=3|Tense=Past|Voice=Act	0	root	_	_
 3	את	את	PART	PART	Case=Acc	4	case:acc	_	_
-4-6	מפלגתו	_	_	_	_	_	_	_	_
+4-6	מפלגתו	_	_	_	_	_	_	_	SpaceAfter=No
 4	מפלגה_	מפלגה	NOUN	NOUN	Definite=Def|Gender=Fem|Number=Sing	2	obj	_	_
 5	_של_	של	ADP	ADP	_	6	case:gen	_	_
 6	_הוא	הוא	PRON	PRON	Case=Gen|Gender=Masc|Number=Sing|Person=3|PronType=Prs	4	nmod:poss	_	_
@@ -9877,14 +9877,14 @@
 12	ו	ו	CCONJ	CCONJ	_	14	cc	_	_
 13	את	את	PART	PART	Case=Acc	14	case:acc	_	_
 14	ארה"ב	ארה"ב	PROPN	PROPN	Abbr=Yes	4	conj	_	_
-15-17	בניצחון	_	_	_	_	_	_	_	_
+15-17	בניצחון	_	_	_	_	_	_	_	SpaceAfter=No
 15	ב	ב	ADP	ADP	_	17	case	_	_
 16	ה_	ה	DET	DET	PronType=Art	17	det:def	_	_
 17	ניצחון	ניצחון	NOUN	NOUN	Gender=Masc|Number=Sing	2	iobj	_	_
 18	.	_	PUNCT	PUNCT	_	2	punct	_	_
 
 # sent_id = 286
-# text = במהלך מערכת הבחירות הכללית העלה סילבר את ההסבר הבא לאי - ההתאמות .
+# text = במהלך מערכת הבחירות הכללית העלה סילבר את ההסבר הבא לאי - ההתאמות.
 1-2	במהלך	_	_	_	_	_	_	_	_
 1	ב	ב	ADP	ADP	_	3	case	_	_
 2	מהלך	מהלך	NOUN	NOUN	Gender=Masc|Number=Sing	1	fixed	_	_
@@ -9908,20 +9908,20 @@
 15	ל	ל	ADP	ADP	_	19	case	_	_
 16	אי	אי	ADV	ADV	Prefix=Yes	19	advmod	_	_
 17	-	_	PUNCT	PUNCT	_	19	punct	_	_
-18-19	ההתאמות	_	_	_	_	_	_	_	_
+18-19	ההתאמות	_	_	_	_	_	_	_	SpaceAfter=No
 18	ה	ה	DET	DET	PronType=Art	19	det:def	_	_
 19	התאמות	התאמה	NOUN	NOUN	Gender=Fem|Number=Plur	12	nmod	_	_
 20	.	_	PUNCT	PUNCT	_	8	punct	_	_
 
 # sent_id = 287
-# text = " אמריקאים " , אמר , " מתרעמים על עצם השאלה איך תצביע .
-1	"	_	PUNCT	PUNCT	_	8	punct	_	_
-2	אמריקאים	אמריקני	NOUN	NOUN	Gender=Masc|Number=Plur	8	nsubj	_	_
-3	"	_	PUNCT	PUNCT	_	8	punct	_	_
+# text = "אמריקאים", אמר, "מתרעמים על עצם השאלה איך תצביע.
+1	"	_	PUNCT	PUNCT	_	8	punct	_	SpaceAfter=No
+2	אמריקאים	אמריקני	NOUN	NOUN	Gender=Masc|Number=Plur	8	nsubj	_	SpaceAfter=No
+3	"	_	PUNCT	PUNCT	_	8	punct	_	SpaceAfter=No
 4	,	_	PUNCT	PUNCT	_	5	punct	_	_
-5	אמר	אמר	VERB	VERB	Gender=Masc|HebBinyan=PAAL|Number=Sing|Person=3|Tense=Past|Voice=Act	8	parataxis	_	_
+5	אמר	אמר	VERB	VERB	Gender=Masc|HebBinyan=PAAL|Number=Sing|Person=3|Tense=Past|Voice=Act	8	parataxis	_	SpaceAfter=No
 6	,	_	PUNCT	PUNCT	_	5	punct	_	_
-7	"	_	PUNCT	PUNCT	_	8	punct	_	_
+7	"	_	PUNCT	PUNCT	_	8	punct	_	SpaceAfter=No
 8	מתרעמים	התרעם	VERB	VERB	Gender=Masc|HebBinyan=HITPAEL|Number=Plur|Person=1,2,3|VerbForm=Part	0	root	_	_
 9	על	על	ADP	ADP	_	10	case	_	_
 10	עצם	עצם	NOUN	NOUN	Definite=Cons|Gender=Masc|Number=Sing	8	iobj	_	_
@@ -9929,13 +9929,13 @@
 11	ה	ה	DET	DET	PronType=Art	12	det:def	_	_
 12	שאלה	שאלה	NOUN	NOUN	Gender=Fem|Number=Sing	10	compound:smixut	_	_
 13	איך	איך	ADV	ADV	PronType=Int	14	advmod	_	_
-14	תצביע	הצביע	VERB	VERB	Gender=Masc|HebBinyan=HIFIL|HebSource=ConvUncertainHead|Number=Sing|Person=2|Tense=Fut|Voice=Act	12	dep	_	_
+14	תצביע	הצביע	VERB	VERB	Gender=Masc|HebBinyan=HIFIL|HebSource=ConvUncertainHead|Number=Sing|Person=2|Tense=Fut|Voice=Act	12	dep	_	SpaceAfter=No
 15	.	_	PUNCT	PUNCT	_	8	punct	_	_
 
 # sent_id = 288
-# text = סוף סוף , כל עניין ההצבעה החופשית הוא פונקציה של סודיותה .
+# text = סוף סוף, כל עניין ההצבעה החופשית הוא פונקציה של סודיותה.
 1	סוף	סוף	NOUN	NOUN	Gender=Masc|Number=Sing	11	advmod	_	_
-2	סוף	סוף	NOUN	NOUN	Gender=Masc|Number=Sing	1	fixed	_	_
+2	סוף	סוף	NOUN	NOUN	Gender=Masc|Number=Sing	1	fixed	_	SpaceAfter=No
 3	,	_	PUNCT	PUNCT	_	11	punct	_	_
 4	כל	כול	DET	DET	Definite=Cons	5	det	_	_
 5	עניין	עניין	NOUN	NOUN	Definite=Cons|Gender=Masc|Number=Sing	11	nsubj:cop	_	_
@@ -9948,75 +9948,75 @@
 10	הוא	הוא	VERB	VERB	Gender=Masc|Number=Sing|Person=3|Polarity=Pos|VerbForm=Part|VerbType=Cop	11	cop	_	_
 11	פונקציה	פונקציה	NOUN	NOUN	Gender=Fem|Number=Sing	0	root	_	_
 12	של	של	PART	PART	Case=Gen	13	case:gen	_	_
-13-15	סודיותה	_	_	_	_	_	_	_	_
+13-15	סודיותה	_	_	_	_	_	_	_	SpaceAfter=No
 13	סודיות_	סודיות	NOUN	NOUN	Definite=Def|Gender=Fem|Number=Sing	11	nmod:poss	_	_
 14	_של_	של	ADP	ADP	_	15	case:gen	_	_
 15	_היא	הוא	PRON	PRON	Case=Gen|Gender=Fem|Number=Sing|Person=3|PronType=Prs	13	nmod:poss	_	_
 16	.	_	PUNCT	PUNCT	_	11	punct	_	_
 
 # sent_id = 289
-# text = כאשר מטלפן אליהם מישהו , שאין הם מכירים , ושואל , איך תצביעו , אין הם בטוחים לעולם מיהו , ומדוע הוא שואל .
+# text = כאשר מטלפן אליהם מישהו, שאין הם מכירים, ושואל, איך תצביעו, אין הם בטוחים לעולם מיהו, ומדוע הוא שואל.
 1	כאשר	כאשר	SCONJ	SCONJ	_	2	mark	_	_
 2	מטלפן	טילפן	VERB	VERB	Gender=Masc|HebBinyan=PIEL|Number=Sing|Person=1,2,3|VerbForm=Part|Voice=Act	20	advcl	_	_
 3-4	אליהם	_	_	_	_	_	_	_	_
 3	אליהם	אל	ADP	ADP	_	4	case	_	_
 4	_הם	הוא	PRON	PRON	Gender=Masc|Number=Plur|Person=3|PronType=Prs	2	obl	_	_
-5	מישהו	מישהו	NOUN	NOUN	Gender=Masc|Number=Sing	2	nsubj	_	_
+5	מישהו	מישהו	NOUN	NOUN	Gender=Masc|Number=Sing	2	nsubj	_	SpaceAfter=No
 6	,	_	PUNCT	PUNCT	_	5	punct	_	_
 7-8	שאין	_	_	_	_	_	_	_	_
 7	ש	ש	SCONJ	SCONJ	_	10	mark	_	_
 8	אין	_	ADV	ADV	Polarity=Neg	10	advmod	_	_
 9	הם	הוא	PRON	PRON	Gender=Masc|Number=Plur|Person=3|PronType=Prs	10	nsubj	_	_
-10	מכירים	הכיר	VERB	VERB	Gender=Masc|Number=Plur|Person=1,2,3|VerbForm=Part	5	acl:relcl	_	_
+10	מכירים	הכיר	VERB	VERB	Gender=Masc|Number=Plur|Person=1,2,3|VerbForm=Part	5	acl:relcl	_	SpaceAfter=No
 11	,	_	PUNCT	PUNCT	_	2	punct	_	_
-12-13	ושואל	_	_	_	_	_	_	_	_
+12-13	ושואל	_	_	_	_	_	_	_	SpaceAfter=No
 12	ו	ו	CCONJ	CCONJ	_	13	cc	_	_
 13	שואל	שאל	VERB	VERB	Gender=Masc|HebBinyan=PAAL|Number=Sing|Person=1,2,3|VerbForm=Part|Voice=Act	2	conj	_	_
 14	,	_	PUNCT	PUNCT	_	13	punct	_	_
 15	איך	איך	ADV	ADV	PronType=Int	16	advmod	_	_
-16	תצביעו	הצביע	VERB	VERB	Gender=Fem,Masc|HebBinyan=HIFIL|Number=Plur|Person=2|Tense=Fut|Voice=Act	13	iobj	_	_
+16	תצביעו	הצביע	VERB	VERB	Gender=Fem,Masc|HebBinyan=HIFIL|Number=Plur|Person=2|Tense=Fut|Voice=Act	13	iobj	_	SpaceAfter=No
 17	,	_	PUNCT	PUNCT	_	20	punct	_	_
 18	אין	_	ADV	ADV	Polarity=Neg	20	advmod	_	_
 19	הם	הוא	PRON	PRON	Gender=Masc|Number=Plur|Person=3|PronType=Prs	20	nsubj	_	_
 20	בטוחים	בטוח	VERB	VERB	VerbForm=Part	0	root	_	_
 21	לעולם	לעולם	ADV	ADV	_	20	advmod	_	_
-22	מיהו	מי	PRON	PRON	Gender=Masc|Number=Sing|PronType=Int	20	advcl	_	_
+22	מיהו	מי	PRON	PRON	Gender=Masc|Number=Sing|PronType=Int	20	advcl	_	SpaceAfter=No
 23	,	_	PUNCT	PUNCT	_	22	punct	_	_
 24-25	ומדוע	_	_	_	_	_	_	_	_
 24	ו	ו	CCONJ	CCONJ	_	27	cc	_	_
 25	מדוע	מדוע	ADV	ADV	PronType=Int	27	advmod	_	_
 26	הוא	הוא	PRON	PRON	Gender=Masc|Number=Sing|Person=3|PronType=Prs	27	nsubj	_	_
-27	שואל	שאל	VERB	VERB	Gender=Masc|HebBinyan=PAAL|Number=Sing|Person=1,2,3|VerbForm=Part|Voice=Act	22	conj	_	_
+27	שואל	שאל	VERB	VERB	Gender=Masc|HebBinyan=PAAL|Number=Sing|Person=1,2,3|VerbForm=Part|Voice=Act	22	conj	_	SpaceAfter=No
 28	.	_	PUNCT	PUNCT	_	20	punct	_	_
 
 # sent_id = 290
-# text = אולי הוא השכן ?
+# text = אולי הוא השכן?
 1	אולי	אולי	ADV	ADV	_	4	advmod	_	_
 2	הוא	הוא	PRON	PRON	Gender=Masc|Number=Sing|Person=3|PronType=Prs	4	nsubj	_	_
-3-4	השכן	_	_	_	_	_	_	_	_
+3-4	השכן	_	_	_	_	_	_	_	SpaceAfter=No
 3	ה	ה	DET	DET	PronType=Art	4	det:def	_	_
 4	שכן	שכן	NOUN	NOUN	Gender=Masc|Number=Sing	0	root	_	_
 5	?	_	PUNCT	PUNCT	_	4	punct	_	_
 
 # sent_id = 291
-# text = אולי הוא ידיד , המנסה להכשילם ?
+# text = אולי הוא ידיד, המנסה להכשילם?
 1	אולי	אולי	ADV	ADV	_	3	advmod	_	_
 2	הוא	הוא	PRON	PRON	Gender=Masc|Number=Sing|Person=3|PronType=Prs	3	nsubj	_	_
-3	ידיד	ידיד	NOUN	NOUN	Gender=Masc|Number=Sing	0	root	_	_
+3	ידיד	ידיד	NOUN	NOUN	Gender=Masc|Number=Sing	0	root	_	SpaceAfter=No
 4	,	_	PUNCT	PUNCT	_	3	punct	_	_
 5-6	המנסה	_	_	_	_	_	_	_	_
 5	ה	ה	SCONJ	SCONJ	_	6	mark	_	_
 6	מנסה	ניסה	VERB	VERB	Gender=Masc|HebBinyan=PIEL|Number=Sing|Person=1,2,3|VerbForm=Part|Voice=Act	3	acl:relcl	_	_
-7-8	להכשילם	_	_	_	_	_	_	_	_
+7-8	להכשילם	_	_	_	_	_	_	_	SpaceAfter=No
 7	להכשילם	הכשיל	VERB	VERB	HebBinyan=HIFIL|VerbForm=Inf|Voice=Act	6	xcomp	_	_
 8	_הם	הוא	PRON	PRON	Case=Acc|Gender=Masc|Number=Plur|Person=3|PronType=Prs	7	obj	_	_
 9	?	_	PUNCT	PUNCT	_	3	punct	_	_
 
 # sent_id = 292
-# text = אולי הוא הבוס , המתכוון לעשות טיהור פוליטי במשרד ?
+# text = אולי הוא הבוס, המתכוון לעשות טיהור פוליטי במשרד?
 1	אולי	אולי	ADV	ADV	_	4	advmod	_	_
 2	הוא	הוא	PRON	PRON	Gender=Masc|Number=Sing|Person=3|PronType=Prs	4	nsubj	_	_
-3-4	הבוס	_	_	_	_	_	_	_	_
+3-4	הבוס	_	_	_	_	_	_	_	SpaceAfter=No
 3	ה	ה	DET	DET	PronType=Art	4	det:def	_	_
 4	בוס	בוס	NOUN	NOUN	Gender=Masc|Number=Sing	0	root	_	_
 5	,	_	PUNCT	PUNCT	_	4	punct	_	_
@@ -10026,27 +10026,27 @@
 8	לעשות	עשה	VERB	VERB	HebBinyan=PAAL|VerbForm=Inf|Voice=Act	7	xcomp	_	_
 9	טיהור	טיהור	NOUN	NOUN	Gender=Fem|Number=Sing	8	obj	_	_
 10	פוליטי	פוליטי	ADJ	ADJ	Gender=Masc|Number=Sing	9	amod	_	_
-11-13	במשרד	_	_	_	_	_	_	_	_
+11-13	במשרד	_	_	_	_	_	_	_	SpaceAfter=No
 11	ב	ב	ADP	ADP	_	13	case	_	_
 12	ה_	ה	DET	DET	PronType=Art	13	det:def	_	_
 13	משרד	משרד	NOUN	NOUN	Gender=Masc|Number=Sing	8	obl	_	_
 14	?	_	PUNCT	PUNCT	_	4	punct	_	_
 
 # sent_id = 293
-# text = ואז הם מתרגזים ומשקרים " .
+# text = ואז הם מתרגזים ומשקרים".
 1-2	ואז	_	_	_	_	_	_	_	_
 1	ו	ו	CCONJ	CCONJ	_	5	cc	_	_
 2	אז	אז	ADV	ADV	_	4	advmod	_	_
 3	הם	הוא	PRON	PRON	Gender=Masc|Number=Plur|Person=3|PronType=Prs	4	nsubj	_	_
 4	מתרגזים	התרגז	VERB	VERB	Gender=Masc|HebBinyan=HITPAEL|Number=Plur|Person=1,2,3|VerbForm=Part	0	root	_	_
-5-6	ומשקרים	_	_	_	_	_	_	_	_
+5-6	ומשקרים	_	_	_	_	_	_	_	SpaceAfter=No
 5	ו	ו	CCONJ	CCONJ	_	6	cc	_	_
 6	משקרים	שיקר	VERB	VERB	Gender=Masc|HebBinyan=PIEL|Number=Plur|Person=1,2,3|VerbForm=Part|Voice=Act	4	conj	_	_
-7	"	_	PUNCT	PUNCT	_	4	punct	_	_
+7	"	_	PUNCT	PUNCT	_	4	punct	_	SpaceAfter=No
 8	.	_	PUNCT	PUNCT	_	4	punct	_	_
 
 # sent_id = 294
-# text = ביום ששמעתי את התיאוריה הזו מפי סילבר פרסם העיתון " בוסטון גלוב " סקר , שהראה לראשונה יתרון לסילבר על פני יריבו הרפובליקאי , ויליאם וולד .
+# text = ביום ששמעתי את התיאוריה הזו מפי סילבר פרסם העיתון "בוסטון גלוב" סקר, שהראה לראשונה יתרון לסילבר על פני יריבו הרפובליקאי, ויליאם וולד.
 1-3	ביום	_	_	_	_	_	_	_	_
 1	ב	ב	ADP	ADP	_	3	case	_	_
 2	ה_	ה	DET	DET	PronType=Art	3	det:def	_	_
@@ -10069,11 +10069,11 @@
 15-16	העיתון	_	_	_	_	_	_	_	_
 15	ה	ה	DET	DET	PronType=Art	16	det:def	_	_
 16	עיתון	עיתון	NOUN	NOUN	Gender=Masc|Number=Sing	14	nsubj	_	_
-17	"	_	PUNCT	PUNCT	_	18	punct	_	_
+17	"	_	PUNCT	PUNCT	_	18	punct	_	SpaceAfter=No
 18	בוסטון	בוסטון	PROPN	PROPN	_	16	appos	_	_
-19	גלוב	גלוב	PROPN	PROPN	_	18	flat:name	_	_
+19	גלוב	גלוב	PROPN	PROPN	_	18	flat:name	_	SpaceAfter=No
 20	"	_	PUNCT	PUNCT	_	18	punct	_	_
-21	סקר	סקר	NOUN	NOUN	Gender=Masc|Number=Sing	14	obj	_	_
+21	סקר	סקר	NOUN	NOUN	Gender=Masc|Number=Sing	14	obj	_	SpaceAfter=No
 22	,	_	PUNCT	PUNCT	_	21	punct	_	_
 23-24	שהראה	_	_	_	_	_	_	_	_
 23	ש	ש	SCONJ	SCONJ	_	24	mark	_	_
@@ -10089,16 +10089,16 @@
 31	יריב_	יריב	NOUN	NOUN	Definite=Def|Gender=Masc|Number=Sing	30	compound:smixut	_	_
 32	_של_	של	ADP	ADP	_	33	case:gen	_	_
 33	_הוא	הוא	PRON	PRON	Case=Gen|Gender=Masc|Number=Sing|Person=3|PronType=Prs	31	nmod:poss	_	_
-34-35	הרפובליקאי	_	_	_	_	_	_	_	_
+34-35	הרפובליקאי	_	_	_	_	_	_	_	SpaceAfter=No
 34	ה	ה	DET	DET	PronType=Art	35	det:def	_	_
 35	רפובליקאי	רפובליקני	ADJ	ADJ	Gender=Masc|Number=Sing	31	amod	_	_
 36	,	_	PUNCT	PUNCT	_	31	punct	_	_
 37	ויליאם	ויליאם	PROPN	PROPN	_	31	appos	_	_
-38	וולד	ולד	PROPN	PROPN	_	37	flat:name	_	_
+38	וולד	ולד	PROPN	PROPN	_	37	flat:name	_	SpaceAfter=No
 39	.	_	PUNCT	PUNCT	_	14	punct	_	_
 
 # sent_id = 295
-# text = כעבור שבוע התרחב היתרון עד 9 % , ובמסצוסטס היו אנשים משוכנעים בניצחונו של סילבר .
+# text = כעבור שבוע התרחב היתרון עד 9 %, ובמסצוסטס היו אנשים משוכנעים בניצחונו של סילבר.
 1	כעבור	כעבור	ADP	ADP	_	2	case	_	_
 2	שבוע	שבוע	NOUN	NOUN	Gender=Masc|Number=Sing	3	obl	_	_
 3	התרחב	התרחב	VERB	VERB	Gender=Masc|HebBinyan=HITPAEL|Number=Sing|Person=3|Tense=Past	0	root	_	_
@@ -10107,7 +10107,7 @@
 5	יתרון	יתרון	NOUN	NOUN	Gender=Masc|Number=Sing	3	nsubj	_	_
 6	עד	עד	ADP	ADP	_	8	case	_	_
 7	9	_	NUM	NUM	_	8	nummod	_	_
-8	%	%	NOUN	NOUN	Gender=Masc|Number=Plur,Sing	3	obl	_	_
+8	%	%	NOUN	NOUN	Gender=Masc|Number=Plur,Sing	3	obl	_	SpaceAfter=No
 9	,	_	PUNCT	PUNCT	_	3	punct	_	_
 10-12	ובמסצוסטס	_	_	_	_	_	_	_	_
 10	ו	ו	CCONJ	CCONJ	_	15	cc	_	_
@@ -10122,11 +10122,11 @@
 18	_של_	של	ADP	ADP	_	19	case:gen	_	_
 19	_הוא	הוא	PRON	PRON	Case=Gen|Gender=Masc|Number=Sing|Person=3|PronType=Prs	17	nmod:poss	_	_
 20	של	של	PART	PART	Case=Gen	21	case:gen	_	_
-21	סילבר	סילבר	PROPN	PROPN	_	17	nmod:poss	_	_
+21	סילבר	סילבר	PROPN	PROPN	_	17	nmod:poss	_	SpaceAfter=No
 22	.	_	PUNCT	PUNCT	_	3	punct	_	_
 
 # sent_id = 296
-# text = הוא נוצח השבוע בהפרש של שני אחוזים .
+# text = הוא נוצח השבוע בהפרש של שני אחוזים.
 1	הוא	הוא	PRON	PRON	Gender=Masc|Number=Sing|Person=3|PronType=Prs	2	nsubj	_	_
 2	נוצח	נוצח	VERB	VERB	Gender=Masc|HebBinyan=PUAL|Number=Sing|Person=3|Tense=Past|Voice=Pass	0	root	_	_
 3	השבוע	השבוע	ADV	ADV	_	2	obl:tmod	_	_
@@ -10135,11 +10135,11 @@
 5	הפרש	הפרש	NOUN	NOUN	Gender=Masc|Number=Sing	2	obl	_	_
 6	של	של	PART	PART	Case=Gen	8	case:gen	_	_
 7	שני	שניים	NUM	NUM	Definite=Cons|Gender=Masc|Number=Plur	8	nummod	_	_
-8	אחוזים	אחוז	NOUN	NOUN	Gender=Masc|Number=Plur	5	nmod:poss	_	_
+8	אחוזים	אחוז	NOUN	NOUN	Gender=Masc|Number=Plur	5	nmod:poss	_	SpaceAfter=No
 9	.	_	PUNCT	PUNCT	_	2	punct	_	_
 
 # sent_id = 297
-# text = סילבר היה אולי הדמות הפוליטית המרתקת , המורכבת והמסוכנת ביותר במערכת הבחירות של 0991 .
+# text = סילבר היה אולי הדמות הפוליטית המרתקת, המורכבת והמסוכנת ביותר במערכת הבחירות של 0991.
 1	סילבר	סילבר	PROPN	PROPN	_	5	nsubj	_	_
 2	היה	היה	VERB	VERB	Gender=Masc|Number=Sing|Person=3|Polarity=Pos|Tense=Past|VerbType=Cop	5	aux	_	_
 3	אולי	אולי	ADV	ADV	_	5	advmod	_	_
@@ -10149,7 +10149,7 @@
 6-7	הפוליטית	_	_	_	_	_	_	_	_
 6	ה	ה	DET	DET	PronType=Art	7	det:def	_	_
 7	פוליטית	פוליטי	ADJ	ADJ	Gender=Fem|Number=Sing	5	amod	_	_
-8-9	המרתקת	_	_	_	_	_	_	_	_
+8-9	המרתקת	_	_	_	_	_	_	_	SpaceAfter=No
 8	ה	ה	DET	DET	PronType=Art	9	det:def	_	_
 9	מרתקת	מרתק	ADJ	ADJ	Gender=Fem|Number=Sing	5	amod	_	_
 10	,	_	PUNCT	PUNCT	_	9	punct	_	_
@@ -10168,14 +10168,14 @@
 19	ה	ה	DET	DET	PronType=Art	20	det:def	_	_
 20	בחירות	בחירות	NOUN	NOUN	Gender=Fem|Number=Plur	18	compound:smixut	_	_
 21	של	של	PART	PART	Case=Gen	22	case:gen	_	_
-22	0991	_	NUM	NUM	_	18	nmod:poss	_	_
+22	0991	_	NUM	NUM	_	18	nmod:poss	_	SpaceAfter=No
 23	.	_	PUNCT	PUNCT	_	5	punct	_	_
 
 # sent_id = 298
-# text = הוא אינטלקטואל רודני , שהתייחס בבוז מתנשא לכל שאלה שנשאל , ולכל הערה של יריב פוליטי .
+# text = הוא אינטלקטואל רודני, שהתייחס בבוז מתנשא לכל שאלה שנשאל, ולכל הערה של יריב פוליטי.
 1	הוא	הוא	PRON	PRON	Gender=Masc|Number=Sing|Person=3|PronType=Prs	2	nsubj	_	_
 2	אינטלקטואל	אינטלקטואל	NOUN	NOUN	Gender=Masc|Number=Sing	0	root	_	_
-3	רודני	רודני	ADJ	ADJ	Gender=Masc|Number=Sing	2	amod	_	_
+3	רודני	רודני	ADJ	ADJ	Gender=Masc|Number=Sing	2	amod	_	SpaceAfter=No
 4	,	_	PUNCT	PUNCT	_	2	punct	_	_
 5-6	שהתייחס	_	_	_	_	_	_	_	_
 5	ש	ש	SCONJ	SCONJ	_	6	mark	_	_
@@ -10188,7 +10188,7 @@
 10	ל	ל	ADP	ADP	_	12	case	_	_
 11	כל	כול	DET	DET	Definite=Cons	12	det	_	_
 12	שאלה	שאלה	NOUN	NOUN	Gender=Fem|Number=Sing	6	obl	_	_
-13-14	שנשאל	_	_	_	_	_	_	_	_
+13-14	שנשאל	_	_	_	_	_	_	_	SpaceAfter=No
 13	ש	ש	SCONJ	SCONJ	_	14	mark	_	_
 14	נשאל	נשאל	VERB	VERB	Gender=Masc|HebBinyan=NIFAL|Number=Sing|Person=3|Tense=Past|Voice=Mid	12	acl:relcl	_	_
 15	,	_	PUNCT	PUNCT	_	12	punct	_	_
@@ -10199,11 +10199,11 @@
 19	הערה	הערה	NOUN	NOUN	Gender=Fem|Number=Sing	12	conj	_	_
 20	של	של	PART	PART	Case=Gen	21	case:gen	_	_
 21	יריב	יריב	NOUN	NOUN	Gender=Masc|Number=Sing	19	nmod:poss	_	_
-22	פוליטי	פוליטי	ADJ	ADJ	Gender=Masc|Number=Sing	21	amod	_	_
+22	פוליטי	פוליטי	ADJ	ADJ	Gender=Masc|Number=Sing	21	amod	_	SpaceAfter=No
 23	.	_	PUNCT	PUNCT	_	2	punct	_	_
 
 # sent_id = 299
-# text = הוא השמיע הכרזות שערורייתיות בגנות מיעוטים אתניים ונגד קבוצות אוכלוסייה חלשות .
+# text = הוא השמיע הכרזות שערורייתיות בגנות מיעוטים אתניים ונגד קבוצות אוכלוסייה חלשות.
 1	הוא	הוא	PRON	PRON	Gender=Masc|Number=Sing|Person=3|PronType=Prs	2	nsubj	_	_
 2	השמיע	השמיע	VERB	VERB	Gender=Masc|HebBinyan=HIFIL|Number=Sing|Person=3|Tense=Past|Voice=Act	0	root	_	_
 3	הכרזות	הכרזה	NOUN	NOUN	Gender=Fem|Number=Plur	2	obj	_	_
@@ -10218,11 +10218,11 @@
 10	נגד	נגד	ADP	ADP	_	11	case	_	_
 11	קבוצות	קבוצה	NOUN	NOUN	Definite=Cons|Gender=Fem|Number=Plur	6	conj	_	_
 12	אוכלוסייה	אוכלוסייה	NOUN	NOUN	Gender=Fem|Number=Sing	11	compound:smixut	_	_
-13	חלשות	חלש	ADJ	ADJ	Gender=Fem|Number=Plur	11	amod	_	_
+13	חלשות	חלש	ADJ	ADJ	Gender=Fem|Number=Plur	11	amod	_	SpaceAfter=No
 14	.	_	PUNCT	PUNCT	_	2	punct	_	_
 
 # sent_id = 300
-# text = הוא גידף ברבים את יריבו ( " בן כלבה , תוקע סכין בגב " , אמר עליו בראיון עיתונאי ) .
+# text = הוא גידף ברבים את יריבו (" בן כלבה, תוקע סכין בגב ", אמר עליו בראיון עיתונאי).
 1	הוא	הוא	PRON	PRON	Gender=Masc|Number=Sing|Person=3|PronType=Prs	2	nsubj	_	_
 2	גידף	גידף	VERB	VERB	Gender=Masc|HebBinyan=PIEL|Number=Sing|Person=3|Tense=Past|Voice=Act	0	root	_	_
 3-5	ברבים	_	_	_	_	_	_	_	_
@@ -10234,10 +10234,10 @@
 7	יריב_	יריב	NOUN	NOUN	Definite=Def|Gender=Masc|Number=Sing	2	obj	_	_
 8	_של_	של	ADP	ADP	_	9	case:gen	_	_
 9	_הוא	הוא	PRON	PRON	Case=Gen|Gender=Masc|Number=Sing|Person=3|PronType=Prs	7	nmod:poss	_	_
-10	(	_	PUNCT	PUNCT	_	12	punct	_	_
+10	(	_	PUNCT	PUNCT	_	12	punct	_	SpaceAfter=No
 11	"	_	PUNCT	PUNCT	_	12	punct	_	_
 12	בן	בן	NOUN	NOUN	Definite=Cons|Gender=Masc|Number=Sing	2	parataxis	_	_
-13	כלבה	כלב	NOUN	NOUN	Gender=Fem|Number=Sing	12	compound:smixut	_	_
+13	כלבה	כלב	NOUN	NOUN	Gender=Fem|Number=Sing	12	compound:smixut	_	SpaceAfter=No
 14	,	_	PUNCT	PUNCT	_	12	punct	_	_
 15	תוקע	תקע	VERB	VERB	Definite=Cons|Gender=Masc|HebBinyan=PAAL|Number=Sing|Person=1,2,3|VerbForm=Part|Voice=Act	12	appos	_	_
 16	סכין	סכין	NOUN	NOUN	Gender=Fem,Masc|Number=Sing	15	compound:smixut	_	_
@@ -10245,7 +10245,7 @@
 17	ב	ב	ADP	ADP	_	19	case	_	_
 18	ה_	ה	DET	DET	PronType=Art	19	det:def	_	_
 19	גב	גב	NOUN	NOUN	Gender=Masc|Number=Sing	15	obl	_	_
-20	"	_	PUNCT	PUNCT	_	12	punct	_	_
+20	"	_	PUNCT	PUNCT	_	12	punct	_	SpaceAfter=No
 21	,	_	PUNCT	PUNCT	_	12	punct	_	_
 22	אמר	אמר	VERB	VERB	Gender=Masc|HebBinyan=PAAL|HebSource=ConvUncertainHead|Number=Sing|Person=3|Tense=Past|Voice=Act	12	dep	_	_
 23-24	עליו	_	_	_	_	_	_	_	_
@@ -10254,12 +10254,12 @@
 25-26	בראיון	_	_	_	_	_	_	_	_
 25	ב	ב	ADP	ADP	_	26	case	_	_
 26	ראיון	ראיון	NOUN	NOUN	Gender=Masc|Number=Sing	12	nmod	_	_
-27	עיתונאי	עיתונאי	ADJ	ADJ	Gender=Masc|Number=Sing	26	amod	_	_
-28	)	_	PUNCT	PUNCT	_	12	punct	_	_
+27	עיתונאי	עיתונאי	ADJ	ADJ	Gender=Masc|Number=Sing	26	amod	_	SpaceAfter=No
+28	)	_	PUNCT	PUNCT	_	12	punct	_	SpaceAfter=No
 29	.	_	PUNCT	PUNCT	_	2	punct	_	_
 
 # sent_id = 301
-# text = הוא צווח על עיתונאים מפורסמים ברשתות טלוויזיה ארציות .
+# text = הוא צווח על עיתונאים מפורסמים ברשתות טלוויזיה ארציות.
 1	הוא	הוא	PRON	PRON	Gender=Masc|Number=Sing|Person=3|PronType=Prs	2	nsubj	_	_
 2	צווח	צווח	VERB	VERB	Gender=Masc|HebBinyan=PAAL|Number=Sing|Person=3|Tense=Past|Voice=Act	0	root	_	_
 3	על	על	ADP	ADP	_	4	case	_	_
@@ -10269,11 +10269,11 @@
 6	ב	ב	ADP	ADP	_	7	case	_	_
 7	רשתות	רשת	NOUN	NOUN	Definite=Cons|Gender=Fem|Number=Plur	4	nmod	_	_
 8	טלוויזיה	טלוויזיה	NOUN	NOUN	Gender=Fem|Number=Sing	7	compound:smixut	_	_
-9	ארציות	ארצי	ADJ	ADJ	Gender=Fem|Number=Plur	7	amod	_	_
+9	ארציות	ארצי	ADJ	ADJ	Gender=Fem|Number=Plur	7	amod	_	SpaceAfter=No
 10	.	_	PUNCT	PUNCT	_	2	punct	_	_
 
 # sent_id = 302
-# text = לעומת זאת הוא גם השמיע מסר פוליטי רב - תוכן , שבו הדגיש יותר מכל עניין אחר את משבר החינוך באמריקה , והציע חלופות רציניות .
+# text = לעומת זאת הוא גם השמיע מסר פוליטי רב - תוכן, שבו הדגיש יותר מכל עניין אחר את משבר החינוך באמריקה, והציע חלופות רציניות.
 1	לעומת	לעומת	ADP	ADP	_	2	case	_	_
 2	זאת	זאת	PRON	PRON	Gender=Fem|Number=Sing|Person=3|PronType=Dem	5	obl	_	_
 3	הוא	הוא	PRON	PRON	Gender=Masc|Number=Sing|Person=3|PronType=Prs	5	nsubj	_	_
@@ -10283,7 +10283,7 @@
 7	פוליטי	פוליטי	ADJ	ADJ	Gender=Masc|Number=Sing	6	amod	_	_
 8	רב	רב	ADJ	ADJ	Definite=Cons|Gender=Masc|Number=Sing	6	amod	_	_
 9	-	_	PUNCT	PUNCT	_	8	punct	_	_
-10	תוכן	תוכן	NOUN	NOUN	Gender=Masc|Number=Sing	8	obl	_	_
+10	תוכן	תוכן	NOUN	NOUN	Gender=Masc|Number=Sing	8	obl	_	SpaceAfter=No
 11	,	_	PUNCT	PUNCT	_	6	punct	_	_
 12-14	שבו	_	_	_	_	_	_	_	_
 12	ש	ש	SCONJ	SCONJ	_	15	mark	_	_
@@ -10301,7 +10301,7 @@
 23-24	החינוך	_	_	_	_	_	_	_	_
 23	ה	ה	DET	DET	PronType=Art	24	det:def	_	_
 24	חינוך	חינוך	NOUN	NOUN	Gender=Masc|Number=Sing	22	compound:smixut	_	_
-25-26	באמריקה	_	_	_	_	_	_	_	_
+25-26	באמריקה	_	_	_	_	_	_	_	SpaceAfter=No
 25	ב	ב	ADP	ADP	_	26	case	_	_
 26	אמריקה	אמריקה	PROPN	PROPN	_	22	nmod	_	_
 27	,	_	PUNCT	PUNCT	_	15	punct	_	_
@@ -10309,11 +10309,11 @@
 28	ו	ו	CCONJ	CCONJ	_	29	cc	_	_
 29	הציע	הציע	VERB	VERB	Gender=Masc|HebBinyan=HIFIL|Number=Sing|Person=3|Tense=Past|Voice=Act	15	conj	_	_
 30	חלופות	חלופה	NOUN	NOUN	Gender=Fem|Number=Plur	29	obj	_	_
-31	רציניות	רציני	ADJ	ADJ	Gender=Fem|Number=Plur	30	amod	_	_
+31	רציניות	רציני	ADJ	ADJ	Gender=Fem|Number=Plur	30	amod	_	SpaceAfter=No
 32	.	_	PUNCT	PUNCT	_	5	punct	_	_
 
 # sent_id = 303
-# text = הוא שכנע הרבה משומעיו שיש לו המיומנות הנחוצה להיות מושל .
+# text = הוא שכנע הרבה משומעיו שיש לו המיומנות הנחוצה להיות מושל.
 1	הוא	הוא	PRON	PRON	Gender=Masc|Number=Sing|Person=3|PronType=Prs	2	nsubj	_	_
 2	שכנע	שכנע	VERB	VERB	Gender=Masc|HebBinyan=PIEL|Number=Sing|Person=3|Tense=Past|Voice=Act	0	root	_	_
 3	הרבה	הרבה	DET	DET	Definite=Cons	5	det	_	_
@@ -10335,11 +10335,11 @@
 14	ה	ה	SCONJ	SCONJ	_	15	mark	_	_
 15	נחוצה	נחוץ	ADJ	ADJ	Gender=Fem|Number=Sing	13	acl:relcl	_	_
 16	להיות	היה	VERB	VERB	Polarity=Pos|VerbForm=Inf|VerbType=Cop	15	xcomp	_	_
-17	מושל	מושל	NOUN	NOUN	Gender=Masc|Number=Sing	16	obj	_	_
+17	מושל	מושל	NOUN	NOUN	Gender=Masc|Number=Sing	16	obj	_	SpaceAfter=No
 18	.	_	PUNCT	PUNCT	_	2	punct	_	_
 
 # sent_id = 304
-# text = אבל מזגו והליכותיו הטילו פחד על סביבותיו .
+# text = אבל מזגו והליכותיו הטילו פחד על סביבותיו.
 1	אבל	אבל	CCONJ	CCONJ	_	9	cc	_	_
 2-4	מזגו	_	_	_	_	_	_	_	_
 2	מזג_	מזג	NOUN	NOUN	Definite=Def|Gender=Masc|Number=Sing	9	nsubj	_	_
@@ -10353,14 +10353,14 @@
 9	הטילו	הטיל	VERB	VERB	Gender=Fem,Masc|HebBinyan=HIFIL|Number=Plur|Person=3|Tense=Past|Voice=Act	0	root	_	_
 10	פחד	פחד	NOUN	NOUN	Gender=Masc|Number=Sing	9	obj	_	_
 11	על	על	ADP	ADP	_	12	case	_	_
-12-14	סביבותיו	_	_	_	_	_	_	_	_
+12-14	סביבותיו	_	_	_	_	_	_	_	SpaceAfter=No
 12	סביבה_	סביבה	NOUN	NOUN	Definite=Def|Gender=Fem|Number=Plur	9	iobj	_	_
 13	_של_	של	ADP	ADP	_	14	case:gen	_	_
 14	_הוא	הוא	PRON	PRON	Case=Gen|Gender=Masc|Number=Sing|Person=3|PronType=Prs	12	nmod:poss	_	_
 15	.	_	PUNCT	PUNCT	_	9	punct	_	_
 
 # sent_id = 305
-# text = אם על פרנקלין דלאנו רוזוולט אמרו שיש לו " מוח ממדרגה שנייה וטמפרמנט ממדרגה ראשונה " , הנה על סילבר היה אפשר לומר בדיוק את ההיפך .
+# text = אם על פרנקלין דלאנו רוזוולט אמרו שיש לו "מוח ממדרגה שנייה וטמפרמנט ממדרגה ראשונה", הנה על סילבר היה אפשר לומר בדיוק את ההיפך.
 1	אם	אם	SCONJ	SCONJ	_	6	mark	_	_
 2	על	על	ADP	ADP	_	3	case	_	_
 3	פרנקלין	פרנקלין	PROPN	PROPN	_	6	obl	_	_
@@ -10373,7 +10373,7 @@
 9-10	לו	_	_	_	_	_	_	_	_
 9	לו	ל	ADP	ADP	_	10	case	_	_
 10	_הוא	הוא	PRON	PRON	Gender=Masc|Number=Sing|Person=3|PronType=Prs	8	obl	_	_
-11	"	_	PUNCT	PUNCT	_	12	punct	_	_
+11	"	_	PUNCT	PUNCT	_	12	punct	_	SpaceAfter=No
 12	מוח	מוח	NOUN	NOUN	Gender=Masc|Number=Sing	8	nsubj	_	_
 13-14	ממדרגה	_	_	_	_	_	_	_	_
 13	מ	מ	ADP	ADP	_	14	case	_	_
@@ -10385,8 +10385,8 @@
 18-19	ממדרגה	_	_	_	_	_	_	_	_
 18	מ	מ	ADP	ADP	_	19	case	_	_
 19	מדרגה	מדרגה	NOUN	NOUN	Gender=Fem|Number=Sing	17	nmod	_	_
-20	ראשונה	_	ADJ	ADJ	Gender=Fem|Number=Sing	19	amod	_	_
-21	"	_	PUNCT	PUNCT	_	12	punct	_	_
+20	ראשונה	_	ADJ	ADJ	Gender=Fem|Number=Sing	19	amod	_	SpaceAfter=No
+21	"	_	PUNCT	PUNCT	_	12	punct	_	SpaceAfter=No
 22	,	_	PUNCT	PUNCT	_	27	punct	_	_
 23	הנה	הנה	ADV	ADV	_	27	advmod	_	_
 24	על	על	ADP	ADP	_	25	case	_	_
@@ -10396,13 +10396,13 @@
 28	לומר	אמר	VERB	VERB	HebBinyan=PAAL|VerbForm=Inf|Voice=Act	27	xcomp	_	_
 29	בדיוק	בדיוק	ADV	ADV	_	28	advmod	_	_
 30	את	את	PART	PART	Case=Acc	32	case:acc	_	_
-31-32	ההיפך	_	_	_	_	_	_	_	_
+31-32	ההיפך	_	_	_	_	_	_	_	SpaceAfter=No
 31	ה	ה	DET	DET	PronType=Art	32	det:def	_	_
 32	היפך	היפך	NOUN	NOUN	Gender=Masc|Number=Sing	28	obj	_	_
 33	.	_	PUNCT	PUNCT	_	27	punct	_	_
 
 # sent_id = 306
-# text = ב32 באוקטובר התפעלה ממנו בעלת טור בעיתון " בוסטון גלוב " במלים היאות למעריצה בת 21 : " הוא עשה בחודשים אחדים למען צחות הדיבור מה שלקח לחברה שנים כדי לעשות למען טלוויזיה צבעונית ... אם דיבור היה ספורט אולימפי , הוא היה זוכה במדליית הזהב ... סילבר כה טוב , עד שהוא גורם לאנגלית להישמע כמו צרפתית ... אם ייבחר , תהיה לכולנו ההזדמנות ללמוד ממנו להיות סטודנטים בכיתתו הענקית , הנקראת מסצוסטס " .
+# text = ב32 באוקטובר התפעלה ממנו בעלת טור בעיתון "בוסטון גלוב" במלים היאות למעריצה בת 21: "הוא עשה בחודשים אחדים למען צחות הדיבור מה שלקח לחברה שנים כדי לעשות למען טלוויזיה צבעונית... אם דיבור היה ספורט אולימפי, הוא היה זוכה במדליית הזהב... סילבר כה טוב, עד שהוא גורם לאנגלית להישמע כמו צרפתית... אם ייבחר, תהיה לכולנו ההזדמנות ללמוד ממנו להיות סטודנטים בכיתתו הענקית, הנקראת מסצוסטס".
 1-3	ב32	_	_	_	_	_	_	_	_
 1	ב	ב	ADP	ADP	_	3	case	_	_
 2	ה_	ה	DET	DET	PronType=Art	3	det:def	_	_
@@ -10420,9 +10420,9 @@
 11	ב	ב	ADP	ADP	_	13	case	_	_
 12	ה_	ה	DET	DET	PronType=Art	13	det:def	_	_
 13	עיתון	עיתון	NOUN	NOUN	Gender=Masc|Number=Sing	6	obl	_	_
-14	"	_	PUNCT	PUNCT	_	15	punct	_	_
+14	"	_	PUNCT	PUNCT	_	15	punct	_	SpaceAfter=No
 15	בוסטון	בוסטון	PROPN	PROPN	_	13	appos	_	_
-16	גלוב	גלוב	PROPN	PROPN	_	15	flat:name	_	_
+16	גלוב	גלוב	PROPN	PROPN	_	15	flat:name	_	SpaceAfter=No
 17	"	_	PUNCT	PUNCT	_	15	punct	_	_
 18-19	במלים	_	_	_	_	_	_	_	_
 18	ב	ב	ADP	ADP	_	19	case	_	_
@@ -10434,9 +10434,9 @@
 22	ל	ל	ADP	ADP	_	23	case	_	_
 23	מעריצה	מעריץ	NOUN	NOUN	Gender=Fem|Number=Sing	21	iobj	_	_
 24	בת	בת	NOUN	NOUN	Definite=Cons|Gender=Fem|Number=Sing	23	acl	_	_
-25	21	_	NUM	NUM	_	24	compound:smixut	_	_
+25	21	_	NUM	NUM	_	24	compound:smixut	_	SpaceAfter=No
 26	:	_	PUNCT	PUNCT	_	29	punct	_	_
-27	"	_	PUNCT	PUNCT	_	29	punct	_	_
+27	"	_	PUNCT	PUNCT	_	29	punct	_	SpaceAfter=No
 28	הוא	הוא	PRON	PRON	Gender=Masc|Number=Sing|Person=3|PronType=Prs	29	nsubj	_	_
 29	עשה	עשה	VERB	VERB	Gender=Masc|HebBinyan=PAAL|Number=Sing|Person=3|Tense=Past|Voice=Act	19	appos	_	_
 30-31	בחודשים	_	_	_	_	_	_	_	_
@@ -10461,13 +10461,13 @@
 45	לעשות	עשה	VERB	VERB	HebBinyan=PAAL|VerbForm=Inf|Voice=Act	39	advcl	_	_
 46	למען	למען	ADP	ADP	_	47	case	_	_
 47	טלוויזיה	טלוויזיה	NOUN	NOUN	Gender=Fem|Number=Sing	45	obl	_	_
-48	צבעונית	צבעוני	ADJ	ADJ	Gender=Fem|Number=Sing	47	amod	_	_
+48	צבעונית	צבעוני	ADJ	ADJ	Gender=Fem|Number=Sing	47	amod	_	SpaceAfter=No
 49	...	_	PUNCT	PUNCT	_	29	punct	_	_
 50	אם	אם	SCONJ	SCONJ	_	53	mark	_	_
 51	דיבור	דיבור	NOUN	NOUN	Gender=Masc|Number=Sing	53	nsubj	_	_
 52	היה	היה	VERB	VERB	Gender=Masc|Number=Sing|Person=3|Polarity=Pos|Tense=Past|VerbType=Cop	53	aux	_	_
 53	ספורט	ספורט	NOUN	NOUN	Gender=Masc|Number=Sing	58	advcl	_	_
-54	אולימפי	אולימפי	ADJ	ADJ	Gender=Masc|Number=Sing	53	amod	_	_
+54	אולימפי	אולימפי	ADJ	ADJ	Gender=Masc|Number=Sing	53	amod	_	SpaceAfter=No
 55	,	_	PUNCT	PUNCT	_	58	punct	_	_
 56	הוא	הוא	PRON	PRON	Gender=Masc|Number=Sing|Person=3|PronType=Prs	58	nsubj	_	_
 57	היה	היה	VERB	VERB	Gender=Masc|Number=Sing|Person=3|Polarity=Pos|Tense=Past|VerbType=Cop	58	aux	_	_
@@ -10475,13 +10475,13 @@
 59-60	במדליית	_	_	_	_	_	_	_	_
 59	ב	ב	ADP	ADP	_	60	case	_	_
 60	מדליית	מדליה	NOUN	NOUN	Definite=Cons|Gender=Fem|Number=Sing	58	iobj	_	_
-61-62	הזהב	_	_	_	_	_	_	_	_
+61-62	הזהב	_	_	_	_	_	_	_	SpaceAfter=No
 61	ה	ה	DET	DET	PronType=Art	62	det:def	_	_
 62	זהב	זהב	NOUN	NOUN	Gender=Masc|Number=Sing	60	compound:smixut	_	_
 63	...	_	PUNCT	PUNCT	_	29	punct	_	_
 64	סילבר	סילבר	PROPN	PROPN	HebSource=ConvUncertainHead	29	dep	_	_
 65	כה	כה	ADV	ADV	_	66	advmod	_	_
-66	טוב	טוב	ADJ	ADJ	Gender=Masc|HebSource=ConvUncertainHead|Number=Sing	64	dep	_	_
+66	טוב	טוב	ADJ	ADJ	Gender=Masc|HebSource=ConvUncertainHead|Number=Sing	64	dep	_	SpaceAfter=No
 67	,	_	PUNCT	PUNCT	HebSource=ConvUncertainHead	64	dep	_	_
 68	עד	עד	ADP	ADP	_	71	case	_	_
 69-70	שהוא	_	_	_	_	_	_	_	_
@@ -10493,10 +10493,10 @@
 73	אנגלית	אנגלית	PROPN	PROPN	_	71	iobj	_	_
 74	להישמע	נשמע	VERB	VERB	HebBinyan=NIFAL|VerbForm=Inf|Voice=Mid	71	xcomp	_	_
 75	כמו	כמו	ADP	ADP	_	76	case	_	_
-76	צרפתית	צרפתית	PROPN	PROPN	_	74	iobj	_	_
+76	צרפתית	צרפתית	PROPN	PROPN	_	74	iobj	_	SpaceAfter=No
 77	...	_	PUNCT	PUNCT	_	29	punct	_	_
 78	אם	אם	SCONJ	SCONJ	_	79	mark	_	_
-79	ייבחר	נבחר	VERB	VERB	Gender=Masc|HebBinyan=NIFAL|Number=Sing|Person=3|Tense=Fut|Voice=Mid	81	advcl	_	_
+79	ייבחר	נבחר	VERB	VERB	Gender=Masc|HebBinyan=NIFAL|Number=Sing|Person=3|Tense=Fut|Voice=Mid	81	advcl	_	SpaceAfter=No
 80	,	_	PUNCT	PUNCT	_	81	punct	_	_
 81	תהיה	היה	VERB	VERB	Gender=Fem|HebSource=ConvUncertainHead|Number=Sing|Person=3|Polarity=Pos|Tense=Fut|VerbType=Cop	29	dep	_	_
 82-84	לכולנו	_	_	_	_	_	_	_	_
@@ -10517,19 +10517,19 @@
 93	כיתה_	כיתה	NOUN	NOUN	Definite=Def|Gender=Fem|Number=Sing	91	nmod	_	_
 94	_של_	של	ADP	ADP	_	95	case:gen	_	_
 95	_הוא	הוא	PRON	PRON	Case=Gen|Gender=Masc|Number=Sing|Person=3|PronType=Prs	93	nmod:poss	_	_
-96-97	הענקית	_	_	_	_	_	_	_	_
+96-97	הענקית	_	_	_	_	_	_	_	SpaceAfter=No
 96	ה	ה	DET	DET	PronType=Art	97	det:def	_	_
 97	ענקית	ענקי	ADJ	ADJ	Gender=Fem|Number=Sing	93	amod	_	_
 98	,	_	PUNCT	PUNCT	_	93	punct	_	_
 99-100	הנקראת	_	_	_	_	_	_	_	_
 99	ה	ה	SCONJ	SCONJ	_	100	mark	_	_
 100	נקראת	נקרא	VERB	VERB	Gender=Fem|HebBinyan=NIFAL|Number=Sing|Person=1,2,3|VerbForm=Part|Voice=Mid	93	acl:relcl	_	_
-101	מסצוסטס	מסצוסטס	PROPN	PROPN	_	100	dep	_	_
-102	"	_	PUNCT	PUNCT	_	29	punct	_	_
+101	מסצוסטס	מסצוסטס	PROPN	PROPN	_	100	dep	_	SpaceAfter=No
+102	"	_	PUNCT	PUNCT	_	29	punct	_	SpaceAfter=No
 103	.	_	PUNCT	PUNCT	_	6	punct	_	_
 
 # sent_id = 307
-# text = אבל בדיוק הרעיון הזה הצורך להיות ארבע שנים ארוכות סטודנטים בכיתתו של פרופסור יהיר שלח מספר מפתיע של אנשי שמאל לזרועותיו של הרפובליקן השמרן ויליאם וולד .
+# text = אבל בדיוק הרעיון הזה הצורך להיות ארבע שנים ארוכות סטודנטים בכיתתו של פרופסור יהיר שלח מספר מפתיע של אנשי שמאל לזרועותיו של הרפובליקן השמרן ויליאם וולד.
 1	אבל	אבל	CCONJ	CCONJ	_	21	cc	_	_
 2	בדיוק	בדיוק	ADV	ADV	_	4	det	_	_
 3-4	הרעיון	_	_	_	_	_	_	_	_
@@ -10573,21 +10573,21 @@
 34	ה	ה	DET	DET	PronType=Art	35	det:def	_	_
 35	שמרן	שמרן	ADJ	ADJ	Gender=Masc|Number=Sing	33	amod	_	_
 36	ויליאם	ויליאם	PROPN	PROPN	_	33	appos	_	_
-37	וולד	ולד	PROPN	PROPN	_	36	flat:name	_	_
+37	וולד	ולד	PROPN	PROPN	_	36	flat:name	_	SpaceAfter=No
 38	.	_	PUNCT	PUNCT	_	21	punct	_	_
 
 # sent_id = 308
-# text = הוא לבבי , חייכן , מסוגל להתבדח על חשבון עצמו , ולוקח את החיים קצת פחות ברצינות .
+# text = הוא לבבי, חייכן, מסוגל להתבדח על חשבון עצמו, ולוקח את החיים קצת פחות ברצינות.
 1	הוא	הוא	PRON	PRON	Gender=Masc|Number=Sing|Person=3|PronType=Prs	2	nsubj	_	_
-2	לבבי	לבבי	ADJ	ADJ	Gender=Masc|Number=Sing	0	root	_	_
+2	לבבי	לבבי	ADJ	ADJ	Gender=Masc|Number=Sing	0	root	_	SpaceAfter=No
 3	,	_	PUNCT	PUNCT	_	2	punct	_	_
-4	חייכן	חייכן	ADJ	ADJ	Gender=Masc|Number=Sing	2	advmod	_	_
+4	חייכן	חייכן	ADJ	ADJ	Gender=Masc|Number=Sing	2	advmod	_	SpaceAfter=No
 5	,	_	PUNCT	PUNCT	_	2	punct	_	_
 6	מסוגל	מסוגל	AUX	AUX	Gender=Masc|Number=Sing|Person=1,2,3|VerbType=Mod	2	conj:discourse	_	_
 7	להתבדח	התבדח	VERB	VERB	HebBinyan=HITPAEL|VerbForm=Inf	6	xcomp	_	_
 8	על	על	ADP	ADP	_	9	case	_	_
 9	חשבון	חשבון	NOUN	NOUN	Definite=Cons|Gender=Masc|Number=Sing	7	obl	_	_
-10	עצמו	עצמו	PRON	PRON	Gender=Masc|Number=Sing|Person=3|PronType=Prs|Reflex=Yes	9	compound:smixut	_	_
+10	עצמו	עצמו	PRON	PRON	Gender=Masc|Number=Sing|Person=3|PronType=Prs|Reflex=Yes	9	compound:smixut	_	SpaceAfter=No
 11	,	_	PUNCT	PUNCT	_	6	punct	_	_
 12-13	ולוקח	_	_	_	_	_	_	_	_
 12	ו	ו	CCONJ	CCONJ	_	13	cc	_	_
@@ -10598,16 +10598,16 @@
 16	חיים	חיים	NOUN	NOUN	Gender=Masc|Number=Plur	13	obj	_	_
 17	קצת	קצת	ADV	ADV	_	13	advmod	_	_
 18	פחות	פחות	ADV	ADV	HebSource=ConvUncertainHead	17	dep	_	_
-19-20	ברצינות	_	_	_	_	_	_	_	_
+19-20	ברצינות	_	_	_	_	_	_	_	SpaceAfter=No
 19	ב	ב	ADP	ADP	_	20	case	_	_
 20	רצינות	רצינות	NOUN	NOUN	Gender=Fem|HebSource=ConvUncertainHead|Number=Sing	17	dep	_	_
 21	.	_	PUNCT	PUNCT	_	2	punct	_	_
 
 # sent_id = 309
-# text = אילו ניצח סילבר , יתכן מאוד שהיה מנסה בעוד שנתיים , או בעוד שש שנים , להתמודד על הנשיאות .
+# text = אילו ניצח סילבר, יתכן מאוד שהיה מנסה בעוד שנתיים, או בעוד שש שנים, להתמודד על הנשיאות.
 1	אילו	אילו	CCONJ	CCONJ	_	2	case	_	_
 2	ניצח	ניצח	VERB	VERB	Gender=Masc|HebBinyan=PIEL|Number=Sing|Person=3|Tense=Past|Voice=Act	5	obl	_	_
-3	סילבר	סילבר	PROPN	PROPN	_	2	nsubj	_	_
+3	סילבר	סילבר	PROPN	PROPN	_	2	nsubj	_	SpaceAfter=No
 4	,	_	PUNCT	PUNCT	_	5	punct	_	_
 5	יתכן	ייתכן	AUX	AUX	VerbType=Mod	0	root	_	_
 6	מאוד	מאוד	ADV	ADV	_	5	advmod	_	_
@@ -10616,30 +10616,30 @@
 8	היה	היה	VERB	VERB	Gender=Masc|Number=Sing|Person=3|Polarity=Pos|Tense=Past|VerbType=Cop	9	aux	_	_
 9	מנסה	ניסה	VERB	VERB	Gender=Masc|HebBinyan=PIEL|Number=Sing|Person=1,2,3|VerbForm=Part|Voice=Act	5	ccomp	_	_
 10	בעוד	בעוד	ADP	ADP	_	11	case	_	_
-11	שנתיים	שנה	NOUN	NOUN	Gender=Fem|Number=Dual	9	obl	_	_
+11	שנתיים	שנה	NOUN	NOUN	Gender=Fem|Number=Dual	9	obl	_	SpaceAfter=No
 12	,	_	PUNCT	PUNCT	_	11	punct	_	_
 13	או	או	CCONJ	CCONJ	_	16	cc	_	_
 14	בעוד	בעוד	ADP	ADP	_	16	case	_	_
 15	שש	שש	NUM	NUM	Gender=Fem|Number=Sing	16	nummod	_	_
-16	שנים	שנה	NOUN	NOUN	Gender=Fem|Number=Plur	11	conj	_	_
+16	שנים	שנה	NOUN	NOUN	Gender=Fem|Number=Plur	11	conj	_	SpaceAfter=No
 17	,	_	PUNCT	PUNCT	_	9	punct	_	_
 18	להתמודד	התמודד	VERB	VERB	HebBinyan=HITPAEL|VerbForm=Inf	9	xcomp	_	_
 19	על	על	ADP	ADP	_	21	case	_	_
-20-21	הנשיאות	_	_	_	_	_	_	_	_
+20-21	הנשיאות	_	_	_	_	_	_	_	SpaceAfter=No
 20	ה	ה	DET	DET	PronType=Art	21	det:def	_	_
 21	נשיאות	נשיאות	NOUN	NOUN	Gender=Fem|Number=Sing	18	iobj	_	_
 22	.	_	PUNCT	PUNCT	_	5	punct	_	_
 
 # sent_id = 310
-# text = אלי ויזל , פרופסור באוניברסיטת בוסטון , שסילבר התאמץ הרבה למען זכייתו בפרס נובל לשלום , תמך בגלוי במועמדותו למשרת המושל .
+# text = אלי ויזל, פרופסור באוניברסיטת בוסטון, שסילבר התאמץ הרבה למען זכייתו בפרס נובל לשלום, תמך בגלוי במועמדותו למשרת המושל.
 1	אלי	אלי	PROPN	PROPN	_	23	nsubj	_	_
-2	ויזל	ויזל	PROPN	PROPN	_	1	flat:name	_	_
+2	ויזל	ויזל	PROPN	PROPN	_	1	flat:name	_	SpaceAfter=No
 3	,	_	PUNCT	PUNCT	_	1	punct	_	_
 4	פרופסור	פרופסור	NOUN	NOUN	Gender=Masc|Number=Sing	1	appos	_	_
 5-6	באוניברסיטת	_	_	_	_	_	_	_	_
 5	ב	ב	ADP	ADP	_	6	case	_	_
 6	אוניברסיטת	אוניברסיטה	NOUN	NOUN	Definite=Cons|Gender=Fem|Number=Sing	4	nmod	_	_
-7	בוסטון	בוסטון	PROPN	PROPN	_	6	flat:name	_	_
+7	בוסטון	בוסטון	PROPN	PROPN	_	6	flat:name	_	SpaceAfter=No
 8	,	_	PUNCT	PUNCT	_	4	punct	_	_
 9-10	שסילבר	_	_	_	_	_	_	_	_
 9	ש	_	SCONJ	SCONJ	_	11	mark	_	_
@@ -10655,7 +10655,7 @@
 17	ב	ב	ADP	ADP	_	18	case	_	_
 18	פרס	פרס	NOUN	NOUN	Definite=Cons|Gender=Masc|Number=Sing	14	nmod	_	_
 19	נובל	נובל	NOUN	NOUN	Gender=Masc|Number=Sing	18	flat:name	_	_
-20-21	לשלום	_	_	_	_	_	_	_	_
+20-21	לשלום	_	_	_	_	_	_	_	SpaceAfter=No
 20	ל	ל	ADP	ADP	_	21	case	_	_
 21	שלום	שלום	NOUN	NOUN	Gender=Masc|Number=Sing	18	nmod	_	_
 22	,	_	PUNCT	PUNCT	_	23	punct	_	_
@@ -10669,13 +10669,13 @@
 29-30	למשרת	_	_	_	_	_	_	_	_
 29	ל	ל	ADP	ADP	_	30	case	_	_
 30	משרת	משרה	NOUN	NOUN	Definite=Cons|Gender=Fem|Number=Sing	26	nmod	_	_
-31-32	המושל	_	_	_	_	_	_	_	_
+31-32	המושל	_	_	_	_	_	_	_	SpaceAfter=No
 31	ה	ה	DET	DET	PronType=Art	32	det:def	_	_
 32	מושל	מושל	NOUN	NOUN	Gender=Masc|Number=Sing	30	compound:smixut	_	_
 33	.	_	PUNCT	PUNCT	_	23	punct	_	_
 
 # sent_id = 311
-# text = הוא היה אפילו מסוגל לראותו מכהן בבית הלבן .
+# text = הוא היה אפילו מסוגל לראותו מכהן בבית הלבן.
 1	הוא	הוא	PRON	PRON	Gender=Masc|Number=Sing|Person=3|PronType=Prs	4	nsubj	_	_
 2	היה	היה	VERB	VERB	Gender=Masc|Number=Sing|Person=3|Polarity=Pos|Tense=Past|VerbType=Cop	4	aux	_	_
 3	אפילו	אפילו	CCONJ	CCONJ	_	4	advmod	_	_
@@ -10688,25 +10688,25 @@
 8	ב	ב	ADP	ADP	_	10	case	_	_
 9	ה_	ה	DET	DET	PronType=Art	10	det:def	_	_
 10	בית	בית	NOUN	NOUN	Gender=Masc|Number=Sing	7	iobj	_	_
-11-12	הלבן	_	_	_	_	_	_	_	_
+11-12	הלבן	_	_	_	_	_	_	_	SpaceAfter=No
 11	ה	ה	DET	DET	PronType=Art	12	det:def	_	_
 12	לבן	לבן	ADJ	ADJ	Gender=Masc|Number=Sing	10	amod	_	_
 13	.	_	PUNCT	PUNCT	_	4	punct	_	_
 
 # sent_id = 312
-# text = " מדוע לא ? " , שאל .
-1	"	_	PUNCT	PUNCT	_	2	punct	_	_
+# text = "מדוע לא?", שאל.
+1	"	_	PUNCT	PUNCT	_	2	punct	_	SpaceAfter=No
 2	מדוע	מדוע	ADV	ADV	PronType=Int	7	iobj	_	_
-3	לא	לא	ADV	ADV	HebSource=ConvUncertainHead|Polarity=Neg	2	dep	_	_
-4	?	_	PUNCT	PUNCT	HebSource=ConvUncertainHead	2	dep	_	_
-5	"	_	PUNCT	PUNCT	_	2	punct	_	_
+3	לא	לא	ADV	ADV	HebSource=ConvUncertainHead|Polarity=Neg	2	dep	_	SpaceAfter=No
+4	?	_	PUNCT	PUNCT	HebSource=ConvUncertainHead	2	dep	_	SpaceAfter=No
+5	"	_	PUNCT	PUNCT	_	2	punct	_	SpaceAfter=No
 6	,	_	PUNCT	PUNCT	_	7	punct	_	_
-7	שאל	שאל	VERB	VERB	Gender=Masc|HebBinyan=PAAL|Number=Sing|Person=3|Tense=Past|Voice=Act	0	root	_	_
+7	שאל	שאל	VERB	VERB	Gender=Masc|HebBinyan=PAAL|Number=Sing|Person=3|Tense=Past|Voice=Act	0	root	_	SpaceAfter=No
 8	.	_	PUNCT	PUNCT	_	7	punct	_	_
 
 # sent_id = 313
-# text = " גם על רונלד רייגן איש לא היה מאמין " .
-1	"	_	PUNCT	PUNCT	_	9	punct	_	_
+# text = "גם על רונלד רייגן איש לא היה מאמין".
+1	"	_	PUNCT	PUNCT	_	9	punct	_	SpaceAfter=No
 2	גם	גם	ADV	ADV	_	9	advmod	_	_
 3	על	על	ADP	ADP	_	4	case	_	_
 4	רונלד	רונלד	PROPN	PROPN	_	9	iobj	_	_
@@ -10714,38 +10714,38 @@
 6	איש	איש	NOUN	NOUN	Gender=Masc|Number=Sing	9	nsubj	_	_
 7	לא	לא	ADV	ADV	Polarity=Neg	9	advmod	_	_
 8	היה	היה	VERB	VERB	Gender=Masc|Number=Sing|Person=3|Polarity=Pos|Tense=Past|VerbType=Cop	9	aux	_	_
-9	מאמין	האמין	VERB	VERB	Gender=Masc|HebBinyan=HIFIL|Number=Sing|Person=1,2,3|VerbForm=Part|Voice=Act	0	root	_	_
-10	"	_	PUNCT	PUNCT	_	9	punct	_	_
+9	מאמין	האמין	VERB	VERB	Gender=Masc|HebBinyan=HIFIL|Number=Sing|Person=1,2,3|VerbForm=Part|Voice=Act	0	root	_	SpaceAfter=No
+10	"	_	PUNCT	PUNCT	_	9	punct	_	SpaceAfter=No
 11	.	_	PUNCT	PUNCT	_	9	punct	_	_
 
 # sent_id = 314
-# text = ההשוואה הזו , על כל תוצאותיה , תיחסך מאתנו .
+# text = ההשוואה הזו, על כל תוצאותיה, תיחסך מאתנו.
 1-2	ההשוואה	_	_	_	_	_	_	_	_
 1	ה	ה	DET	DET	PronType=Art	2	det:def	_	_
 2	השוואה	השוואה	NOUN	NOUN	Gender=Fem|Number=Sing	12	nsubj	_	_
-3-4	הזו	_	_	_	_	_	_	_	_
+3-4	הזו	_	_	_	_	_	_	_	SpaceAfter=No
 3	ה	ה	DET	DET	PronType=Art	4	det:def	_	_
 4	זו	זו	PRON	PRON	Gender=Fem|Number=Sing|Person=3|PronType=Dem	2	amod	_	_
 5	,	_	PUNCT	PUNCT	_	2	punct	_	_
 6	על	על	ADP	ADP	_	8	case	_	_
 7	כל	כול	DET	DET	Definite=Cons	8	det	_	_
-8-10	תוצאותיה	_	_	_	_	_	_	_	_
+8-10	תוצאותיה	_	_	_	_	_	_	_	SpaceAfter=No
 8	תוצאה_	תוצאה	NOUN	NOUN	Definite=Def|Gender=Fem|Number=Plur	2	nmod	_	_
 9	_של_	של	ADP	ADP	_	10	case:gen	_	_
 10	_היא	הוא	PRON	PRON	Case=Gen|Gender=Fem|Number=Sing|Person=3|PronType=Prs	8	nmod:poss	_	_
 11	,	_	PUNCT	PUNCT	_	12	punct	_	_
 12	תיחסך	נחסך	VERB	VERB	Gender=Fem|HebBinyan=NIFAL|Number=Sing|Person=3|Tense=Fut|Voice=Mid	0	root	_	_
-13-14	מאתנו	_	_	_	_	_	_	_	_
+13-14	מאתנו	_	_	_	_	_	_	_	SpaceAfter=No
 13	מאתנו	מאת	ADP	ADP	_	14	case	_	_
 14	_אנחנו	הוא	PRON	PRON	Gender=Fem,Masc|Number=Plur|Person=1|PronType=Prs	12	iobj	_	_
 15	.	_	PUNCT	PUNCT	_	12	punct	_	_
 
 # sent_id = 315
-# text = סילבר חזר השבוע לאוניברסיטה , כועס ומתוסכל יותר מאי - פעם .
+# text = סילבר חזר השבוע לאוניברסיטה, כועס ומתוסכל יותר מאי - פעם.
 1	סילבר	סילבר	PROPN	PROPN	_	2	nsubj	_	_
 2	חזר	חזר	VERB	VERB	Gender=Masc|Number=Sing|Person=3|Tense=Past	0	root	_	_
 3	השבוע	השבוע	ADV	ADV	_	2	obl:tmod	_	_
-4-6	לאוניברסיטה	_	_	_	_	_	_	_	_
+4-6	לאוניברסיטה	_	_	_	_	_	_	_	SpaceAfter=No
 4	ל	ל	ADP	ADP	_	6	case	_	_
 5	ה_	ה	DET	DET	PronType=Art	6	det:def	_	_
 6	אוניברסיטה	אוניברסיטה	NOUN	NOUN	Gender=Fem|Number=Sing	2	iobj	_	_
@@ -10759,11 +10759,11 @@
 12	מ	מ	ADP	ADP	HebSource=ConvUncertainHead	11	dep	_	_
 13	אי	אי	ADV	ADV	HebSource=ConvUncertainHead|Prefix=Yes	11	dep	_	_
 14	-	_	PUNCT	PUNCT	_	13	fixed	_	_
-15	פעם	פעם	ADV	ADV	_	13	fixed	_	_
+15	פעם	פעם	ADV	ADV	_	13	fixed	_	SpaceAfter=No
 16	.	_	PUNCT	PUNCT	_	2	punct	_	_
 
 # sent_id = 316
-# text = המפלגות הפוליטיות בארה"ב מתחילות כבר את הכנותיהן לקראת הסיבוב הבא , ב2991 .
+# text = המפלגות הפוליטיות בארה"ב מתחילות כבר את הכנותיהן לקראת הסיבוב הבא, ב2991.
 1-2	המפלגות	_	_	_	_	_	_	_	_
 1	ה	ה	DET	DET	PronType=Art	2	det:def	_	_
 2	מפלגות	מפלגה	NOUN	NOUN	Gender=Fem|Number=Plur	7	nsubj	_	_
@@ -10784,34 +10784,34 @@
 14-15	הסיבוב	_	_	_	_	_	_	_	_
 14	ה	ה	DET	DET	PronType=Art	15	det:def	_	_
 15	סיבוב	סיבוב	NOUN	NOUN	Gender=Masc|Number=Sing	10	nmod	_	_
-16-17	הבא	_	_	_	_	_	_	_	_
+16-17	הבא	_	_	_	_	_	_	_	SpaceAfter=No
 16	ה	ה	DET	DET	PronType=Art	17	det:def	_	_
 17	בא	בא	ADJ	ADJ	Gender=Masc|Number=Sing	15	amod	_	_
 18	,	_	PUNCT	PUNCT	_	15	punct	_	_
-19-20	ב2991	_	_	_	_	_	_	_	_
+19-20	ב2991	_	_	_	_	_	_	_	SpaceAfter=No
 19	ב	ב	ADP	ADP	_	20	case	_	_
 20	2991	_	NUM	NUM	_	15	nmod	_	_
 21	.	_	PUNCT	PUNCT	_	7	punct	_	_
 
 # sent_id = 317
-# text = אז ייבחר לא רק הקונגרס , אלא גם הנשיא .
+# text = אז ייבחר לא רק הקונגרס, אלא גם הנשיא.
 1	אז	אז	ADV	ADV	_	2	advmod	_	_
 2	ייבחר	נבחר	VERB	VERB	Gender=Masc|HebBinyan=NIFAL|Number=Sing|Person=3|Tense=Fut|Voice=Mid	0	root	_	_
 3	לא	לא	ADV	ADV	Polarity=Neg	4	advmod	_	_
 4	רק	רק	ADV	ADV	_	6	advmod	_	_
-5-6	הקונגרס	_	_	_	_	_	_	_	_
+5-6	הקונגרס	_	_	_	_	_	_	_	SpaceAfter=No
 5	ה	ה	DET	DET	PronType=Art	6	det:def	_	_
 6	קונגרס	קונגרס	NOUN	NOUN	Gender=Masc|Number=Sing	2	nsubj	_	_
 7	,	_	PUNCT	PUNCT	_	6	punct	_	_
 8	אלא	אלא	CCONJ	CCONJ	_	11	cc	_	_
 9	גם	גם	ADV	ADV	_	11	det	_	_
-10-11	הנשיא	_	_	_	_	_	_	_	_
+10-11	הנשיא	_	_	_	_	_	_	_	SpaceAfter=No
 10	ה	ה	DET	DET	PronType=Art	11	det:def	_	_
 11	נשיא	נשיא	NOUN	NOUN	Gender=Masc|Number=Sing	6	conj	_	_
 12	.	_	PUNCT	PUNCT	_	2	punct	_	_
 
 # sent_id = 318
-# text = רק ארבע פעמים ב521 השנה האחרונות לא הצליח נשיא לחזור ולהיבחר , אם רצה .
+# text = רק ארבע פעמים ב521 השנה האחרונות לא הצליח נשיא לחזור ולהיבחר, אם רצה.
 1	רק	רק	ADV	ADV	_	3	det	_	_
 2	ארבע	ארבע	NUM	NUM	Gender=Fem|Number=Sing	3	nummod	_	_
 3	פעמים	פעם	NOUN	NOUN	Gender=Fem|Number=Plur	11	dep	_	_
@@ -10828,16 +10828,16 @@
 11	הצליח	הצליח	VERB	VERB	Gender=Masc|HebBinyan=HIFIL|Number=Sing|Person=3|Tense=Past|Voice=Act	0	root	_	_
 12	נשיא	נשיא	NOUN	NOUN	Gender=Masc|Number=Sing	11	nsubj	_	_
 13	לחזור	חזר	VERB	VERB	HebBinyan=PAAL|VerbForm=Inf|Voice=Act	11	xcomp	_	_
-14-15	ולהיבחר	_	_	_	_	_	_	_	_
+14-15	ולהיבחר	_	_	_	_	_	_	_	SpaceAfter=No
 14	ו	ו	CCONJ	CCONJ	_	15	cc	_	_
 15	להיבחר	נבחר	VERB	VERB	HebBinyan=NIFAL|VerbForm=Inf|Voice=Mid	13	conj	_	_
 16	,	_	PUNCT	PUNCT	_	11	punct	_	_
 17	אם	אם	SCONJ	SCONJ	_	18	mark	_	_
-18	רצה	רצה	VERB	VERB	Gender=Masc|HebBinyan=PAAL|Number=Sing|Person=3|Tense=Past|Voice=Act	11	advcl	_	_
+18	רצה	רצה	VERB	VERB	Gender=Masc|HebBinyan=PAAL|Number=Sing|Person=3|Tense=Past|Voice=Act	11	advcl	_	SpaceAfter=No
 19	.	_	PUNCT	PUNCT	_	11	punct	_	_
 
 # sent_id = 319
-# text = עד לפני חודשיים לא היתה סיבה טובה להניח שגורג בוש יהיה המקרה החמישי .
+# text = עד לפני חודשיים לא היתה סיבה טובה להניח שגורג בוש יהיה המקרה החמישי.
 1	עד	עד	ADP	ADP	_	3	case	_	_
 2	לפני	לפני	ADP	ADP	_	3	case	_	_
 3	חודשיים	חודש	NOUN	NOUN	Gender=Masc|Number=Dual	5	obl	_	_
@@ -10854,13 +10854,13 @@
 13-14	המקרה	_	_	_	_	_	_	_	_
 13	ה	ה	DET	DET	PronType=Art	14	det:def	_	_
 14	מקרה	מקרה	NOUN	NOUN	Gender=Masc|Number=Sing	8	ccomp	_	_
-15-16	החמישי	_	_	_	_	_	_	_	_
+15-16	החמישי	_	_	_	_	_	_	_	SpaceAfter=No
 15	ה	ה	DET	DET	PronType=Art	16	det:def	_	_
 16	חמישי	חמישי	NUM	NUM	Gender=Masc|Number=Sing	14	amod	_	_
 17	.	_	PUNCT	PUNCT	_	5	punct	_	_
 
 # sent_id = 320
-# text = אבל מאז נכשל בוש בטיפולו בפרשת התקציב , הסתבך בהתכתשויות - סרק עם הדמוקרטים , ונכנע לבסוף לאורך כל הדרך , שוררת בין דמוקרטים התחושה שיש להם סיכוי ממשי להוציא את בוש מן הבית הלבן בעוד שנתיים .
+# text = אבל מאז נכשל בוש בטיפולו בפרשת התקציב, הסתבך בהתכתשויות - סרק עם הדמוקרטים, ונכנע לבסוף לאורך כל הדרך, שוררת בין דמוקרטים התחושה שיש להם סיכוי ממשי להוציא את בוש מן הבית הלבן בעוד שנתיים.
 1	אבל	אבל	CCONJ	CCONJ	_	32	cc	_	_
 2-3	מאז	_	_	_	_	_	_	_	_
 2	מ	מ	ADP	ADP	_	4	case	_	_
@@ -10875,7 +10875,7 @@
 10-11	בפרשת	_	_	_	_	_	_	_	_
 10	ב	ב	ADP	ADP	_	11	case	_	_
 11	פרשת	פרשה	NOUN	NOUN	Definite=Cons|Gender=Fem|Number=Sing	7	nmod	_	_
-12-13	התקציב	_	_	_	_	_	_	_	_
+12-13	התקציב	_	_	_	_	_	_	_	SpaceAfter=No
 12	ה	ה	DET	DET	PronType=Art	13	det:def	_	_
 13	תקציב	תקציב	NOUN	NOUN	Gender=Masc|Number=Sing	11	compound:smixut	_	_
 14	,	_	PUNCT	PUNCT	_	4	punct	_	_
@@ -10886,7 +10886,7 @@
 18	-	_	PUNCT	PUNCT	_	19	punct	_	_
 19	סרק	סרק	NOUN	NOUN	Gender=Masc|Number=Sing	15	iobj	_	_
 20	עם	עם	ADP	ADP	_	22	case	_	_
-21-22	הדמוקרטים	_	_	_	_	_	_	_	_
+21-22	הדמוקרטים	_	_	_	_	_	_	_	SpaceAfter=No
 21	ה	ה	DET	DET	PronType=Art	22	det:def	_	_
 22	דמוקרטים	דמוקרט	NOUN	NOUN	Gender=Masc|Number=Plur	19	nmod	_	_
 23	,	_	PUNCT	PUNCT	_	4	punct	_	_
@@ -10896,7 +10896,7 @@
 26	לבסוף	לבסוף	ADV	ADV	_	25	advmod	_	_
 27	לאורך	לאורך	ADP	ADP	_	30	case	_	_
 28	כל	כול	DET	DET	Definite=Cons	30	det	_	_
-29-30	הדרך	_	_	_	_	_	_	_	_
+29-30	הדרך	_	_	_	_	_	_	_	SpaceAfter=No
 29	ה	ה	DET	DET	PronType=Art	30	det:def	_	_
 30	דרך	דרך	NOUN	NOUN	Gender=Fem|Number=Sing	25	obl	_	_
 31	,	_	PUNCT	PUNCT	_	32	punct	_	_
@@ -10925,11 +10925,11 @@
 49	ה	ה	DET	DET	PronType=Art	50	det:def	_	_
 50	לבן	לבן	ADJ	ADJ	Gender=Masc|Number=Sing	48	amod	_	_
 51	בעוד	בעוד	ADP	ADP	_	52	case	_	_
-52	שנתיים	שנה	NOUN	NOUN	Gender=Fem|Number=Dual	43	obl	_	_
+52	שנתיים	שנה	NOUN	NOUN	Gender=Fem|Number=Dual	43	obl	_	SpaceAfter=No
 53	.	_	PUNCT	PUNCT	_	32	punct	_	_
 
 # sent_id = 321
-# text = יש לא מעט רפובליקאים הנוטים להסכים אתם .
+# text = יש לא מעט רפובליקאים הנוטים להסכים אתם.
 1	יש	יש	VERB	VERB	HebExistential=True	0	root	_	_
 2	לא	לא	ADV	ADV	Polarity=Neg	4	det	_	_
 3	מעט	מעט	DET	DET	Definite=Cons	4	det	_	_
@@ -10938,25 +10938,25 @@
 5	ה	ה	SCONJ	SCONJ	_	6	mark	_	_
 6	נוטים	נטה	VERB	VERB	Gender=Masc|HebBinyan=PAAL|Number=Plur|Person=1,2,3|VerbForm=Part|Voice=Act	4	acl:relcl	_	_
 7	להסכים	הסכים	VERB	VERB	HebBinyan=HIFIL|VerbForm=Inf|Voice=Act	6	xcomp	_	_
-8-9	אתם	_	_	_	_	_	_	_	_
+8-9	אתם	_	_	_	_	_	_	_	SpaceAfter=No
 8	אתם	את	ADP	ADP	_	9	case	_	_
 9	_הם	הוא	PRON	PRON	Gender=Masc|Number=Plur|Person=3|PronType=Prs	7	obl	_	_
 10	.	_	PUNCT	PUNCT	_	1	punct	_	_
 
 # sent_id = 322
-# text = עכשיו נבחנים המועמדים ל1992 .
+# text = עכשיו נבחנים המועמדים ל1992.
 1	עכשיו	עכשיו	ADV	ADV	_	2	advmod	_	_
 2	נבחנים	נבחן	VERB	VERB	Gender=Masc|HebBinyan=NIFAL|Number=Plur|Person=1,2,3|VerbForm=Part|Voice=Mid	0	root	_	_
 3-4	המועמדים	_	_	_	_	_	_	_	_
 3	ה	ה	DET	DET	PronType=Art	4	det:def	_	_
 4	מועמדים	מועמד	NOUN	NOUN	Gender=Masc|Number=Plur	2	nsubj	_	_
-5-6	ל1992	_	_	_	_	_	_	_	_
+5-6	ל1992	_	_	_	_	_	_	_	SpaceAfter=No
 5	ל	ל	ADP	ADP	_	6	case	_	_
 6	1992	_	NUM	NUM	_	4	nmod	_	_
 7	.	_	PUNCT	PUNCT	_	2	punct	_	_
 
 # sent_id = 323
-# text = הבחירות של השבוע יכלו להעניק דחיפה נאה לשניים מן הפוליטיקאים המוזכרים ביותר : המושל רב - הכריזמה של מדינת ניו יורק , מריו קואומו , ששמו מתרוצץ בהקשרים נשיאותיים מאז 4891 ; והסנאטור מניו גרסי , האינטלקטואל וכוכב הכדורסל המהולל של שנות ה06 , ביל בראדלי .
+# text = הבחירות של השבוע יכלו להעניק דחיפה נאה לשניים מן הפוליטיקאים המוזכרים ביותר: המושל רב - הכריזמה של מדינת ניו יורק, מריו קואומו, ששמו מתרוצץ בהקשרים נשיאותיים מאז 4891; והסנאטור מניו גרסי, האינטלקטואל וכוכב הכדורסל המהולל של שנות ה06, ביל בראדלי.
 1-2	הבחירות	_	_	_	_	_	_	_	_
 1	ה	ה	DET	DET	PronType=Art	2	det:def	_	_
 2	בחירות	בחירות	NOUN	NOUN	Gender=Fem|Number=Plur	6	nsubj	_	_
@@ -10978,7 +10978,7 @@
 15-16	המוזכרים	_	_	_	_	_	_	_	_
 15	ה	ה	DET	DET	PronType=Art	16	det:def	_	_
 16	מוזכרים	הוזכר	VERB	VERB	Gender=Masc|HebBinyan=HUFAL|Number=Plur|Person=1,2,3|VerbForm=Part|Voice=Pass	14	amod	_	_
-17	ביותר	ביותר	ADV	ADV	_	16	advmod	_	_
+17	ביותר	ביותר	ADV	ADV	_	16	advmod	_	SpaceAfter=No
 18	:	_	PUNCT	PUNCT	_	14	punct	_	_
 19-20	המושל	_	_	_	_	_	_	_	_
 19	ה	ה	DET	DET	PronType=Art	20	det:def	_	_
@@ -10991,10 +10991,10 @@
 25	של	של	PART	PART	Case=Gen	26	case:gen	_	_
 26	מדינת	מדינה	NOUN	NOUN	Definite=Cons|Gender=Fem|Number=Sing	20	nmod	_	_
 27	ניו	ניו	PROPN	PROPN	_	26	flat:name	_	_
-28	יורק	יורק	PROPN	PROPN	_	27	flat:name	_	_
+28	יורק	יורק	PROPN	PROPN	_	27	flat:name	_	SpaceAfter=No
 29	,	_	PUNCT	PUNCT	_	20	punct	_	_
 30	מריו	מריו	PROPN	PROPN	_	20	appos	_	_
-31	קואומו	קואומו	PROPN	PROPN	_	30	flat:name	_	_
+31	קואומו	קואומו	PROPN	PROPN	_	30	flat:name	_	SpaceAfter=No
 32	,	_	PUNCT	PUNCT	_	20	punct	_	_
 33-36	ששמו	_	_	_	_	_	_	_	_
 33	ש	ש	SCONJ	SCONJ	_	37	mark	_	_
@@ -11009,7 +11009,7 @@
 41-42	מאז	_	_	_	_	_	_	_	_
 41	מ	מ	ADP	ADP	_	43	case	_	_
 42	אז	אז	ADV	ADV	_	41	fixed	_	_
-43	4891	_	NUM	NUM	_	37	obl	_	_
+43	4891	_	NUM	NUM	_	37	obl	_	SpaceAfter=No
 44	;	_	PUNCT	PUNCT	_	45	cc	_	_
 45-47	והסנאטור	_	_	_	_	_	_	_	_
 45	ו	ו	CCONJ	CCONJ	_	47	cc	_	_
@@ -11018,7 +11018,7 @@
 48-49	מניו	_	_	_	_	_	_	_	_
 48	מ	_	ADP	ADP	_	49	case	_	_
 49	ניו	מניו	PROPN	PROPN	_	47	nmod	_	_
-50	גרסי	גרס	PROPN	PROPN	_	49	flat:name	_	_
+50	גרסי	גרס	PROPN	PROPN	_	49	flat:name	_	SpaceAfter=No
 51	,	_	PUNCT	PUNCT	_	47	punct	_	_
 52-53	האינטלקטואל	_	_	_	_	_	_	_	_
 52	ה	ה	DET	DET	PronType=Art	53	det:def	_	_
@@ -11034,16 +11034,16 @@
 59	מהולל	_	ADJ	ADJ	_	55	amod	_	_
 60	של	של	PART	PART	Case=Gen	61	case:gen	_	_
 61	שנות	שנה	NOUN	NOUN	Definite=Cons|Gender=Fem|Number=Plur	55	nmod	_	_
-62-63	ה06	_	_	_	_	_	_	_	_
+62-63	ה06	_	_	_	_	_	_	_	SpaceAfter=No
 62	ה	ה	DET	DET	PronType=Art	63	det:def	_	_
 63	06	_	NUM	NUM	_	61	compound:smixut	_	_
 64	,	_	PUNCT	PUNCT	_	47	punct	_	_
 65	ביל	ביל	PROPN	PROPN	_	47	appos	_	_
-66	בראדלי	בראדלי	PROPN	PROPN	_	65	flat:name	_	_
+66	בראדלי	בראדלי	PROPN	PROPN	_	65	flat:name	_	SpaceAfter=No
 67	.	_	PUNCT	PUNCT	_	6	punct	_	_
 
 # sent_id = 324
-# text = ניצחונות שניהם לא הועמדו אף דקה אחת בספק במהלך מערכת הבחירות .
+# text = ניצחונות שניהם לא הועמדו אף דקה אחת בספק במהלך מערכת הבחירות.
 1	ניצחונות	ניצחון	NOUN	NOUN	Definite=Cons|Gender=Masc|Number=Plur	4	nsubj	_	_
 2	שניהם	שניים	PRON	PRON	Gender=Masc|Number=Plur|Person=3|PronType=Prs	1	compound:smixut	_	_
 3	לא	לא	ADV	ADV	Polarity=Neg	4	advmod	_	_
@@ -11058,13 +11058,13 @@
 10	ב	ב	ADP	ADP	_	12	case	_	_
 11	מהלך	מהלך	NOUN	NOUN	Gender=Masc|Number=Sing	10	fixed	_	_
 12	מערכת	מערכת	NOUN	NOUN	Definite=Cons|Gender=Fem|Number=Sing	4	obl	_	_
-13-14	הבחירות	_	_	_	_	_	_	_	_
+13-14	הבחירות	_	_	_	_	_	_	_	SpaceAfter=No
 13	ה	ה	DET	DET	PronType=Art	14	det:def	_	_
 14	בחירות	בחירות	NOUN	NOUN	Gender=Fem|Number=Plur	12	compound:smixut	_	_
 15	.	_	PUNCT	PUNCT	_	4	punct	_	_
 
 # sent_id = 325
-# text = השאלה היחידה היתה באיזה הפרש ירסקו יריבים רפובליקאיים בני בלי שם .
+# text = השאלה היחידה היתה באיזה הפרש ירסקו יריבים רפובליקאיים בני בלי שם.
 1-2	השאלה	_	_	_	_	_	_	_	_
 1	ה	ה	DET	DET	PronType=Art	2	det:def	_	_
 2	שאלה	שאלה	NOUN	NOUN	Gender=Fem|Number=Sing	9	nsubj	_	_
@@ -11081,11 +11081,11 @@
 11	רפובליקאיים	רפובליקני	ADJ	ADJ	Gender=Masc|Number=Plur	10	amod	_	_
 12	בני	בן	NOUN	NOUN	Definite=Cons|Gender=Masc|Number=Plur	10	acl	_	_
 13	בלי	בלי	ADP	ADP	_	14	case	_	_
-14	שם	שם	NOUN	NOUN	Gender=Masc|Number=Sing	12	compound:smixut	_	_
+14	שם	שם	NOUN	NOUN	Gender=Masc|Number=Sing	12	compound:smixut	_	SpaceAfter=No
 15	.	_	PUNCT	PUNCT	_	9	punct	_	_
 
 # sent_id = 326
-# text = בראדלי ניצח לבסוף בהפרש של שלושה אחוזים .
+# text = בראדלי ניצח לבסוף בהפרש של שלושה אחוזים.
 1	בראדלי	בראדלי	PROPN	PROPN	_	2	nsubj	_	_
 2	ניצח	ניצח	VERB	VERB	Gender=Masc|HebBinyan=PIEL|Number=Sing|Person=3|Tense=Past|Voice=Act	0	root	_	_
 3	לבסוף	לבסוף	ADV	ADV	_	2	advmod	_	_
@@ -11094,11 +11094,11 @@
 5	הפרש	הפרש	NOUN	NOUN	Gender=Masc|Number=Sing	2	iobj	_	_
 6	של	של	PART	PART	Case=Gen	8	case:gen	_	_
 7	שלושה	שלושה	NUM	NUM	Gender=Masc|Number=Sing	8	nummod	_	_
-8	אחוזים	אחוז	NOUN	NOUN	Gender=Masc|Number=Plur	5	nmod:poss	_	_
+8	אחוזים	אחוז	NOUN	NOUN	Gender=Masc|Number=Plur	5	nmod:poss	_	SpaceAfter=No
 9	.	_	PUNCT	PUNCT	_	2	punct	_	_
 
 # sent_id = 327
-# text = במוצאי יום הבחירות התבוננו רפובליקאים באי - אמון בתוצאות , ואמרו באנחה עמוקה כי אילו היו משכילים לעמוד על גודל ההזדמנות בניו גרסי , היו מתגייסים לעזרת המועמדת הרפובליקאית , כריסטין טוד ויטמן .
+# text = במוצאי יום הבחירות התבוננו רפובליקאים באי - אמון בתוצאות, ואמרו באנחה עמוקה כי אילו היו משכילים לעמוד על גודל ההזדמנות בניו גרסי, היו מתגייסים לעזרת המועמדת הרפובליקאית, כריסטין טוד ויטמן.
 1-2	במוצאי	_	_	_	_	_	_	_	_
 1	ב	ב	ADP	ADP	_	2	case	_	_
 2	מוצאי	מוצאי	NOUN	NOUN	Definite=Cons|Gender=Masc|Number=Plur	6	obl	_	_
@@ -11113,7 +11113,7 @@
 9	אי	אי	ADV	ADV	HebSource=ConvUncertainHead|Prefix=Yes	11	dep	_	_
 10	-	_	PUNCT	PUNCT	_	11	punct	_	_
 11	אמון	אמון	NOUN	NOUN	Gender=Masc|Number=Sing	6	obl	_	_
-12-14	בתוצאות	_	_	_	_	_	_	_	_
+12-14	בתוצאות	_	_	_	_	_	_	_	SpaceAfter=No
 12	ב	ב	ADP	ADP	_	14	case	_	_
 13	ה_	ה	DET	DET	PronType=Art	14	det:def	_	_
 14	תוצאות	תוצאה	NOUN	NOUN	Gender=Fem|Number=Plur	6	iobj	_	_
@@ -11138,7 +11138,7 @@
 30-31	בניו	_	_	_	_	_	_	_	_
 30	ב	ב	ADP	ADP	_	31	case	_	_
 31	ניו	ניו	PROPN	PROPN	_	29	nmod	_	_
-32	גרסי	גרס	PROPN	PROPN	_	31	flat:name	_	_
+32	גרסי	גרס	PROPN	PROPN	_	31	flat:name	_	SpaceAfter=No
 33	,	_	PUNCT	PUNCT	_	35	punct	_	_
 34	היו	היה	VERB	VERB	Gender=Fem,Masc|Number=Plur|Person=3|Polarity=Pos|Tense=Past|VerbType=Cop	35	aux	_	_
 35	מתגייסים	התגייס	VERB	VERB	Gender=Masc|HebBinyan=HITPAEL|Number=Plur|Person=1,2,3|VerbForm=Part	17	ccomp	_	_
@@ -11148,17 +11148,17 @@
 38-39	המועמדת	_	_	_	_	_	_	_	_
 38	ה	ה	DET	DET	PronType=Art	39	det:def	_	_
 39	מועמדת	מועמד	NOUN	NOUN	Gender=Fem|Number=Sing	37	compound:smixut	_	_
-40-41	הרפובליקאית	_	_	_	_	_	_	_	_
+40-41	הרפובליקאית	_	_	_	_	_	_	_	SpaceAfter=No
 40	ה	ה	DET	DET	PronType=Art	41	det:def	_	_
 41	רפובליקאית	רפובליקני	ADJ	ADJ	Gender=Fem|Number=Sing	39	amod	_	_
 42	,	_	PUNCT	PUNCT	_	39	punct	_	_
 43	כריסטין	כריסטין	PROPN	PROPN	_	39	appos	_	_
 44	טוד	טוד	PROPN	PROPN	_	43	flat:name	_	_
-45	ויטמן	ויטמן	PROPN	PROPN	_	43	flat:name	_	_
+45	ויטמן	ויטמן	PROPN	PROPN	_	43	flat:name	_	SpaceAfter=No
 46	.	_	PUNCT	PUNCT	_	6	punct	_	_
 
 # sent_id = 328
-# text = מאחר שהכול ראו בה שיה מובלת לטבח , היא נשארה עם תקציב בחירות קטן ב90 % מזה של בראדלי .
+# text = מאחר שהכול ראו בה שיה מובלת לטבח, היא נשארה עם תקציב בחירות קטן ב90 % מזה של בראדלי.
 1	מאחר	מאחר	CCONJ	CCONJ	_	4	case	_	_
 2-3	שהכול	_	_	_	_	_	_	_	_
 2	ש	ש	SCONJ	SCONJ	_	4	mark	_	_
@@ -11169,7 +11169,7 @@
 6	_היא	הוא	PRON	PRON	Gender=Fem|Number=Sing|Person=3|PronType=Prs	4	iobj	_	_
 7	שיה	שי	NOUN	NOUN	_	4	obj	_	_
 8	מובלת	מובלת	VERB	VERB	Gender=Fem|HebBinyan=PUAL|Number=Sing|Person=1,2,3|VerbForm=Part|Voice=Pass	7	amod	_	_
-9-11	לטבח	_	_	_	_	_	_	_	_
+9-11	לטבח	_	_	_	_	_	_	_	SpaceAfter=No
 9	ל	ל	ADP	ADP	_	11	case	_	_
 10	ה_	ה	DET	DET	PronType=Art	11	det:def	_	_
 11	טבח	טבח	NOUN	NOUN	Gender=Masc|Number=Sing	8	advmod	_	_
@@ -11188,11 +11188,11 @@
 22	מ	מ	ADP	ADP	_	23	case	_	_
 23	זה	זה	PRON	PRON	Gender=Masc|Number=Sing|Person=3|PronType=Prs	18	iobj	_	_
 24	של	של	PART	PART	Case=Gen	25	case:gen	_	_
-25	בראדלי	בראדלי	PROPN	PROPN	_	23	nmod:poss	_	_
+25	בראדלי	בראדלי	PROPN	PROPN	_	23	nmod:poss	_	SpaceAfter=No
 26	.	_	PUNCT	PUNCT	_	14	punct	_	_
 
 # sent_id = 329
-# text = מריו קואומו היה המועמד הטבעי ביותר לנשיאות מאז נשא נאום מלהיב באוזני ועידת המפלגה הדמוקרטית , בקיץ 4891 .
+# text = מריו קואומו היה המועמד הטבעי ביותר לנשיאות מאז נשא נאום מלהיב באוזני ועידת המפלגה הדמוקרטית, בקיץ 4891.
 1	מריו	מריו	PROPN	PROPN	_	5	nsubj	_	_
 2	קואומו	קואומו	PROPN	PROPN	_	1	flat:name	_	_
 3	היה	היה	VERB	VERB	Gender=Masc|Number=Sing|Person=3|Polarity=Pos|Tense=Past|VerbType=Cop	5	aux	_	_
@@ -11218,30 +11218,30 @@
 19-20	המפלגה	_	_	_	_	_	_	_	_
 19	ה	ה	DET	DET	PronType=Art	20	det:def	_	_
 20	מפלגה	מפלגה	NOUN	NOUN	Gender=Fem|Number=Sing	18	compound:smixut	_	_
-21-22	הדמוקרטית	_	_	_	_	_	_	_	_
+21-22	הדמוקרטית	_	_	_	_	_	_	_	SpaceAfter=No
 21	ה	ה	DET	DET	PronType=Art	22	det:def	_	_
 22	דמוקרטית	דמוקרטי	ADJ	ADJ	Gender=Fem|Number=Sing	20	amod	_	_
 23	,	_	PUNCT	PUNCT	_	14	punct	_	_
 24-25	בקיץ	_	_	_	_	_	_	_	_
 24	ב	ב	ADP	ADP	_	25	case	_	_
 25	קיץ	קיץ	NOUN	NOUN	Definite=Cons|Gender=Masc|Number=Sing	14	obl	_	_
-26	4891	_	NUM	NUM	_	25	compound:smixut	_	_
+26	4891	_	NUM	NUM	_	25	compound:smixut	_	SpaceAfter=No
 27	.	_	PUNCT	PUNCT	_	5	punct	_	_
 
 # sent_id = 330
-# text = כשרון הדיבור שלו , העומק האינטלקטואלי , הנעימות והחמימות שכנעו אנשים רבים בארה"ב שהוא יהיה יום אחד התשובה הדמוקרטית לרונלד רייגן .
+# text = כשרון הדיבור שלו, העומק האינטלקטואלי, הנעימות והחמימות שכנעו אנשים רבים בארה"ב שהוא יהיה יום אחד התשובה הדמוקרטית לרונלד רייגן.
 1	כשרון	כישרון	NOUN	NOUN	Definite=Cons|Gender=Masc|Number=Sing	17	nsubj	_	_
 2-3	הדיבור	_	_	_	_	_	_	_	_
 2	ה	ה	DET	DET	PronType=Art	3	det:def	_	_
 3	דיבור	דיבור	NOUN	NOUN	Gender=Masc|Number=Sing	1	compound:smixut	_	_
-4-5	שלו	_	_	_	_	_	_	_	_
+4-5	שלו	_	_	_	_	_	_	_	SpaceAfter=No
 4	של_	של	ADP	ADP	Case=Gen	5	case:gen	_	_
 5	_הוא	הוא	PRON	PRON	Gender=Masc|Number=Sing|Person=3|PronType=Prs	1	nmod:poss	_	_
 6	,	_	PUNCT	PUNCT	_	1	punct	_	_
 7-8	העומק	_	_	_	_	_	_	_	_
 7	ה	ה	DET	DET	PronType=Art	8	det:def	_	_
 8	עומק	עומק	NOUN	NOUN	Gender=Masc|Number=Sing	1	conj	_	_
-9-10	האינטלקטואלי	_	_	_	_	_	_	_	_
+9-10	האינטלקטואלי	_	_	_	_	_	_	_	SpaceAfter=No
 9	ה	ה	DET	DET	PronType=Art	10	det:def	_	_
 10	אינטלקטואלי	אינטלקטואלי	ADJ	ADJ	Gender=Masc|Number=Sing	8	amod	_	_
 11	,	_	PUNCT	PUNCT	_	1	punct	_	_
@@ -11273,11 +11273,11 @@
 31-32	לרונלד	_	_	_	_	_	_	_	_
 31	ל	ל	ADP	ADP	_	32	case	_	_
 32	רונלד	רונלד	PROPN	PROPN	_	28	nmod	_	_
-33	רייגן	רייגן	PROPN	PROPN	_	32	flat:name	_	_
+33	רייגן	רייגן	PROPN	PROPN	_	32	flat:name	_	SpaceAfter=No
 34	.	_	PUNCT	PUNCT	_	17	punct	_	_
 
 # sent_id = 331
-# text = העובדה שנחל ניצחון כל כך לא מרשים על יריבים כל כך לא מרשימים אינה אומרת בהכרח שסיכויו להתמודד על הבית הלבן אבדו לנצח .
+# text = העובדה שנחל ניצחון כל כך לא מרשים על יריבים כל כך לא מרשימים אינה אומרת בהכרח שסיכויו להתמודד על הבית הלבן אבדו לנצח.
 1-2	העובדה	_	_	_	_	_	_	_	_
 1	ה	ה	DET	DET	PronType=Art	2	det:def	_	_
 2	עובדה	עובדה	NOUN	NOUN	Gender=Fem|Number=Sing	17	nsubj	_	_
@@ -11312,15 +11312,15 @@
 27	ה	ה	DET	DET	PronType=Art	28	det:def	_	_
 28	לבן	לבן	ADJ	ADJ	Gender=Masc|Number=Sing	26	amod	_	_
 29	אבדו	אבד	VERB	VERB	Gender=Fem,Masc|Number=Plur|Person=3|Tense=Past	17	ccomp	_	_
-30	לנצח	לנצח	ADV	ADV	_	29	advmod	_	_
+30	לנצח	לנצח	ADV	ADV	_	29	advmod	_	SpaceAfter=No
 31	.	_	PUNCT	PUNCT	_	17	punct	_	_
 
 # sent_id = 332
-# text = היא אומרת לעומת זאת , שמשהו מן הקסם שלו אבד .
+# text = היא אומרת לעומת זאת, שמשהו מן הקסם שלו אבד.
 1	היא	הוא	PRON	PRON	Gender=Fem|Number=Sing|Person=3|PronType=Prs	2	nsubj	_	_
 2	אומרת	אמר	VERB	VERB	Gender=Fem|HebBinyan=PAAL|Number=Sing|Person=1,2,3|VerbForm=Part|Voice=Act	0	root	_	_
 3	לעומת	לעומת	ADP	ADP	_	4	case	_	_
-4	זאת	זאת	PRON	PRON	Gender=Fem|Number=Sing|Person=3|PronType=Dem	2	obl	_	_
+4	זאת	זאת	PRON	PRON	Gender=Fem|Number=Sing|Person=3|PronType=Dem	2	obl	_	SpaceAfter=No
 5	,	_	PUNCT	PUNCT	_	2	punct	_	_
 6-7	שמשהו	_	_	_	_	_	_	_	_
 6	ש	ש	SCONJ	SCONJ	_	13	mark	_	_
@@ -11332,11 +11332,11 @@
 11-12	שלו	_	_	_	_	_	_	_	_
 11	של_	של	ADP	ADP	Case=Gen	12	case:gen	_	_
 12	_הוא	הוא	PRON	PRON	Gender=Masc|Number=Sing|Person=3|PronType=Prs	10	nmod:poss	_	_
-13	אבד	אבד	VERB	VERB	Gender=Masc|Number=Sing|Person=3|Tense=Past	2	ccomp	_	_
+13	אבד	אבד	VERB	VERB	Gender=Masc|Number=Sing|Person=3|Tense=Past	2	ccomp	_	SpaceAfter=No
 14	.	_	PUNCT	PUNCT	_	2	punct	_	_
 
 # sent_id = 333
-# text = על סנאטורים אומרים כי אין לך אחד מהם שאינו רואה את עצמו , כך או אחרת , מועמד פוטנציאלי לנשיאות .
+# text = על סנאטורים אומרים כי אין לך אחד מהם שאינו רואה את עצמו, כך או אחרת, מועמד פוטנציאלי לנשיאות.
 1	על	על	ADP	ADP	_	2	case	_	_
 2	סנאטורים	סנטור	NOUN	NOUN	Gender=Masc|Number=Plur	3	obl	_	_
 3	אומרים	אמר	VERB	VERB	Gender=Masc|HebBinyan=PAAL|Number=Plur|Person=1,2,3|VerbForm=Part|Voice=Act	0	root	_	_
@@ -11354,22 +11354,22 @@
 12	אינו	אינו	VERB	VERB	Gender=Masc|Number=Sing|Person=3|Polarity=Neg|VerbForm=Part|VerbType=Cop	13	advmod	_	_
 13	רואה	ראה	VERB	VERB	Gender=Masc|HebBinyan=PAAL|Number=Sing|Person=1,2,3|VerbForm=Part|Voice=Act	10	acl:relcl	_	_
 14	את	את	PART	PART	Case=Acc	15	case:acc	_	_
-15	עצמו	עצמו	PRON	PRON	Gender=Masc|Number=Sing|Person=3|PronType=Prs|Reflex=Yes	13	obj	_	_
+15	עצמו	עצמו	PRON	PRON	Gender=Masc|Number=Sing|Person=3|PronType=Prs|Reflex=Yes	13	obj	_	SpaceAfter=No
 16	,	_	PUNCT	PUNCT	_	15	punct	_	_
 17	כך	כך	ADV	ADV	_	15	dep	_	_
 18	או	או	CCONJ	CCONJ	_	17	fixed	_	_
-19	אחרת	אחרת	ADV	ADV	_	17	fixed	_	_
+19	אחרת	אחרת	ADV	ADV	_	17	fixed	_	SpaceAfter=No
 20	,	_	PUNCT	PUNCT	_	15	punct	_	_
 21	מועמד	מועמד	NOUN	NOUN	Gender=Masc|Number=Sing	15	acl	_	_
 22	פוטנציאלי	פוטנציאלי	ADJ	ADJ	Gender=Masc|Number=Sing	21	amod	_	_
-23-25	לנשיאות	_	_	_	_	_	_	_	_
+23-25	לנשיאות	_	_	_	_	_	_	_	SpaceAfter=No
 23	ל	ל	ADP	ADP	_	25	case	_	_
 24	ה_	ה	DET	DET	PronType=Art	25	det:def	_	_
 25	נשיאות	נשיאות	NOUN	NOUN	Gender=Fem|Number=Sing	21	nmod	_	_
 26	.	_	PUNCT	PUNCT	_	3	punct	_	_
 
 # sent_id = 334
-# text = במאה הזו נבחרו שני סנאטורים לנשיאים , ושלושה נשיאים אחרים כיהנו בסנאט בזמן כלשהו של הקריירה שלהם .
+# text = במאה הזו נבחרו שני סנאטורים לנשיאים, ושלושה נשיאים אחרים כיהנו בסנאט בזמן כלשהו של הקריירה שלהם.
 1-3	במאה	_	_	_	_	_	_	_	_
 1	ב	ב	ADP	ADP	_	3	case	_	_
 2	ה_	ה	DET	DET	PronType=Art	3	det:def	_	_
@@ -11380,7 +11380,7 @@
 6	נבחרו	נבחר	VERB	VERB	Gender=Fem,Masc|HebBinyan=NIFAL|Number=Plur|Person=3|Tense=Past|Voice=Mid	0	root	_	_
 7	שני	שניים	NUM	NUM	Definite=Cons|Gender=Masc|Number=Plur	8	nummod	_	_
 8	סנאטורים	סנטור	NOUN	NOUN	Gender=Masc|Number=Plur	6	nsubj	_	_
-9-10	לנשיאים	_	_	_	_	_	_	_	_
+9-10	לנשיאים	_	_	_	_	_	_	_	SpaceAfter=No
 9	ל	ל	ADP	ADP	_	10	case	_	_
 10	נשיאים	נשיא	NOUN	NOUN	Gender=Masc|Number=Plur	6	iobj	_	_
 11	,	_	PUNCT	PUNCT	_	6	punct	_	_
@@ -11402,13 +11402,13 @@
 24-25	הקריירה	_	_	_	_	_	_	_	_
 24	ה	ה	DET	DET	PronType=Art	25	det:def	_	_
 25	קריירה	קריירה	NOUN	NOUN	Gender=Fem|Number=Sing	21	nmod	_	_
-26-27	שלהם	_	_	_	_	_	_	_	_
+26-27	שלהם	_	_	_	_	_	_	_	SpaceAfter=No
 26	של_	של	ADP	ADP	Case=Gen	27	case:gen	_	_
 27	_הם	הוא	PRON	PRON	Gender=Masc|Number=Plur|Person=3|PronType=Prs	25	nmod:poss	_	_
 28	.	_	PUNCT	PUNCT	_	6	punct	_	_
 
 # sent_id = 335
-# text = לעומת זאת הגיעו לנשיאות חמישה מושלי מדינות .
+# text = לעומת זאת הגיעו לנשיאות חמישה מושלי מדינות.
 1	לעומת	לעומת	ADP	ADP	_	2	case	_	_
 2	זאת	זאת	PRON	PRON	Gender=Fem|Number=Sing|Person=3|PronType=Dem	3	obl	_	_
 3	הגיעו	הגיע	VERB	VERB	Gender=Fem,Masc|HebBinyan=HIFIL|Number=Plur|Person=3|Tense=Past|Voice=Act	0	root	_	_
@@ -11418,11 +11418,11 @@
 6	נשיאות	נשיאות	NOUN	NOUN	Gender=Fem|Number=Sing	3	iobj	_	_
 7	חמישה	חמישה	NUM	NUM	Gender=Masc|Number=Sing	8	nummod	_	_
 8	מושלי	מושל	NOUN	NOUN	Definite=Cons|Gender=Masc|Number=Plur	3	nsubj	_	_
-9	מדינות	מדינה	NOUN	NOUN	Gender=Fem|Number=Plur	8	compound:smixut	_	_
+9	מדינות	מדינה	NOUN	NOUN	Gender=Fem|Number=Plur	8	compound:smixut	_	SpaceAfter=No
 10	.	_	PUNCT	PUNCT	_	3	punct	_	_
 
 # sent_id = 336
-# text = כהונת מושל במדינה גדולה היא קרש קפיצה אל מרכז תשומת הלב הלאומית .
+# text = כהונת מושל במדינה גדולה היא קרש קפיצה אל מרכז תשומת הלב הלאומית.
 1	כהונת	כהונה	NOUN	NOUN	Definite=Cons|Gender=Fem|Number=Sing	7	nsubj:cop	_	_
 2	מושל	מושל	NOUN	NOUN	Gender=Masc|Number=Sing	1	compound:smixut	_	_
 3-4	במדינה	_	_	_	_	_	_	_	_
@@ -11438,13 +11438,13 @@
 12-13	הלב	_	_	_	_	_	_	_	_
 12	ה	ה	DET	DET	PronType=Art	13	det:def	_	_
 13	לב	לב	NOUN	NOUN	Gender=Masc|Number=Sing	11	compound:smixut	_	_
-14-15	הלאומית	_	_	_	_	_	_	_	_
+14-15	הלאומית	_	_	_	_	_	_	_	SpaceAfter=No
 14	ה	ה	DET	DET	PronType=Art	15	det:def	_	_
 15	לאומית	לאומי	ADJ	ADJ	Gender=Fem|Number=Sing	11	amod	_	_
 16	.	_	PUNCT	PUNCT	_	7	punct	_	_
 
 # sent_id = 337
-# text = בארץ המתעניינת קודם כל ביכולת הביצוע , כהונת הנשיא נתפסת לעתים קרובות באותו אופן שנתפסת כהונת מנכ"ל תעשיית המכוניות קרייזלר .
+# text = בארץ המתעניינת קודם כל ביכולת הביצוע, כהונת הנשיא נתפסת לעתים קרובות באותו אופן שנתפסת כהונת מנכ"ל תעשיית המכוניות קרייזלר.
 1-2	בארץ	_	_	_	_	_	_	_	_
 1	ב	ב	ADP	ADP	_	2	case	_	_
 2	ארץ	ארץ	NOUN	NOUN	Gender=Fem|Number=Sing	15	obl	_	_
@@ -11456,7 +11456,7 @@
 7-8	ביכולת	_	_	_	_	_	_	_	_
 7	ב	ב	ADP	ADP	_	8	case	_	_
 8	יכולת	יכולת	NOUN	NOUN	Definite=Cons|Gender=Fem|Number=Sing	4	obl	_	_
-9-10	הביצוע	_	_	_	_	_	_	_	_
+9-10	הביצוע	_	_	_	_	_	_	_	SpaceAfter=No
 9	ה	ה	DET	DET	PronType=Art	10	det:def	_	_
 10	ביצוע	ביצוע	NOUN	NOUN	Gender=Masc|Number=Sing	8	compound:smixut	_	_
 11	,	_	PUNCT	PUNCT	_	15	punct	_	_
@@ -11480,11 +11480,11 @@
 26-27	המכוניות	_	_	_	_	_	_	_	_
 26	ה	ה	DET	DET	PronType=Art	27	det:def	_	_
 27	מכוניות	מכונית	NOUN	NOUN	Gender=Fem|Number=Plur	25	compound:smixut	_	_
-28	קרייזלר	קרייזלר	PROPN	PROPN	_	25	appos	_	_
+28	קרייזלר	קרייזלר	PROPN	PROPN	_	25	appos	_	SpaceAfter=No
 29	.	_	PUNCT	PUNCT	_	15	punct	_	_
 
 # sent_id = 338
-# text = הבחירות האלה מתנהלות על מיומנות , לא על אידיאולוגיה " , הכריז חגיגית מייקל דוקאקיס , כאשר נבחר למועמד הדמוקרטי לנשיאות .
+# text = הבחירות האלה מתנהלות על מיומנות, לא על אידיאולוגיה", הכריז חגיגית מייקל דוקאקיס, כאשר נבחר למועמד הדמוקרטי לנשיאות.
 1-2	הבחירות	_	_	_	_	_	_	_	_
 1	ה	ה	DET	DET	PronType=Art	2	det:def	_	_
 2	בחירות	בחירות	NOUN	NOUN	Gender=Fem|Number=Plur	5	nsubj	_	_
@@ -11493,17 +11493,17 @@
 4	אלה	אלה	PRON	PRON	Gender=Masc|Number=Plur|Person=3|PronType=Dem	2	amod	_	_
 5	מתנהלות	התנהל	VERB	VERB	Gender=Fem|HebBinyan=HITPAEL|Number=Plur|Person=1,2,3|VerbForm=Part	14	iobj	_	_
 6	על	על	ADP	ADP	_	7	case	_	_
-7	מיומנות	מיומנות	NOUN	NOUN	Gender=Fem|Number=Sing	5	iobj	_	_
+7	מיומנות	מיומנות	NOUN	NOUN	Gender=Fem|Number=Sing	5	iobj	_	SpaceAfter=No
 8	,	_	PUNCT	PUNCT	_	5	punct	_	_
 9	לא	לא	ADV	ADV	Polarity=Neg	10	advmod	_	_
 10	על	על	ADP	ADP	_	11	case	_	_
-11	אידיאולוגיה	אידיאולוגיה	NOUN	NOUN	Gender=Fem|Number=Sing	5	iobj	_	_
-12	"	_	PUNCT	PUNCT	_	5	punct	_	_
+11	אידיאולוגיה	אידיאולוגיה	NOUN	NOUN	Gender=Fem|Number=Sing	5	iobj	_	SpaceAfter=No
+12	"	_	PUNCT	PUNCT	_	5	punct	_	SpaceAfter=No
 13	,	_	PUNCT	PUNCT	_	14	punct	_	_
 14	הכריז	הכריז	VERB	VERB	Gender=Masc|HebBinyan=HIFIL|Number=Sing|Person=3|Tense=Past|Voice=Act	0	root	_	_
 15	חגיגית	חגיגית	ADV	ADV	_	14	advmod	_	_
 16	מייקל	מייקל	PROPN	PROPN	_	14	nsubj	_	_
-17	דוקאקיס	דוקאקיס	PROPN	PROPN	_	16	flat:name	_	_
+17	דוקאקיס	דוקאקיס	PROPN	PROPN	_	16	flat:name	_	SpaceAfter=No
 18	,	_	PUNCT	PUNCT	_	14	punct	_	_
 19	כאשר	כאשר	SCONJ	SCONJ	_	20	mark	_	_
 20	נבחר	נבחר	VERB	VERB	Gender=Masc|HebBinyan=NIFAL|Number=Sing|Person=3|Tense=Past|Voice=Mid	14	advcl	_	_
@@ -11514,14 +11514,14 @@
 24-25	הדמוקרטי	_	_	_	_	_	_	_	_
 24	ה	ה	DET	DET	PronType=Art	25	det:def	_	_
 25	דמוקרטי	דמוקרטי	ADJ	ADJ	Gender=Masc|Number=Sing	23	amod	_	_
-26-28	לנשיאות	_	_	_	_	_	_	_	_
+26-28	לנשיאות	_	_	_	_	_	_	_	SpaceAfter=No
 26	ל	ל	ADP	ADP	_	28	case	_	_
 27	ה_	ה	DET	DET	PronType=Art	28	det:def	_	_
 28	נשיאות	נשיאות	NOUN	NOUN	Gender=Fem|Number=Sing	23	nmod	_	_
 29	.	_	PUNCT	PUNCT	_	14	punct	_	_
 
 # sent_id = 339
-# text = הצלחתה הכלכלית של מדינתו , מסצוסטס , היתה צריכה להיות האישור לדרגת מיומנותו .
+# text = הצלחתה הכלכלית של מדינתו, מסצוסטס, היתה צריכה להיות האישור לדרגת מיומנותו.
 1-3	הצלחתה	_	_	_	_	_	_	_	_
 1	הצלחה_	הצלחה	NOUN	NOUN	Definite=Def|Gender=Fem|Number=Sing	14	nsubj	_	_
 2	_של_	של	ADP	ADP	_	3	case:gen	_	_
@@ -11530,12 +11530,12 @@
 4	ה	ה	DET	DET	PronType=Art	5	det:def	_	_
 5	כלכלית	כלכלי	ADJ	ADJ	Gender=Fem|Number=Sing	1	amod	_	_
 6	של	של	PART	PART	Case=Gen	7	case:gen	_	_
-7-9	מדינתו	_	_	_	_	_	_	_	_
+7-9	מדינתו	_	_	_	_	_	_	_	SpaceAfter=No
 7	מדינה_	מדינה	NOUN	NOUN	Definite=Def|Gender=Fem|Number=Sing	1	nmod:poss	_	_
 8	_של_	של	ADP	ADP	_	9	case:gen	_	_
 9	_הוא	הוא	PRON	PRON	Case=Gen|Gender=Masc|Number=Sing|Person=3|PronType=Prs	7	nmod:poss	_	_
 10	,	_	PUNCT	PUNCT	_	7	punct	_	_
-11	מסצוסטס	מסצוסטס	PROPN	PROPN	_	7	appos	_	_
+11	מסצוסטס	מסצוסטס	PROPN	PROPN	_	7	appos	_	SpaceAfter=No
 12	,	_	PUNCT	PUNCT	_	14	punct	_	_
 13	היתה	היה	VERB	VERB	Gender=Fem|Number=Sing|Person=3|Polarity=Pos|Tense=Past|VerbType=Cop	14	aux	_	_
 14	צריכה	צריך	AUX	AUX	Gender=Fem|Number=Sing|Person=1,2,3|VerbType=Mod	0	root	_	_
@@ -11546,14 +11546,14 @@
 18-19	לדרגת	_	_	_	_	_	_	_	_
 18	ל	ל	ADP	ADP	_	19	case	_	_
 19	דרגת	דרגה	NOUN	NOUN	Definite=Cons|Gender=Fem|Number=Sing	17	nmod	_	_
-20-22	מיומנותו	_	_	_	_	_	_	_	_
+20-22	מיומנותו	_	_	_	_	_	_	_	SpaceAfter=No
 20	מיומנות_	מיומנות	NOUN	NOUN	Definite=Def|Gender=Fem|Number=Sing	19	compound:smixut	_	_
 21	_של_	של	ADP	ADP	_	22	case:gen	_	_
 22	_הוא	הוא	PRON	PRON	Case=Gen|Gender=Masc|Number=Sing|Person=3|PronType=Prs	20	nmod:poss	_	_
 23	.	_	PUNCT	PUNCT	_	14	punct	_	_
 
 # sent_id = 340
-# text = בסופו של דבר התברר שההצלחה היתה כישלון , ודוקאקיס הובס .
+# text = בסופו של דבר התברר שההצלחה היתה כישלון, ודוקאקיס הובס.
 1-4	בסופו	_	_	_	_	_	_	_	_
 1	ב	ב	ADP	ADP	_	2	case	_	_
 2	סוף_	סוף	NOUN	NOUN	Definite=Def|Gender=Masc|Number=Sing	7	obl	_	_
@@ -11567,26 +11567,26 @@
 9	ה	ה	DET	DET	PronType=Art	10	det:def	_	_
 10	הצלחה	הצלחה	NOUN	NOUN	Gender=Fem|Number=Sing	12	nsubj	_	_
 11	היתה	היה	VERB	VERB	Gender=Fem|Number=Sing|Person=3|Polarity=Pos|Tense=Past|VerbType=Cop	12	aux	_	_
-12	כישלון	כישלון	NOUN	NOUN	Gender=Masc|Number=Sing	7	ccomp	_	_
+12	כישלון	כישלון	NOUN	NOUN	Gender=Masc|Number=Sing	7	ccomp	_	SpaceAfter=No
 13	,	_	PUNCT	PUNCT	_	7	punct	_	_
 14-15	ודוקאקיס	_	_	_	_	_	_	_	_
 14	ו	ו	CCONJ	CCONJ	_	16	cc	_	_
 15	דוקאקיס	דוקאקיס	PROPN	PROPN	_	16	nsubj	_	_
-16	הובס	הובס	VERB	VERB	Gender=Masc|HebBinyan=HUFAL|Number=Sing|Person=3|Tense=Past|Voice=Pass	7	conj	_	_
+16	הובס	הובס	VERB	VERB	Gender=Masc|HebBinyan=HUFAL|Number=Sing|Person=3|Tense=Past|Voice=Pass	7	conj	_	SpaceAfter=No
 17	.	_	PUNCT	PUNCT	_	7	punct	_	_
 
 # sent_id = 341
-# text = אבל הנוסחה בעינה עומדת .
+# text = אבל הנוסחה בעינה עומדת.
 1	אבל	אבל	CCONJ	CCONJ	_	5	cc	_	_
 2-3	הנוסחה	_	_	_	_	_	_	_	_
 2	ה	ה	DET	DET	PronType=Art	3	det:def	_	_
 3	נוסחה	נוסחה	NOUN	NOUN	Gender=Fem|Number=Sing	5	nsubj	_	_
 4	בעינה	בעין	ADV	ADV	_	5	advmod	_	_
-5	עומדת	עמד	VERB	VERB	Gender=Fem|HebBinyan=PAAL|Number=Sing|Person=1,2,3|VerbForm=Part|Voice=Act	0	root	_	_
+5	עומדת	עמד	VERB	VERB	Gender=Fem|HebBinyan=PAAL|Number=Sing|Person=1,2,3|VerbForm=Part|Voice=Act	0	root	_	SpaceAfter=No
 6	.	_	PUNCT	PUNCT	_	5	punct	_	_
 
 # sent_id = 342
-# text = לכן יעוררו מידה גדולה של סקרנות המושלים החדשים של קליפורניה , של טקסס , של פלורידה , של אילינוי ושל מישיגן .
+# text = לכן יעוררו מידה גדולה של סקרנות המושלים החדשים של קליפורניה, של טקסס, של פלורידה, של אילינוי ושל מישיגן.
 1	לכן	לכן	CCONJ	CCONJ	_	2	cc	_	_
 2	יעוררו	עורר	VERB	VERB	Gender=Fem,Masc|HebBinyan=PIEL|Number=Plur|Person=3|Tense=Fut|Voice=Act	0	root	_	_
 3	מידה	מידה	NOUN	NOUN	Gender=Fem|Number=Sing	2	obj	_	_
@@ -11600,24 +11600,24 @@
 9	ה	ה	DET	DET	PronType=Art	10	det:def	_	_
 10	חדשים	חדש	ADJ	ADJ	Gender=Masc|Number=Plur	8	amod	_	_
 11	של	של	PART	PART	Case=Gen	12	case:gen	_	_
-12	קליפורניה	קליפורניה	PROPN	PROPN	_	8	nmod	_	_
+12	קליפורניה	קליפורניה	PROPN	PROPN	_	8	nmod	_	SpaceAfter=No
 13	,	_	PUNCT	PUNCT	_	12	punct	_	_
 14	של	של	PART	PART	Case=Gen	15	case:gen	_	_
-15	טקסס	טקסס	PROPN	PROPN	_	12	conj	_	_
+15	טקסס	טקסס	PROPN	PROPN	_	12	conj	_	SpaceAfter=No
 16	,	_	PUNCT	PUNCT	_	12	punct	_	_
 17	של	של	PART	PART	Case=Gen	18	case:gen	_	_
-18	פלורידה	פלורידה	PROPN	PROPN	_	12	conj	_	_
+18	פלורידה	פלורידה	PROPN	PROPN	_	12	conj	_	SpaceAfter=No
 19	,	_	PUNCT	PUNCT	_	12	punct	_	_
 20	של	של	PART	PART	Case=Gen	21	case:gen	_	_
 21	אילינוי	אילינוי	PROPN	PROPN	_	12	conj	_	_
 22-23	ושל	_	_	_	_	_	_	_	_
 22	ו	ו	CCONJ	CCONJ	_	24	cc	_	_
 23	של	של	PART	PART	Case=Gen	24	case:gen	_	_
-24	מישיגן	מישיגן	PROPN	PROPN	_	12	conj	_	_
+24	מישיגן	מישיגן	PROPN	PROPN	_	12	conj	_	SpaceAfter=No
 25	.	_	PUNCT	PUNCT	_	2	punct	_	_
 
 # sent_id = 343
-# text = מכל המושלים האלה בולטת אן ריצארדס .
+# text = מכל המושלים האלה בולטת אן ריצארדס.
 1-2	מכל	_	_	_	_	_	_	_	_
 1	מ	מ	ADP	ADP	_	4	case	_	_
 2	כל	כול	DET	DET	Definite=Cons	4	det	_	_
@@ -11629,11 +11629,11 @@
 6	אלה	אלה	PRON	PRON	Gender=Masc|Number=Plur|Person=3|PronType=Dem	4	amod	_	_
 7	בולטת	בלט	VERB	VERB	Gender=Fem|HebBinyan=PAAL|Number=Sing|Person=1,2,3|VerbForm=Part|Voice=Act	0	root	_	_
 8	אן	אן	PROPN	PROPN	_	7	nsubj	_	_
-9	ריצארדס	ריצארדס	PROPN	PROPN	_	8	flat:name	_	_
+9	ריצארדס	ריצארדס	PROPN	PROPN	_	8	flat:name	_	SpaceAfter=No
 10	.	_	PUNCT	PUNCT	_	7	punct	_	_
 
 # sent_id = 344
-# text = בגיל 85 היא רשאית לטעון לתואר הפוליטיקאית הבכירה ביותר בארה"ב .
+# text = בגיל 85 היא רשאית לטעון לתואר הפוליטיקאית הבכירה ביותר בארה"ב.
 1-2	בגיל	_	_	_	_	_	_	_	_
 1	ב	ב	ADP	ADP	_	2	case	_	_
 2	גיל	גיל	NOUN	NOUN	Definite=Cons|Gender=Masc|Number=Sing	5	obl	_	_
@@ -11651,20 +11651,20 @@
 11	ה	ה	DET	DET	PronType=Art	12	det:def	_	_
 12	בכירה	בכיר	ADJ	ADJ	Gender=Fem|Number=Sing	10	amod	_	_
 13	ביותר	ביותר	ADV	ADV	_	12	advmod	_	_
-14-15	בארה"ב	_	_	_	_	_	_	_	_
+14-15	בארה"ב	_	_	_	_	_	_	_	SpaceAfter=No
 14	ב	ב	ADP	ADP	_	15	case	_	_
 15	ארה"ב	ארה"ב	PROPN	PROPN	Abbr=Yes	10	nmod	_	_
 16	.	_	PUNCT	PUNCT	_	5	punct	_	_
 
 # sent_id = 345
-# text = היא נבחרה השבוע למושלת טקסס , מקץ מערכת הבחירות המכוערת והדרמטית ביותר של 0991 .
+# text = היא נבחרה השבוע למושלת טקסס, מקץ מערכת הבחירות המכוערת והדרמטית ביותר של 0991.
 1	היא	הוא	PRON	PRON	Gender=Fem|Number=Sing|Person=3|PronType=Prs	2	nsubj	_	_
 2	נבחרה	נבחר	VERB	VERB	Gender=Fem|HebBinyan=NIFAL|Number=Sing|Person=3|Tense=Past|Voice=Mid	0	root	_	_
 3	השבוע	השבוע	ADV	ADV	_	2	obl:tmod	_	_
 4-5	למושלת	_	_	_	_	_	_	_	_
 4	ל	ל	ADP	ADP	_	5	case	_	_
 5	מושלת	מושל	NOUN	NOUN	Definite=Cons|Gender=Fem|Number=Sing	2	iobj	_	_
-6	טקסס	טקסס	PROPN	PROPN	_	5	compound:smixut	_	_
+6	טקסס	טקסס	PROPN	PROPN	_	5	compound:smixut	_	SpaceAfter=No
 7	,	_	PUNCT	PUNCT	_	2	punct	_	_
 8-9	מקץ	_	_	_	_	_	_	_	_
 8	מ	מ	ADP	ADP	_	9	case	_	_
@@ -11682,11 +11682,11 @@
 17	דרמטית	דרמטי	ADJ	ADJ	Gender=Fem|Number=Sing	14	conj	_	_
 18	ביותר	ביותר	ADV	ADV	_	14	advmod	_	_
 19	של	של	PART	PART	Case=Gen	20	case:gen	_	_
-20	0991	_	NUM	NUM	_	10	nmod	_	_
+20	0991	_	NUM	NUM	_	10	nmod	_	SpaceAfter=No
 21	.	_	PUNCT	PUNCT	_	2	punct	_	_
 
 # sent_id = 346
-# text = ריצארדס הגיעה לראשונה אל התודעה הלאומית בארה"ב , כאשר הוזמנה לשאת את הנאום המרכזי בוועידת המפלגה הדמוקרטית , ערב הבחירות לנשיאות של 8891 .
+# text = ריצארדס הגיעה לראשונה אל התודעה הלאומית בארה"ב, כאשר הוזמנה לשאת את הנאום המרכזי בוועידת המפלגה הדמוקרטית, ערב הבחירות לנשיאות של 8891.
 1	ריצארדס	ריצארדס	PROPN	PROPN	_	2	nsubj	_	_
 2	הגיעה	הגיע	VERB	VERB	Gender=Fem|HebBinyan=HIFIL|Number=Sing|Person=3|Tense=Past|Voice=Act	0	root	_	_
 3	לראשונה	לראשונה	ADV	ADV	_	2	advmod	_	_
@@ -11697,7 +11697,7 @@
 7-8	הלאומית	_	_	_	_	_	_	_	_
 7	ה	ה	DET	DET	PronType=Art	8	det:def	_	_
 8	לאומית	לאומי	ADJ	ADJ	Gender=Fem|Number=Sing	6	amod	_	_
-9-10	בארה"ב	_	_	_	_	_	_	_	_
+9-10	בארה"ב	_	_	_	_	_	_	_	SpaceAfter=No
 9	ב	ב	ADP	ADP	_	10	case	_	_
 10	ארה"ב	ארה"ב	PROPN	PROPN	Abbr=Yes	6	nmod	_	_
 11	,	_	PUNCT	PUNCT	_	2	punct	_	_
@@ -11717,7 +11717,7 @@
 22-23	המפלגה	_	_	_	_	_	_	_	_
 22	ה	ה	DET	DET	PronType=Art	23	det:def	_	_
 23	מפלגה	מפלגה	NOUN	NOUN	Gender=Fem|Number=Sing	21	compound:smixut	_	_
-24-25	הדמוקרטית	_	_	_	_	_	_	_	_
+24-25	הדמוקרטית	_	_	_	_	_	_	_	SpaceAfter=No
 24	ה	ה	DET	DET	PronType=Art	25	det:def	_	_
 25	דמוקרטית	דמוקרטי	ADJ	ADJ	Gender=Fem|Number=Sing	23	amod	_	_
 26	,	_	PUNCT	PUNCT	_	14	punct	_	_
@@ -11730,11 +11730,11 @@
 31	ה_	ה	DET	DET	PronType=Art	32	det:def	_	_
 32	נשיאות	נשיאות	NOUN	NOUN	Gender=Fem|Number=Sing	29	nmod	_	_
 33	של	של	PART	PART	Case=Gen	34	case:gen	_	_
-34	8891	_	NUM	NUM	_	29	nmod	_	_
+34	8891	_	NUM	NUM	_	29	nmod	_	SpaceAfter=No
 35	.	_	PUNCT	PUNCT	_	2	punct	_	_
 
 # sent_id = 347
-# text = הדמוקרטים היו באווירת אופוריה , והניחו שמועמדם דוקאקיס לא יצטרך אפילו לרוץ לבית הלבן .
+# text = הדמוקרטים היו באווירת אופוריה, והניחו שמועמדם דוקאקיס לא יצטרך אפילו לרוץ לבית הלבן.
 1-2	הדמוקרטים	_	_	_	_	_	_	_	_
 1	ה	ה	DET	DET	PronType=Art	2	det:def	_	_
 2	דמוקרטים	דמוקרט	NOUN	NOUN	Gender=Masc|Number=Plur	5	nsubj	_	_
@@ -11742,7 +11742,7 @@
 4-5	באווירת	_	_	_	_	_	_	_	_
 4	ב	ב	ADP	ADP	_	5	case	_	_
 5	אווירת	אווירה	NOUN	NOUN	Definite=Cons|Gender=Fem|Number=Sing	0	root	_	_
-6	אופוריה	אופוריה	NOUN	NOUN	Gender=Fem|Number=Sing	5	compound:smixut	_	_
+6	אופוריה	אופוריה	NOUN	NOUN	Gender=Fem|Number=Sing	5	compound:smixut	_	SpaceAfter=No
 7	,	_	PUNCT	PUNCT	_	5	punct	_	_
 8-9	והניחו	_	_	_	_	_	_	_	_
 8	ו	ו	CCONJ	CCONJ	_	9	cc	_	_
@@ -11761,20 +11761,20 @@
 19	ל	ל	ADP	ADP	_	21	case	_	_
 20	ה_	ה	DET	DET	PronType=Art	21	det:def	_	_
 21	בית	בית	NOUN	NOUN	Gender=Masc|Number=Sing	18	obl	_	_
-22-23	הלבן	_	_	_	_	_	_	_	_
+22-23	הלבן	_	_	_	_	_	_	_	SpaceAfter=No
 22	ה	ה	DET	DET	PronType=Art	23	det:def	_	_
 23	לבן	לבן	ADJ	ADJ	Gender=Masc|Number=Sing	21	amod	_	_
 24	.	_	PUNCT	PUNCT	_	5	punct	_	_
 
 # sent_id = 348
-# text = הוא יוכל ללכת לשם בנחת , בגלל הבוז והלעג שעורר היריב הרפובליקאי גורג בוש .
+# text = הוא יוכל ללכת לשם בנחת, בגלל הבוז והלעג שעורר היריב הרפובליקאי גורג בוש.
 1	הוא	הוא	PRON	PRON	Gender=Masc|Number=Sing|Person=3|PronType=Prs	2	nsubj	_	_
 2	יוכל	יכול	AUX	AUX	Gender=Masc|Number=Sing|Person=2|Tense=Fut|VerbType=Mod	0	root	_	_
 3	ללכת	הלך	VERB	VERB	HebBinyan=PAAL|VerbForm=Inf|Voice=Act	2	xcomp	_	_
 4-5	לשם	_	_	_	_	_	_	_	_
 4	ל	ל	ADP	ADP	_	5	case	_	_
 5	שם	שם	ADV	ADV	_	3	obl	_	_
-6-7	בנחת	_	_	_	_	_	_	_	_
+6-7	בנחת	_	_	_	_	_	_	_	SpaceAfter=No
 6	ב	ב	ADP	ADP	_	7	case	_	_
 7	נחת	נחת	NOUN	NOUN	Gender=Fem|Number=Sing	3	obl	_	_
 8	,	_	PUNCT	PUNCT	_	2	punct	_	_
@@ -11796,11 +11796,11 @@
 19	ה	ה	DET	DET	PronType=Art	20	det:def	_	_
 20	רפובליקאי	רפובליקני	ADJ	ADJ	Gender=Masc|Number=Sing	18	amod	_	_
 21	גורג	גורג	PROPN	PROPN	_	18	appos	_	_
-22	בוש	בוש	PROPN	PROPN	_	21	flat:name	_	_
+22	בוש	בוש	PROPN	PROPN	_	21	flat:name	_	SpaceAfter=No
 23	.	_	PUNCT	PUNCT	_	2	punct	_	_
 
 # sent_id = 349
-# text = ריצארדס הצחיקה מיליוני אמריקאים בנאום שזור עקיצות לגלגניות על בוש .
+# text = ריצארדס הצחיקה מיליוני אמריקאים בנאום שזור עקיצות לגלגניות על בוש.
 1	ריצארדס	ריצארדס	PROPN	PROPN	_	2	nsubj	_	_
 2	הצחיקה	הצחיק	VERB	VERB	Gender=Fem|HebBinyan=HIFIL|Number=Sing|Person=3|Tense=Past|Voice=Act	0	root	_	_
 3	מיליוני	מיליון	NUM	NUM	Definite=Cons|Gender=Masc|Number=Plur	4	nummod	_	_
@@ -11812,17 +11812,17 @@
 8	עקיצות	עקיצה	NOUN	NOUN	Gender=Fem|Number=Plur	7	compound:smixut	_	_
 9	לגלגניות	לגלגני	ADJ	ADJ	Gender=Fem|Number=Plur	8	amod	_	_
 10	על	על	ADP	ADP	_	11	case	_	_
-11	בוש	בוש	PROPN	PROPN	_	8	nmod	_	_
+11	בוש	בוש	PROPN	PROPN	_	8	nmod	_	SpaceAfter=No
 12	.	_	PUNCT	PUNCT	_	2	punct	_	_
 
 # sent_id = 350
-# text = " גורג המסכן " , אמרה ריצארדס בהגיה הטקסאנית הרכה שלה , " הוא לא אשם , הוא נולד עם רגל כסף בפה " .
-1	"	_	PUNCT	PUNCT	_	2	punct	_	_
+# text = "גורג המסכן", אמרה ריצארדס בהגיה הטקסאנית הרכה שלה, "הוא לא אשם, הוא נולד עם רגל כסף בפה".
+1	"	_	PUNCT	PUNCT	_	2	punct	_	SpaceAfter=No
 2	גורג	גורג	PROPN	PROPN	_	0	root	_	_
-3-4	המסכן	_	_	_	_	_	_	_	_
+3-4	המסכן	_	_	_	_	_	_	_	SpaceAfter=No
 3	ה	ה	DET	DET	PronType=Art	4	det:def	_	_
 4	מסכן	מסכן	ADJ	ADJ	Gender=Masc|Number=Sing	2	amod	_	_
-5	"	_	PUNCT	PUNCT	_	2	punct	_	_
+5	"	_	PUNCT	PUNCT	_	2	punct	_	SpaceAfter=No
 6	,	_	PUNCT	PUNCT	_	7	punct	_	_
 7	אמרה	אמר	VERB	VERB	Gender=Fem|HebBinyan=PAAL|Number=Sing|Person=3|Tense=Past|Voice=Act	2	parataxis	_	_
 8	ריצארדס	ריצארדס	PROPN	PROPN	_	7	nsubj	_	_
@@ -11836,29 +11836,29 @@
 14-15	הרכה	_	_	_	_	_	_	_	_
 14	ה	ה	DET	DET	PronType=Art	15	det:def	_	_
 15	רכה	רך	ADJ	ADJ	Gender=Fem|Number=Sing	11	amod	_	_
-16-17	שלה	_	_	_	_	_	_	_	_
+16-17	שלה	_	_	_	_	_	_	_	SpaceAfter=No
 16	של_	של	ADP	ADP	Case=Gen	17	case:gen	_	_
 17	_היא	הוא	PRON	PRON	Gender=Fem|Number=Sing|Person=3|PronType=Prs	11	nmod	_	_
 18	,	_	PUNCT	PUNCT	_	7	punct	_	_
-19	"	_	PUNCT	PUNCT	_	22	punct	_	_
+19	"	_	PUNCT	PUNCT	_	22	punct	_	SpaceAfter=No
 20	הוא	הוא	PRON	PRON	Gender=Masc|Number=Sing|Person=3|PronType=Prs	22	nsubj	_	_
 21	לא	לא	ADV	ADV	Polarity=Neg	22	advmod	_	_
-22	אשם	אשם	ADJ	ADJ	Gender=Masc|HebSource=ConvUncertainHead|Number=Sing	2	dep	_	_
+22	אשם	אשם	ADJ	ADJ	Gender=Masc|HebSource=ConvUncertainHead|Number=Sing	2	dep	_	SpaceAfter=No
 23	,	_	PUNCT	PUNCT	_	22	punct	_	_
 24	הוא	הוא	PRON	PRON	Gender=Masc|Number=Sing|Person=3|PronType=Prs	25	nsubj	_	_
 25	נולד	נולד	VERB	VERB	Gender=Masc|HebBinyan=NIFAL|Number=Sing|Person=3|Tense=Past|Voice=Mid	22	conj:discourse	_	_
 26	עם	עם	ADP	ADP	_	27	case	_	_
 27	רגל	רגל	NOUN	NOUN	Definite=Cons|Gender=Fem|Number=Sing	25	iobj	_	_
 28	כסף	כסף	NOUN	NOUN	Gender=Masc|Number=Sing	27	compound:smixut	_	_
-29-31	בפה	_	_	_	_	_	_	_	_
+29-31	בפה	_	_	_	_	_	_	_	SpaceAfter=No
 29	ב	ב	ADP	ADP	_	31	case	_	_
 30	ה_	ה	DET	DET	PronType=Art	31	det:def	_	_
 31	פה	פה	NOUN	NOUN	Gender=Masc|Number=Sing	27	nmod	_	_
-32	"	_	PUNCT	PUNCT	_	22	punct	_	_
+32	"	_	PUNCT	PUNCT	_	22	punct	_	SpaceAfter=No
 33	.	_	PUNCT	PUNCT	_	2	punct	_	_
 
 # sent_id = 351
-# text = זה היה רמז הן להיותו בן טובים , והן ליכולתו יוצאת הדופן להגיד את הדברים הלא - נכונים בזמן הלא - נכון ובמקום הלא - נכון .
+# text = זה היה רמז הן להיותו בן טובים, והן ליכולתו יוצאת הדופן להגיד את הדברים הלא - נכונים בזמן הלא - נכון ובמקום הלא - נכון.
 1	זה	זה	PRON	PRON	Gender=Masc|Number=Sing|Person=3	3	nsubj	_	_
 2	היה	היה	VERB	VERB	Gender=Masc|Number=Sing|Person=3|Polarity=Pos|Tense=Past|VerbType=Cop	3	aux	_	_
 3	רמז	רמז	NOUN	NOUN	Gender=Masc|Number=Sing	0	root	_	_
@@ -11867,7 +11867,7 @@
 5	ל	ל	ADP	ADP	_	6	case	_	_
 6	היותו	היות	VERB	VERB	Gender=Masc|Number=Sing	3	nmod	_	_
 7	בן	בן	NOUN	NOUN	Definite=Cons|Gender=Masc|Number=Sing	6	acl	_	_
-8	טובים	טוב	NOUN	NOUN	Gender=Masc|Number=Plur	7	compound:smixut	_	_
+8	טובים	טוב	NOUN	NOUN	Gender=Masc|Number=Plur	7	compound:smixut	_	SpaceAfter=No
 9	,	_	PUNCT	PUNCT	_	6	punct	_	_
 10-11	והן	_	_	_	_	_	_	_	_
 10	ו	ו	CCONJ	CCONJ	_	13	cc	_	_
@@ -11909,11 +11909,11 @@
 38	ה	ה	DET	DET	PronType=Art	41	det:def	_	_
 39	לא	לא	ADV	ADV	Polarity=Neg	41	advmod	_	_
 40	-	_	PUNCT	PUNCT	_	41	punct	_	_
-41	נכון	נכון	ADJ	ADJ	Gender=Masc|Number=Sing	37	amod	_	_
+41	נכון	נכון	ADJ	ADJ	Gender=Masc|Number=Sing	37	amod	_	SpaceAfter=No
 42	.	_	PUNCT	PUNCT	_	3	punct	_	_
 
 # sent_id = 352
-# text = בוש טען לימים כי ההתקפה ההיא נסכה בו את הנחישות להשיב לדמוקרטים במתקפת נגד , שזכר תוקפנותה מעורר עד עכשיו אי - נוחות ניכרת בין משקיפים פוליטים .
+# text = בוש טען לימים כי ההתקפה ההיא נסכה בו את הנחישות להשיב לדמוקרטים במתקפת נגד, שזכר תוקפנותה מעורר עד עכשיו אי - נוחות ניכרת בין משקיפים פוליטים.
 1	בוש	בוש	PROPN	PROPN	_	2	dep	_	_
 2	טען	טען	VERB	VERB	Gender=Masc|HebBinyan=PAAL|Number=Sing|Person=3|Tense=Past|Voice=Act	0	root	_	_
 3-4	לימים	_	_	_	_	_	_	_	_
@@ -11942,7 +11942,7 @@
 20-21	במתקפת	_	_	_	_	_	_	_	_
 20	ב	ב	ADP	ADP	_	21	case	_	_
 21	מתקפת	מתקפה	NOUN	NOUN	Definite=Cons|Gender=Fem|Number=Sing	16	iobj	_	_
-22	נגד	נגד	NOUN	NOUN	Gender=Masc|Number=Sing	21	compound:smixut	_	_
+22	נגד	נגד	NOUN	NOUN	Gender=Masc|Number=Sing	21	compound:smixut	_	SpaceAfter=No
 23	,	_	PUNCT	PUNCT	_	21	punct	_	_
 24-25	שזכר	_	_	_	_	_	_	_	_
 24	ש	ש	SCONJ	SCONJ	_	29	mark	_	_
@@ -11960,23 +11960,23 @@
 35	ניכרת	ניכר	ADJ	ADJ	Gender=Fem|Number=Sing	34	amod	_	_
 36	בין	בין	ADP	ADP	_	37	case	_	_
 37	משקיפים	משקיף	NOUN	NOUN	Gender=Masc|Number=Plur	34	nmod	_	_
-38	פוליטים	פוליטים	ADJ	ADJ	_	37	amod	_	_
+38	פוליטים	פוליטים	ADJ	ADJ	_	37	amod	_	SpaceAfter=No
 39	.	_	PUNCT	PUNCT	_	2	punct	_	_
 
 # sent_id = 353
-# text = מאז היתה ריצארדס דמות שנויה במחלוקת .
+# text = מאז היתה ריצארדס דמות שנויה במחלוקת.
 1	מאז	מאז	ADV	ADV	_	4	advmod	_	_
 2	היתה	היה	VERB	VERB	Gender=Fem|Number=Sing|Person=3|Polarity=Pos|Tense=Past|VerbType=Cop	4	aux	_	_
 3	ריצארדס	ריצארדס	PROPN	PROPN	_	4	nsubj	_	_
 4	דמות	דמות	NOUN	NOUN	Gender=Fem|Number=Sing	0	root	_	_
 5	שנויה	שנוי	ADJ	ADJ	Gender=Fem|Number=Sing	4	amod	_	_
-6-7	במחלוקת	_	_	_	_	_	_	_	_
+6-7	במחלוקת	_	_	_	_	_	_	_	SpaceAfter=No
 6	ב	ב	ADP	ADP	_	7	case	_	_
 7	מחלוקת	מחלוקת	NOUN	NOUN	Gender=Fem|Number=Sing	5	iobj	_	_
 8	.	_	PUNCT	PUNCT	_	4	punct	_	_
 
 # sent_id = 354
-# text = כאשר החליטה להתמודד על מועמדות מפלגתה למושל , התייצבו נגדה שני דמוקרטים אחרים , שהפיצו ידיעות כי היא השתמשה בעבר בסמים .
+# text = כאשר החליטה להתמודד על מועמדות מפלגתה למושל, התייצבו נגדה שני דמוקרטים אחרים, שהפיצו ידיעות כי היא השתמשה בעבר בסמים.
 1	כאשר	כאשר	SCONJ	SCONJ	_	2	mark	_	_
 2	החליטה	החליט	VERB	VERB	Gender=Fem|HebBinyan=HIFIL|Number=Sing|Person=3|Tense=Past|Voice=Act	12	advcl	_	_
 3	להתמודד	התמודד	VERB	VERB	HebBinyan=HITPAEL|VerbForm=Inf	2	xcomp	_	_
@@ -11986,7 +11986,7 @@
 6	מפלגה_	מפלגה	NOUN	NOUN	Definite=Def|Gender=Fem|Number=Sing	5	compound:smixut	_	_
 7	_של_	של	ADP	ADP	_	8	case:gen	_	_
 8	_היא	הוא	PRON	PRON	Case=Gen|Gender=Fem|Number=Sing|Person=3|PronType=Prs	6	nmod:poss	_	_
-9-10	למושל	_	_	_	_	_	_	_	_
+9-10	למושל	_	_	_	_	_	_	_	SpaceAfter=No
 9	ל	ל	ADP	ADP	_	10	case	_	_
 10	מושל	מושל	NOUN	NOUN	Gender=Masc|Number=Sing	5	nmod	_	_
 11	,	_	PUNCT	PUNCT	_	12	punct	_	_
@@ -11996,7 +11996,7 @@
 14	_היא	הוא	PRON	PRON	Gender=Fem|Number=Sing|Person=3|PronType=Prs	12	iobj	_	_
 15	שני	שניים	NUM	NUM	Definite=Cons|Gender=Masc|Number=Plur	16	nummod	_	_
 16	דמוקרטים	דמוקרט	NOUN	NOUN	Gender=Masc|Number=Plur	12	nsubj	_	_
-17	אחרים	אחר	ADJ	ADJ	Gender=Masc|Number=Plur	16	amod	_	_
+17	אחרים	אחר	ADJ	ADJ	Gender=Masc|Number=Plur	16	amod	_	SpaceAfter=No
 18	,	_	PUNCT	PUNCT	_	16	punct	_	_
 19-20	שהפיצו	_	_	_	_	_	_	_	_
 19	ש	ש	SCONJ	SCONJ	_	20	mark	_	_
@@ -12009,13 +12009,13 @@
 25	ב	ב	ADP	ADP	_	27	case	_	_
 26	ה_	ה	DET	DET	PronType=Art	27	det:def	_	_
 27	עבר	עבר	NOUN	NOUN	Gender=Masc|Number=Sing	24	obl	_	_
-28-29	בסמים	_	_	_	_	_	_	_	_
+28-29	בסמים	_	_	_	_	_	_	_	SpaceAfter=No
 28	ב	ב	ADP	ADP	_	29	case	_	_
 29	סמים	סם	NOUN	NOUN	Gender=Masc|Number=Plur	24	iobj	_	_
 30	.	_	PUNCT	PUNCT	_	12	punct	_	_
 
 # sent_id = 355
-# text = ריצארדס לא טמנה את ידה בצלחת .
+# text = ריצארדס לא טמנה את ידה בצלחת.
 1	ריצארדס	ריצארדס	PROPN	PROPN	_	3	nsubj	_	_
 2	לא	לא	ADV	ADV	Polarity=Neg	3	advmod	_	_
 3	טמנה	טמן	VERB	VERB	Gender=Fem|HebBinyan=PAAL|Number=Sing|Person=3|Tense=Past|Voice=Act	0	root	_	_
@@ -12024,14 +12024,14 @@
 5	יד_	יד	NOUN	NOUN	Definite=Def|Gender=Fem|Number=Sing	3	obj	_	_
 6	_של_	של	ADP	ADP	_	7	case:gen	_	_
 7	_היא	הוא	PRON	PRON	Case=Gen|Gender=Fem|Number=Sing|Person=3|PronType=Prs	5	nmod:poss	_	_
-8-10	בצלחת	_	_	_	_	_	_	_	_
+8-10	בצלחת	_	_	_	_	_	_	_	SpaceAfter=No
 8	ב	ב	ADP	ADP	_	10	case	_	_
 9	ה_	ה	DET	DET	PronType=Art	10	det:def	_	_
 10	צלחת	צלחת	NOUN	NOUN	Gender=Fem|Number=Sing	3	iobj	_	_
 11	.	_	PUNCT	PUNCT	_	3	punct	_	_
 
 # sent_id = 356
-# text = היא אמנם יצאה מן המערכה הדמוקרטית בניצחון , אבל גם בשן ועין .
+# text = היא אמנם יצאה מן המערכה הדמוקרטית בניצחון, אבל גם בשן ועין.
 1	היא	הוא	PRON	PRON	Gender=Fem|Number=Sing|Person=3|PronType=Prs	3	nsubj	_	_
 2	אמנם	אמנם	ADV	ADV	_	3	advmod	_	_
 3	יצאה	יצא	VERB	VERB	Gender=Fem|Number=Sing|Person=3|Tense=Past	0	root	_	_
@@ -12042,7 +12042,7 @@
 7-8	הדמוקרטית	_	_	_	_	_	_	_	_
 7	ה	ה	DET	DET	PronType=Art	8	det:def	_	_
 8	דמוקרטית	דמוקרטי	ADJ	ADJ	Gender=Fem|Number=Sing	6	amod	_	_
-9-10	בניצחון	_	_	_	_	_	_	_	_
+9-10	בניצחון	_	_	_	_	_	_	_	SpaceAfter=No
 9	ב	ב	ADP	ADP	_	10	case	_	_
 10	ניצחון	ניצחון	NOUN	NOUN	Gender=Masc|Number=Sing	3	iobj	_	_
 11	,	_	PUNCT	PUNCT	_	10	punct	_	_
@@ -12051,13 +12051,13 @@
 14-15	בשן	_	_	_	_	_	_	_	_
 14	ב	ב	ADP	ADP	_	15	case	_	_
 15	שן	שן	NOUN	NOUN	Gender=Fem|Number=Sing	10	conj	_	_
-16-17	ועין	_	_	_	_	_	_	_	_
+16-17	ועין	_	_	_	_	_	_	_	SpaceAfter=No
 16	ו	ו	CCONJ	CCONJ	_	17	cc	_	_
 17	עין	עין	NOUN	NOUN	Gender=Fem|Number=Sing	15	conj	_	_
 18	.	_	PUNCT	PUNCT	_	3	punct	_	_
 
 # sent_id = 357
-# text = איש בטקסס לא פיקפק שיריבה הרפובליקאי , קלייטון ויליאמס , חוואי ואיש נפט , יביס אותה בקלות .
+# text = איש בטקסס לא פיקפק שיריבה הרפובליקאי, קלייטון ויליאמס, חוואי ואיש נפט, יביס אותה בקלות.
 1	איש	איש	NOUN	NOUN	Gender=Masc|Number=Sing	5	nsubj	_	_
 2-3	בטקסס	_	_	_	_	_	_	_	_
 2	ב	ב	ADP	ADP	_	3	case	_	_
@@ -12069,30 +12069,30 @@
 7	יריב_	יריב	NOUN	NOUN	Definite=Def|Gender=Masc|Number=Sing	21	nsubj	_	_
 8	_של_	של	ADP	ADP	_	9	case:gen	_	_
 9	_היא	הוא	PRON	PRON	Case=Gen|Gender=Fem|Number=Sing|Person=3|PronType=Prs	7	nmod:poss	_	_
-10-11	הרפובליקאי	_	_	_	_	_	_	_	_
+10-11	הרפובליקאי	_	_	_	_	_	_	_	SpaceAfter=No
 10	ה	ה	DET	DET	PronType=Art	11	det:def	_	_
 11	רפובליקאי	רפובליקני	ADJ	ADJ	Gender=Masc|Number=Sing	7	amod	_	_
 12	,	_	PUNCT	PUNCT	_	7	punct	_	_
 13	קלייטון	קלייטון	PROPN	PROPN	HebSource=ConvUncertainHead	7	dep	_	_
-14	ויליאמס	ויליאמס	PROPN	PROPN	_	13	flat:name	_	_
+14	ויליאמס	ויליאמס	PROPN	PROPN	_	13	flat:name	_	SpaceAfter=No
 15	,	_	PUNCT	PUNCT	_	7	punct	_	_
 16	חוואי	חוואי	NOUN	NOUN	Gender=Masc|HebSource=ConvUncertainHead|Number=Sing	7	dep	_	_
 17-18	ואיש	_	_	_	_	_	_	_	_
 17	ו	ו	CCONJ	CCONJ	_	18	cc	_	_
 18	איש	איש	NOUN	NOUN	Definite=Cons|Gender=Masc|Number=Sing	16	conj	_	_
-19	נפט	נפט	NOUN	NOUN	Gender=Masc|Number=Sing	18	compound:smixut	_	_
+19	נפט	נפט	NOUN	NOUN	Gender=Masc|Number=Sing	18	compound:smixut	_	SpaceAfter=No
 20	,	_	PUNCT	PUNCT	_	21	punct	_	_
 21	יביס	הביס	VERB	VERB	Gender=Masc|HebBinyan=HIFIL|Number=Sing|Person=3|Tense=Fut|Voice=Act	5	ccomp	_	_
 22-23	אותה	_	_	_	_	_	_	_	_
 22	את_	את	PART	PART	Case=Acc	23	case:acc	_	_
 23	_היא	הוא	PRON	PRON	Gender=Fem|Number=Sing|Person=3|PronType=Prs	21	obj	_	_
-24-25	בקלות	_	_	_	_	_	_	_	_
+24-25	בקלות	_	_	_	_	_	_	_	SpaceAfter=No
 24	ב	ב	ADP	ADP	_	25	case	_	_
 25	קלות	קלות	NOUN	NOUN	Gender=Fem|Number=Sing	21	obl	_	_
 26	.	_	PUNCT	PUNCT	_	5	punct	_	_
 
 # sent_id = 358
-# text = הוא הופיע בתשדירי הבחירות שלו רכוב על סוס , עם מגבעת רחבת תיתורת , ופרט על נימי המאציזמו הטקסני .
+# text = הוא הופיע בתשדירי הבחירות שלו רכוב על סוס, עם מגבעת רחבת תיתורת, ופרט על נימי המאציזמו הטקסני.
 1	הוא	הוא	PRON	PRON	Gender=Masc|Number=Sing|Person=3|PronType=Prs	2	nsubj	_	_
 2	הופיע	הופיע	VERB	VERB	Gender=Masc|HebBinyan=HIFIL|Number=Sing|Person=3|Tense=Past|Voice=Act	0	root	_	_
 3-4	בתשדירי	_	_	_	_	_	_	_	_
@@ -12106,12 +12106,12 @@
 8	_הוא	הוא	PRON	PRON	Gender=Masc|Number=Sing|Person=3|PronType=Prs	4	nmod:poss	_	_
 9	רכוב	רכב	VERB	VERB	Gender=Masc|HebBinyan=PAAL|HebSource=ConvUncertainLabel|Number=Sing|Person=1,2,3|VerbForm=Part|Voice=Act	2	advmod	_	_
 10	על	על	ADP	ADP	_	11	case	_	_
-11	סוס	סוס	NOUN	NOUN	Gender=Masc|Number=Sing	9	advmod	_	_
+11	סוס	סוס	NOUN	NOUN	Gender=Masc|Number=Sing	9	advmod	_	SpaceAfter=No
 12	,	_	PUNCT	PUNCT	_	2	punct	_	_
 13	עם	עם	ADP	ADP	_	14	case	_	_
 14	מגבעת	מגבעת	NOUN	NOUN	Gender=Fem|Number=Sing	2	obl	_	_
 15	רחבת	רחב	ADJ	ADJ	Definite=Cons|Gender=Fem|Number=Sing	14	amod	_	_
-16	תיתורת	תיתורה	NOUN	NOUN	Definite=Cons|Gender=Fem|Number=Sing	15	compound:smixut	_	_
+16	תיתורת	תיתורה	NOUN	NOUN	Definite=Cons|Gender=Fem|Number=Sing	15	compound:smixut	_	SpaceAfter=No
 17	,	_	PUNCT	PUNCT	_	2	punct	_	_
 18-19	ופרט	_	_	_	_	_	_	_	_
 18	ו	ו	CCONJ	CCONJ	_	19	cc	_	_
@@ -12121,27 +12121,27 @@
 22-23	המאציזמו	_	_	_	_	_	_	_	_
 22	ה	_	DET	DET	PronType=Art	23	det:def	_	_
 23	מאציזמו	_	NOUN	NOUN	_	21	compound:smixut	_	_
-24-25	הטקסני	_	_	_	_	_	_	_	_
+24-25	הטקסני	_	_	_	_	_	_	_	SpaceAfter=No
 24	ה	ה	DET	DET	PronType=Art	25	det:def	_	_
 25	טקסני	טקסאני	ADJ	ADJ	Gender=Masc|Number=Sing	23	amod	_	_
 26	.	_	PUNCT	PUNCT	_	2	punct	_	_
 
 # sent_id = 359
-# text = הוא גם התחיל למעוד מעידות מילוליות שערורייתיות .
+# text = הוא גם התחיל למעוד מעידות מילוליות שערורייתיות.
 1	הוא	הוא	PRON	PRON	Gender=Masc|Number=Sing|Person=3|PronType=Prs	3	nsubj	_	_
 2	גם	גם	ADV	ADV	_	3	advmod	_	_
 3	התחיל	התחיל	VERB	VERB	Gender=Masc|Number=Sing|Person=3|Tense=Past	0	root	_	_
 4	למעוד	מעד	VERB	VERB	HebBinyan=PAAL|VerbForm=Inf|Voice=Act	3	xcomp	_	_
 5	מעידות	מעידה	NOUN	NOUN	Gender=Fem|Number=Plur	4	obj	_	_
 6	מילוליות	מילולי	ADJ	ADJ	Gender=Fem|Number=Plur	5	amod	_	_
-7	שערורייתיות	שערורייתי	ADJ	ADJ	Gender=Fem|Number=Plur	5	amod	_	_
+7	שערורייתיות	שערורייתי	ADJ	ADJ	Gender=Fem|Number=Plur	5	amod	_	SpaceAfter=No
 8	.	_	PUNCT	PUNCT	_	3	punct	_	_
 
 # sent_id = 360
-# text = הוא יעץ לנשים , שאם הן נופלות קרבן לאונס והן חסרות אונים , " מוטב לשתוק וליהנות " .
+# text = הוא יעץ לנשים, שאם הן נופלות קרבן לאונס והן חסרות אונים, "מוטב לשתוק וליהנות".
 1	הוא	הוא	PRON	PRON	Gender=Masc|Number=Sing|Person=3|PronType=Prs	2	nsubj	_	_
 2	יעץ	יעץ	VERB	VERB	Gender=Masc|Number=Sing|Person=3|Tense=Past	0	root	_	_
-3-5	לנשים	_	_	_	_	_	_	_	_
+3-5	לנשים	_	_	_	_	_	_	_	SpaceAfter=No
 3	ל	ל	ADP	ADP	_	5	case	_	_
 4	ה_	ה	DET	DET	PronType=Art	5	det:def	_	_
 5	נשים	איש	NOUN	NOUN	Gender=Fem|Number=Plur	2	iobj	_	_
@@ -12159,19 +12159,19 @@
 14	ו	ו	CCONJ	CCONJ	_	16	cc	_	_
 15	הן	הוא	PRON	PRON	Gender=Fem|Number=Plur|Person=3|PronType=Prs	16	nsubj	_	_
 16	חסרות	חסר	ADJ	ADJ	Definite=Cons|Gender=Fem|Number=Plur	10	conj	_	_
-17	אונים	און	NOUN	NOUN	Gender=Masc|Number=Plur	16	compound:smixut	_	_
+17	אונים	און	NOUN	NOUN	Gender=Masc|Number=Plur	16	compound:smixut	_	SpaceAfter=No
 18	,	_	PUNCT	PUNCT	_	10	punct	_	_
-19	"	_	PUNCT	PUNCT	_	20	punct	_	_
+19	"	_	PUNCT	PUNCT	_	20	punct	_	SpaceAfter=No
 20	מוטב	מוטב	AUX	AUX	HebSource=ConvUncertainHead|VerbType=Mod	10	dep	_	_
 21	לשתוק	שתק	VERB	VERB	HebBinyan=PAAL|VerbForm=Inf|Voice=Act	20	xcomp	_	_
-22-23	וליהנות	_	_	_	_	_	_	_	_
+22-23	וליהנות	_	_	_	_	_	_	_	SpaceAfter=No
 22	ו	ו	CCONJ	CCONJ	_	23	cc	_	_
 23	ליהנות	נהנה	VERB	VERB	HebBinyan=NIFAL|VerbForm=Inf|Voice=Mid	21	conj	_	_
-24	"	_	PUNCT	PUNCT	_	20	punct	_	_
+24	"	_	PUNCT	PUNCT	_	20	punct	_	SpaceAfter=No
 25	.	_	PUNCT	PUNCT	_	2	punct	_	_
 
 # sent_id = 361
-# text = הוא דיבר בפומבי על ניסיונו כאיש צעיר בבתי - בושת מקסיקאיים .
+# text = הוא דיבר בפומבי על ניסיונו כאיש צעיר בבתי - בושת מקסיקאיים.
 1	הוא	הוא	PRON	PRON	Gender=Masc|Number=Sing|Person=3|PronType=Prs	2	nsubj	_	_
 2	דיבר	דיבר	VERB	VERB	Gender=Masc|HebBinyan=PIEL|Number=Sing|Person=3|Tense=Past|Voice=Act	0	root	_	_
 3-4	בפומבי	_	_	_	_	_	_	_	_
@@ -12191,11 +12191,11 @@
 13	בתי	בית	NOUN	NOUN	Definite=Cons|Gender=Masc|Number=Plur	15	nmod	_	_
 14	-	_	PUNCT	PUNCT	_	15	punct	_	_
 15	בושת	בושת	NOUN	NOUN	Gender=Fem|Number=Sing	6	nmod	_	_
-16	מקסיקאיים	מקסיקני	ADJ	ADJ	Gender=Masc|Number=Plur	15	amod	_	_
+16	מקסיקאיים	מקסיקני	ADJ	ADJ	Gender=Masc|Number=Plur	15	amod	_	SpaceAfter=No
 17	.	_	PUNCT	PUNCT	_	2	punct	_	_
 
 # sent_id = 362
-# text = הוא סירב ללחוץ את ידה של ריצארדס ברבים , וקרא לה בפניה שקרנית " .
+# text = הוא סירב ללחוץ את ידה של ריצארדס ברבים, וקרא לה בפניה שקרנית".
 1	הוא	הוא	PRON	PRON	Gender=Masc|Number=Sing|Person=3|PronType=Prs	2	nsubj	_	_
 2	סירב	סירב	VERB	VERB	Gender=Masc|HebBinyan=PIEL|Number=Sing|Person=3|Tense=Past|Voice=Act	0	root	_	_
 3	ללחוץ	לחץ	VERB	VERB	HebBinyan=PAAL|VerbForm=Inf|Voice=Act	2	xcomp	_	_
@@ -12206,7 +12206,7 @@
 7	_היא	הוא	PRON	PRON	Case=Gen|Gender=Fem|Number=Sing|Person=3|PronType=Prs	5	nmod:poss	_	_
 8	של	של	PART	PART	Case=Gen	9	case:gen	_	_
 9	ריצארדס	ריצארדס	PROPN	PROPN	_	5	nmod:poss	_	_
-10-12	ברבים	_	_	_	_	_	_	_	_
+10-12	ברבים	_	_	_	_	_	_	_	SpaceAfter=No
 10	ב	ב	ADP	ADP	_	12	case	_	_
 11	ה_	ה	DET	DET	PronType=Art	12	det:def	_	_
 12	רבים	רב	VERB	VERB	Gender=Masc|HebBinyan=PAAL|Number=Plur|Person=1,2,3|VerbForm=Part|Voice=Act	3	obl	_	_
@@ -12222,25 +12222,25 @@
 19	פנים_	פנים	NOUN	NOUN	Definite=Def|Gender=Fem,Masc|Number=Plur	15	obl	_	_
 20	_של_	של	ADP	ADP	_	21	case:gen	_	_
 21	_היא	הוא	PRON	PRON	Case=Gen|Gender=Fem|Number=Sing|Person=3|PronType=Prs	19	nmod:poss	_	_
-22	שקרנית	שקרן	NOUN	NOUN	Gender=Fem|Number=Sing	15	obj	_	_
-23	"	_	PUNCT	PUNCT	_	15	punct	_	_
+22	שקרנית	שקרן	NOUN	NOUN	Gender=Fem|Number=Sing	15	obj	_	SpaceAfter=No
+23	"	_	PUNCT	PUNCT	_	15	punct	_	SpaceAfter=No
 24	.	_	PUNCT	PUNCT	_	2	punct	_	_
 
 # sent_id = 363
-# text = פעם אחרת שאל בחיוך גדול , האם חזרה להיות אלכוהוליסטית ( ריצארדס הודתה שעברה טיפול נגד אלכוהוליזם בתקופה מסוימת של חייה ) .
+# text = פעם אחרת שאל בחיוך גדול, האם חזרה להיות אלכוהוליסטית (ריצארדס הודתה שעברה טיפול נגד אלכוהוליזם בתקופה מסוימת של חייה).
 1	פעם	פעם	NOUN	NOUN	Gender=Fem|Number=Sing	3	dep	_	_
 2	אחרת	אחר	ADJ	ADJ	Gender=Fem|Number=Sing	1	amod	_	_
 3	שאל	שאל	VERB	VERB	Gender=Masc|HebBinyan=PAAL|Number=Sing|Person=3|Tense=Past|Voice=Act	0	root	_	_
 4-5	בחיוך	_	_	_	_	_	_	_	_
 4	ב	ב	ADP	ADP	_	5	case	_	_
 5	חיוך	חיוך	NOUN	NOUN	Gender=Masc|Number=Sing	3	obl	_	_
-6	גדול	גדול	ADJ	ADJ	Gender=Masc|Number=Sing	5	amod	_	_
+6	גדול	גדול	ADJ	ADJ	Gender=Masc|Number=Sing	5	amod	_	SpaceAfter=No
 7	,	_	PUNCT	PUNCT	_	3	punct	_	_
 8	האם	האם	ADV	ADV	PronType=Int	9	aux:q	_	_
 9	חזרה	חזר	VERB	VERB	Gender=Fem|Number=Sing|Person=3|Tense=Past	3	advcl	_	_
 10	להיות	היה	VERB	VERB	Polarity=Pos|VerbForm=Inf|VerbType=Cop	9	xcomp	_	_
 11	אלכוהוליסטית	אלכוהוליסט	NOUN	NOUN	Gender=Fem|Number=Sing	10	obj	_	_
-12	(	_	PUNCT	PUNCT	_	14	punct	_	_
+12	(	_	PUNCT	PUNCT	_	14	punct	_	SpaceAfter=No
 13	ריצארדס	ריצארדס	PROPN	PROPN	_	14	nsubj	_	_
 14	הודתה	הודה	VERB	VERB	Gender=Fem|HebBinyan=HIFIL|Number=Sing|Person=3|Tense=Past|Voice=Act	3	parataxis	_	_
 15-16	שעברה	_	_	_	_	_	_	_	_
@@ -12254,15 +12254,15 @@
 21	תקופה	תקופה	NOUN	NOUN	Gender=Fem|Number=Sing	16	obl	_	_
 22	מסוימת	מסוים	ADJ	ADJ	Gender=Fem|Number=Sing	21	amod	_	_
 23	של	של	PART	PART	Case=Gen	24	case:gen	_	_
-24-26	חייה	_	_	_	_	_	_	_	_
+24-26	חייה	_	_	_	_	_	_	_	SpaceAfter=No
 24	חיים_	חיים	NOUN	NOUN	Definite=Def|Gender=Masc|Number=Plur	21	nmod	_	_
 25	_של_	של	ADP	ADP	_	26	case:gen	_	_
 26	_היא	הוא	PRON	PRON	Case=Gen|Gender=Fem|Number=Sing|Person=3|PronType=Prs	24	nmod:poss	_	_
-27	)	_	PUNCT	PUNCT	_	14	punct	_	_
+27	)	_	PUNCT	PUNCT	_	14	punct	_	SpaceAfter=No
 28	.	_	PUNCT	PUNCT	_	3	punct	_	_
 
 # sent_id = 364
-# text = יתרונו העצום של ויליאמס בסקרים פחת והלך , והרפובליקאים מרטו בייאוש את שערותיהם .
+# text = יתרונו העצום של ויליאמס בסקרים פחת והלך, והרפובליקאים מרטו בייאוש את שערותיהם.
 1-3	יתרונו	_	_	_	_	_	_	_	_
 1	יתרון_	יתרון	NOUN	NOUN	Definite=Def|Gender=Masc|Number=Sing	11	nsubj	_	_
 2	_של_	של	ADP	ADP	_	3	case:gen	_	_
@@ -12277,7 +12277,7 @@
 9	ה_	ה	DET	DET	PronType=Art	10	det:def	_	_
 10	סקרים	סקר	NOUN	NOUN	Gender=Masc|Number=Plur	1	nmod	_	_
 11	פחת	פחת	VERB	VERB	Gender=Masc|Number=Sing|Person=3|Tense=Past	0	root	_	_
-12-13	והלך	_	_	_	_	_	_	_	_
+12-13	והלך	_	_	_	_	_	_	_	SpaceAfter=No
 12	ו	ו	CCONJ	CCONJ	_	13	cc	_	_
 13	הלך	הלך	VERB	VERB	Gender=Masc|Number=Sing|Person=3|Tense=Past	11	conj	_	_
 14	,	_	PUNCT	PUNCT	_	11	punct	_	_
@@ -12290,30 +12290,30 @@
 19	ב	ב	ADP	ADP	_	20	case	_	_
 20	ייאוש	ייאוש	NOUN	NOUN	Gender=Masc|Number=Sing	18	obl	_	_
 21	את	את	PART	PART	Case=Acc	22	case:acc	_	_
-22-24	שערותיהם	_	_	_	_	_	_	_	_
+22-24	שערותיהם	_	_	_	_	_	_	_	SpaceAfter=No
 22	שערה_	שערה	NOUN	NOUN	Definite=Def|Gender=Fem|Number=Plur	18	obj	_	_
 23	_של_	של	ADP	ADP	_	24	case:gen	_	_
 24	_הם	הוא	PRON	PRON	Case=Gen|Gender=Masc|Number=Plur|Person=3|PronType=Prs	22	nmod:poss	_	_
 25	.	_	PUNCT	PUNCT	_	11	punct	_	_
 
 # sent_id = 365
-# text = הם התחננו לפני ויליאמס לשתוק .
+# text = הם התחננו לפני ויליאמס לשתוק.
 1	הם	הוא	PRON	PRON	Gender=Masc|Number=Plur|Person=3|PronType=Prs	2	nsubj	_	_
 2	התחננו	התחנן	VERB	VERB	Gender=Fem,Masc|HebBinyan=HITPAEL|Number=Plur|Person=3|Tense=Past	0	root	_	_
 3	לפני	לפני	ADP	ADP	_	4	case	_	_
 4	ויליאמס	ויליאמס	PROPN	PROPN	_	2	obl	_	_
-5	לשתוק	שתק	VERB	VERB	HebBinyan=PAAL|VerbForm=Inf|Voice=Act	2	xcomp	_	_
+5	לשתוק	שתק	VERB	VERB	HebBinyan=PAAL|VerbForm=Inf|Voice=Act	2	xcomp	_	SpaceAfter=No
 6	.	_	PUNCT	PUNCT	_	2	punct	_	_
 
 # sent_id = 366
-# text = הוא לא הצליח .
+# text = הוא לא הצליח.
 1	הוא	הוא	PRON	PRON	Gender=Masc|Number=Sing|Person=3|PronType=Prs	3	nsubj	_	_
 2	לא	לא	ADV	ADV	Polarity=Neg	3	advmod	_	_
-3	הצליח	הצליח	VERB	VERB	Gender=Masc|HebBinyan=HIFIL|Number=Sing|Person=3|Tense=Past|Voice=Act	0	root	_	_
+3	הצליח	הצליח	VERB	VERB	Gender=Masc|HebBinyan=HIFIL|Number=Sing|Person=3|Tense=Past|Voice=Act	0	root	_	SpaceAfter=No
 4	.	_	PUNCT	PUNCT	_	3	punct	_	_
 
 # sent_id = 367
-# text = בינואר תקבל לידיה ריצארדס את האחריות המינהלית הגדולה ביותר שנמסרה אי - פעם לידי אשה בתולדות ארה"ב .
+# text = בינואר תקבל לידיה ריצארדס את האחריות המינהלית הגדולה ביותר שנמסרה אי - פעם לידי אשה בתולדות ארה"ב.
 1-2	בינואר	_	_	_	_	_	_	_	_
 1	ב	ב	ADP	ADP	_	2	case	_	_
 2	ינואר	ינואר	PROPN	PROPN	_	3	obl	_	_
@@ -12346,16 +12346,16 @@
 24-25	בתולדות	_	_	_	_	_	_	_	_
 24	ב	ב	ADP	ADP	_	25	case	_	_
 25	תולדות	תולדה	NOUN	NOUN	Definite=Cons|Gender=Fem|Number=Plur	18	obl	_	_
-26	ארה"ב	ארה"ב	PROPN	PROPN	Abbr=Yes	25	compound:smixut	_	_
+26	ארה"ב	ארה"ב	PROPN	PROPN	Abbr=Yes	25	compound:smixut	_	SpaceAfter=No
 27	.	_	PUNCT	PUNCT	_	3	punct	_	_
 
 # sent_id = 368
-# text = אשה אחרת , דיאן פיינסטיין , ראש העיר לשעבר של סן פרנסיסקו , חצי - יהודיה , נוצחה בהפרש קטן בבחירות למושל קליפורניה , הגדולה במדינות הברית .
+# text = אשה אחרת, דיאן פיינסטיין, ראש העיר לשעבר של סן פרנסיסקו, חצי - יהודיה, נוצחה בהפרש קטן בבחירות למושל קליפורניה, הגדולה במדינות הברית.
 1	אשה	איש	NOUN	NOUN	Gender=Fem|Number=Sing	19	nsubj	_	_
-2	אחרת	אחר	ADJ	ADJ	Gender=Fem|Number=Sing	1	amod	_	_
+2	אחרת	אחר	ADJ	ADJ	Gender=Fem|Number=Sing	1	amod	_	SpaceAfter=No
 3	,	_	PUNCT	PUNCT	_	1	punct	_	_
 4	דיאן	דיאן	PROPN	PROPN	HebSource=ConvUncertainHead	1	dep	_	_
-5	פיינסטיין	פיינסטיין	PROPN	PROPN	_	4	flat:name	_	_
+5	פיינסטיין	פיינסטיין	PROPN	PROPN	_	4	flat:name	_	SpaceAfter=No
 6	,	_	PUNCT	PUNCT	_	1	punct	_	_
 7	ראש	ראש	NOUN	NOUN	Definite=Cons|Gender=Masc|HebSource=ConvUncertainHead|Number=Sing	1	dep	_	_
 8-9	העיר	_	_	_	_	_	_	_	_
@@ -12364,11 +12364,11 @@
 10	לשעבר	לשעבר	ADV	ADV	_	7	advmod	_	_
 11	של	של	PART	PART	Case=Gen	12	case:gen	_	_
 12	סן	סן	PROPN	PROPN	_	7	nmod:poss	_	_
-13	פרנסיסקו	פרנסיסקו	PROPN	PROPN	_	12	flat:name	_	_
+13	פרנסיסקו	פרנסיסקו	PROPN	PROPN	_	12	flat:name	_	SpaceAfter=No
 14	,	_	PUNCT	PUNCT	_	1	punct	_	_
 15	חצי	חץ	NOUN	NOUN	Definite=Cons|Gender=Masc|Number=Plur	17	nmod	_	_
 16	-	_	PUNCT	PUNCT	_	17	punct	_	_
-17	יהודיה	יהודי	NOUN	NOUN	Gender=Fem|HebSource=ConvUncertainHead|Number=Sing	1	dep	_	_
+17	יהודיה	יהודי	NOUN	NOUN	Gender=Fem|HebSource=ConvUncertainHead|Number=Sing	1	dep	_	SpaceAfter=No
 18	,	_	PUNCT	PUNCT	_	19	punct	_	_
 19	נוצחה	נוצח	VERB	VERB	Gender=Fem|HebBinyan=PUAL|Number=Sing|Person=3|Tense=Past|Voice=Pass	0	root	_	_
 20-21	בהפרש	_	_	_	_	_	_	_	_
@@ -12382,7 +12382,7 @@
 26-27	למושל	_	_	_	_	_	_	_	_
 26	ל	ל	ADP	ADP	_	27	case	_	_
 27	מושל	מושל	NOUN	NOUN	Definite=Cons|Gender=Masc|Number=Sing	25	nmod	_	_
-28	קליפורניה	קליפורניה	PROPN	PROPN	_	27	compound:smixut	_	_
+28	קליפורניה	קליפורניה	PROPN	PROPN	_	27	compound:smixut	_	SpaceAfter=No
 29	,	_	PUNCT	PUNCT	_	28	punct	_	_
 30-31	הגדולה	_	_	_	_	_	_	_	_
 30	ה	ה	DET	DET	PronType=Art	31	det:def	_	_
@@ -12390,18 +12390,18 @@
 32-33	במדינות	_	_	_	_	_	_	_	_
 32	ב	ב	ADP	ADP	_	33	case	_	_
 33	מדינות	מדינה	NOUN	NOUN	Definite=Cons|Gender=Fem|Number=Plur	31	nmod	_	_
-34-35	הברית	_	_	_	_	_	_	_	_
+34-35	הברית	_	_	_	_	_	_	_	SpaceAfter=No
 34	ה	ה	DET	DET	PronType=Art	35	det:def	_	_
 35	ברית	ברית	NOUN	NOUN	Gender=Fem|Number=Sing	33	compound:smixut	_	_
 36	.	_	PUNCT	PUNCT	_	19	punct	_	_
 
 # sent_id = 369
-# text = אשה אחרת , קיי אור , איבדה את כהונת המושלת במדינת נבראסקה מקץ תקופת כהונה אחת .
+# text = אשה אחרת, קיי אור, איבדה את כהונת המושלת במדינת נבראסקה מקץ תקופת כהונה אחת.
 1	אשה	איש	NOUN	NOUN	Gender=Fem|Number=Sing	7	nsubj	_	_
-2	אחרת	אחר	ADJ	ADJ	Gender=Fem|Number=Sing	1	amod	_	_
+2	אחרת	אחר	ADJ	ADJ	Gender=Fem|Number=Sing	1	amod	_	SpaceAfter=No
 3	,	_	PUNCT	PUNCT	_	1	punct	_	_
 4	קיי	קיי	PROPN	PROPN	_	1	appos	_	_
-5	אור	אור	PROPN	PROPN	_	4	flat:name	_	_
+5	אור	אור	PROPN	PROPN	_	4	flat:name	_	SpaceAfter=No
 6	,	_	PUNCT	PUNCT	_	7	punct	_	_
 7	איבדה	איבד	VERB	VERB	Gender=Fem|HebBinyan=PIEL|Number=Sing|Person=3|Tense=Past|Voice=Act	0	root	_	_
 8	את	את	PART	PART	Case=Acc	9	case:acc	_	_
@@ -12418,19 +12418,19 @@
 16	קץ	קץ	NOUN	NOUN	Definite=Cons|Gender=Masc|Number=Sing	7	obl	_	_
 17	תקופת	תקופה	NOUN	NOUN	Definite=Cons|Gender=Fem|Number=Sing	16	compound:smixut	_	_
 18	כהונה	כהונה	NOUN	NOUN	Gender=Fem|Number=Sing	17	compound:smixut	_	_
-19	אחת	אחת	NUM	NUM	Gender=Fem|Number=Sing	17	nummod	_	_
+19	אחת	אחת	NUM	NUM	Gender=Fem|Number=Sing	17	nummod	_	SpaceAfter=No
 20	.	_	PUNCT	PUNCT	_	7	punct	_	_
 
 # sent_id = 370
-# text = אשה שלישית , מדלן קיונין , יהודייה מלאה , סיימה שש שנות כהונה כמושלת ורמונט , ולא העמידה את עצמה לבחירה חוזרת .
+# text = אשה שלישית, מדלן קיונין, יהודייה מלאה, סיימה שש שנות כהונה כמושלת ורמונט, ולא העמידה את עצמה לבחירה חוזרת.
 1	אשה	איש	NOUN	NOUN	Gender=Fem|Number=Sing	10	nsubj	_	_
-2	שלישית	שלישי	NUM	NUM	Gender=Fem|Number=Sing	1	amod	_	_
+2	שלישית	שלישי	NUM	NUM	Gender=Fem|Number=Sing	1	amod	_	SpaceAfter=No
 3	,	_	PUNCT	PUNCT	_	1	punct	_	_
 4	מדלן	מדלן	PROPN	PROPN	HebSource=ConvUncertainHead	1	dep	_	_
-5	קיונין	קיונין	PROPN	PROPN	_	4	flat:name	_	_
+5	קיונין	קיונין	PROPN	PROPN	_	4	flat:name	_	SpaceAfter=No
 6	,	_	PUNCT	PUNCT	_	1	punct	_	_
 7	יהודייה	יהודי	NOUN	NOUN	Gender=Fem|HebSource=ConvUncertainHead|Number=Sing	1	dep	_	_
-8	מלאה	מלא	ADJ	ADJ	Gender=Fem|Number=Sing	7	amod	_	_
+8	מלאה	מלא	ADJ	ADJ	Gender=Fem|Number=Sing	7	amod	_	SpaceAfter=No
 9	,	_	PUNCT	PUNCT	_	10	punct	_	_
 10	סיימה	סיים	VERB	VERB	Gender=Fem|HebBinyan=PIEL|Number=Sing|Person=3|Tense=Past|Voice=Act	0	root	_	_
 11	שש	שש	NUM	NUM	Gender=Fem|Number=Sing	12	nummod	_	_
@@ -12439,7 +12439,7 @@
 14-15	כמושלת	_	_	_	_	_	_	_	_
 14	כ	כ	ADP	ADP	_	15	case	_	_
 15	מושלת	מושל	NOUN	NOUN	Definite=Cons|Gender=Fem|Number=Sing	12	nmod	_	_
-16	ורמונט	ורמונט	PROPN	PROPN	_	15	compound:smixut	_	_
+16	ורמונט	ורמונט	PROPN	PROPN	_	15	compound:smixut	_	SpaceAfter=No
 17	,	_	PUNCT	PUNCT	_	10	punct	_	_
 18-19	ולא	_	_	_	_	_	_	_	_
 18	ו	ו	CCONJ	CCONJ	_	20	cc	_	_
@@ -12450,13 +12450,13 @@
 23-24	לבחירה	_	_	_	_	_	_	_	_
 23	ל	ל	ADP	ADP	_	24	case	_	_
 24	בחירה	בחירה	NOUN	NOUN	Gender=Fem|Number=Sing	20	iobj	_	_
-25	חוזרת	חוזר	ADJ	ADJ	Gender=Fem|Number=Sing	24	amod	_	_
+25	חוזרת	חוזר	ADJ	ADJ	Gender=Fem|Number=Sing	24	amod	_	SpaceAfter=No
 26	.	_	PUNCT	PUNCT	_	10	punct	_	_
 
 # sent_id = 371
-# text = נשים הפתיעו , ונבחרו למושלות במדינת קנזאס ובמדינת אורגון .
+# text = נשים הפתיעו, ונבחרו למושלות במדינת קנזאס ובמדינת אורגון.
 1	נשים	איש	NOUN	NOUN	Gender=Fem|Number=Plur	2	nsubj	_	_
-2	הפתיעו	הפתיע	VERB	VERB	Gender=Fem,Masc|HebBinyan=HIFIL|Number=Plur|Person=3|Tense=Past|Voice=Act	0	root	_	_
+2	הפתיעו	הפתיע	VERB	VERB	Gender=Fem,Masc|HebBinyan=HIFIL|Number=Plur|Person=3|Tense=Past|Voice=Act	0	root	_	SpaceAfter=No
 3	,	_	PUNCT	PUNCT	_	2	punct	_	_
 4-5	ונבחרו	_	_	_	_	_	_	_	_
 4	ו	ו	CCONJ	CCONJ	_	5	cc	_	_
@@ -12472,11 +12472,11 @@
 11	ו	ו	CCONJ	CCONJ	_	13	cc	_	_
 12	ב	ב	ADP	ADP	_	13	case	_	_
 13	מדינת	מדינה	NOUN	NOUN	Definite=Cons|Gender=Fem|Number=Sing	9	conj	_	_
-14	אורגון	אורגון	PROPN	PROPN	_	13	compound:smixut	_	_
+14	אורגון	אורגון	PROPN	PROPN	_	13	compound:smixut	_	SpaceAfter=No
 15	.	_	PUNCT	PUNCT	_	2	punct	_	_
 
 # sent_id = 372
-# text = בסך הכול יהיו איפוא בינואר הבא שלוש מושלות בארה"ב ושתי סנאטוריות .
+# text = בסך הכול יהיו איפוא בינואר הבא שלוש מושלות בארה"ב ושתי סנאטוריות.
 1-2	בסך	_	_	_	_	_	_	_	_
 1	ב	ב	ADP	ADP	_	2	case	_	_
 2	סך	סך	NOUN	NOUN	Definite=Cons|Gender=Masc|Number=Sing	4	obl	_	_
@@ -12497,11 +12497,11 @@
 14-15	ושתי	_	_	_	_	_	_	_	_
 14	ו	ו	CCONJ	CCONJ	_	16	cc	_	_
 15	שתי	שתיים	NUM	NUM	Definite=Cons|Gender=Fem|Number=Plur	16	nummod	_	_
-16	סנאטוריות	סנאטוריות	NOUN	NOUN	_	11	conj	_	_
+16	סנאטוריות	סנאטוריות	NOUN	NOUN	_	11	conj	_	SpaceAfter=No
 17	.	_	PUNCT	PUNCT	_	4	punct	_	_
 
 # sent_id = 373
-# text = אף אשה אחת לא הצליחה להיבחר השנה לסנאט .
+# text = אף אשה אחת לא הצליחה להיבחר השנה לסנאט.
 1	אף	אף	DET	DET	Definite=Cons	2	det	_	_
 2	אשה	איש	NOUN	NOUN	Gender=Fem|Number=Sing	5	nsubj	_	_
 3	אחת	אחת	NUM	NUM	Gender=Fem|Number=Sing	2	nummod	_	_
@@ -12509,14 +12509,14 @@
 5	הצליחה	הצליח	VERB	VERB	Gender=Fem|HebBinyan=HIFIL|Number=Sing|Person=3|Tense=Past|Voice=Act	0	root	_	_
 6	להיבחר	נבחר	VERB	VERB	HebBinyan=NIFAL|VerbForm=Inf|Voice=Mid	5	xcomp	_	_
 7	השנה	השנה	ADV	ADV	_	6	obl:tmod	_	_
-8-10	לסנאט	_	_	_	_	_	_	_	_
+8-10	לסנאט	_	_	_	_	_	_	_	SpaceAfter=No
 8	ל	ל	ADP	ADP	_	10	case	_	_
 9	ה_	ה	DET	DET	PronType=Art	10	det:def	_	_
 10	סנאט	סנאט	NOUN	NOUN	Gender=Masc|Number=Sing	6	iobj	_	_
 11	.	_	PUNCT	PUNCT	_	5	punct	_	_
 
 # sent_id = 374
-# text = לעומת זאת נשמרה רמת הייצוג היהודי .
+# text = לעומת זאת נשמרה רמת הייצוג היהודי.
 1	לעומת	לעומת	ADP	ADP	_	2	case	_	_
 2	זאת	זאת	PRON	PRON	Gender=Fem|Number=Sing|Person=3|PronType=Dem	3	obl	_	_
 3	נשמרה	נשמר	VERB	VERB	Gender=Fem|HebBinyan=NIFAL|Number=Sing|Person=3|Tense=Past|Voice=Mid	0	root	_	_
@@ -12524,20 +12524,20 @@
 5-6	הייצוג	_	_	_	_	_	_	_	_
 5	ה	ה	DET	DET	PronType=Art	6	det:def	_	_
 6	ייצוג	ייצוג	NOUN	NOUN	Gender=Masc|Number=Sing	4	compound:smixut	_	_
-7-8	היהודי	_	_	_	_	_	_	_	_
+7-8	היהודי	_	_	_	_	_	_	_	SpaceAfter=No
 7	ה	ה	DET	DET	PronType=Art	8	det:def	_	_
 8	יהודי	יהודי	ADJ	ADJ	Gender=Masc|Number=Sing	6	amod	_	_
 9	.	_	PUNCT	PUNCT	_	3	punct	_	_
 
 # sent_id = 375
-# text = לפני הבחירות היו שבעה סנאטורים , וגם אחריהם יש שבעה סנאטורים .
+# text = לפני הבחירות היו שבעה סנאטורים, וגם אחריהם יש שבעה סנאטורים.
 1	לפני	לפני	ADP	ADP	_	3	case	_	_
 2-3	הבחירות	_	_	_	_	_	_	_	_
 2	ה	ה	DET	DET	PronType=Art	3	det:def	_	_
 3	בחירות	בחירות	NOUN	NOUN	Gender=Fem|Number=Plur	4	obl	_	_
 4	היו	היה	VERB	VERB	Gender=Fem,Masc|Number=Plur|Person=3|Polarity=Pos|Tense=Past|VerbType=Cop	0	root	_	_
 5	שבעה	שבעה	NUM	NUM	Gender=Masc|Number=Sing	6	nummod	_	_
-6	סנאטורים	סנטור	NOUN	NOUN	Gender=Masc|Number=Plur	4	nsubj	_	_
+6	סנאטורים	סנטור	NOUN	NOUN	Gender=Masc|Number=Plur	4	nsubj	_	SpaceAfter=No
 7	,	_	PUNCT	PUNCT	_	4	punct	_	_
 8-9	וגם	_	_	_	_	_	_	_	_
 8	ו	ו	CCONJ	CCONJ	_	12	cc	_	_
@@ -12547,27 +12547,27 @@
 11	_הם	הוא	PRON	PRON	Gender=Masc|Number=Plur|Person=3|PronType=Prs	12	obl	_	_
 12	יש	יש	VERB	VERB	HebExistential=True	4	conj	_	_
 13	שבעה	שבעה	NUM	NUM	Gender=Masc|Number=Sing	14	nummod	_	_
-14	סנאטורים	סנטור	NOUN	NOUN	Gender=Masc|Number=Plur	12	nsubj	_	_
+14	סנאטורים	סנטור	NOUN	NOUN	Gender=Masc|Number=Plur	12	nsubj	_	SpaceAfter=No
 15	.	_	PUNCT	PUNCT	_	4	punct	_	_
 
 # sent_id = 376
-# text = אחד מהם , רודי בושוויץ , רפובליקן ממדינת מינסוטה , נוצח בבחירות , אבל את מקומו תופס יהודי אחר ממינסוטה , פול ולסטון .
+# text = אחד מהם, רודי בושוויץ, רפובליקן ממדינת מינסוטה, נוצח בבחירות, אבל את מקומו תופס יהודי אחר ממינסוטה, פול ולסטון.
 1	אחד	אחד	NUM	NUM	Gender=Masc|Number=Sing	3	det	_	_
-2-3	מהם	_	_	_	_	_	_	_	_
+2-3	מהם	_	_	_	_	_	_	_	SpaceAfter=No
 2	מהם	מן	ADP	ADP	_	3	case	_	_
 3	_הם	הוא	PRON	PRON	Gender=Masc|Number=Plur|Person=3|PronType=Prs	13	nsubj	_	_
 4	,	_	PUNCT	PUNCT	_	3	punct	_	_
 5	רודי	רודי	PROPN	PROPN	HebSource=ConvUncertainHead	3	dep	_	_
-6	בושוויץ	בושוויץ	PROPN	PROPN	_	5	flat:name	_	_
+6	בושוויץ	בושוויץ	PROPN	PROPN	_	5	flat:name	_	SpaceAfter=No
 7	,	_	PUNCT	PUNCT	_	3	punct	_	_
 8	רפובליקן	רפובליקן	ADJ	ADJ	Gender=Masc|HebSource=ConvUncertainHead|Number=Sing	3	dep	_	_
 9-10	ממדינת	_	_	_	_	_	_	_	_
 9	מ	מ	ADP	ADP	_	10	case	_	_
 10	מדינת	מדינה	NOUN	NOUN	Definite=Cons|Gender=Fem|Number=Sing	8	obl	_	_
-11	מינסוטה	מינסוטה	PROPN	PROPN	_	10	compound:smixut	_	_
+11	מינסוטה	מינסוטה	PROPN	PROPN	_	10	compound:smixut	_	SpaceAfter=No
 12	,	_	PUNCT	PUNCT	_	13	punct	_	_
 13	נוצח	נוצח	VERB	VERB	Gender=Masc|HebBinyan=PUAL|Number=Sing|Person=3|Tense=Past|Voice=Pass	0	root	_	_
-14-16	בבחירות	_	_	_	_	_	_	_	_
+14-16	בבחירות	_	_	_	_	_	_	_	SpaceAfter=No
 14	ב	ב	ADP	ADP	_	16	case	_	_
 15	ה_	ה	DET	DET	PronType=Art	16	det:def	_	_
 16	בחירות	בחירות	NOUN	NOUN	Gender=Fem|Number=Plur	13	iobj	_	_
@@ -12581,16 +12581,16 @@
 23	תופס	תפס	VERB	VERB	Gender=Masc|HebBinyan=PAAL|Number=Sing|Person=1,2,3|VerbForm=Part|Voice=Act	13	conj	_	_
 24	יהודי	יהודי	NOUN	NOUN	Gender=Masc|Number=Sing	23	nsubj	_	_
 25	אחר	אחר	ADJ	ADJ	Gender=Masc|Number=Sing	24	amod	_	_
-26-27	ממינסוטה	_	_	_	_	_	_	_	_
+26-27	ממינסוטה	_	_	_	_	_	_	_	SpaceAfter=No
 26	מ	מ	ADP	ADP	_	27	case	_	_
 27	מינסוטה	מינסוטה	PROPN	PROPN	_	24	nmod	_	_
 28	,	_	PUNCT	PUNCT	_	24	punct	_	_
 29	פול	פול	PROPN	PROPN	_	24	appos	_	_
-30	ולסטון	ולסטון	PROPN	PROPN	_	29	flat:name	_	_
+30	ולסטון	ולסטון	PROPN	PROPN	_	29	flat:name	_	SpaceAfter=No
 31	.	_	PUNCT	PUNCT	_	13	punct	_	_
 
 # sent_id = 377
-# text = יהדותו של וולסטון נעשתה נושא מרכזי בשלושת הימים האחרונים של מערכת הבחירות .
+# text = יהדותו של וולסטון נעשתה נושא מרכזי בשלושת הימים האחרונים של מערכת הבחירות.
 1-3	יהדותו	_	_	_	_	_	_	_	_
 1	יהדות_	יהדות	NOUN	NOUN	Definite=Def|Gender=Fem|Number=Sing	6	nsubj	_	_
 2	_של_	של	ADP	ADP	_	3	case:gen	_	_
@@ -12611,13 +12611,13 @@
 14	אחרונים	אחרון	ADJ	ADJ	Gender=Masc|Number=Plur	12	amod	_	_
 15	של	של	PART	PART	Case=Gen	16	case:gen	_	_
 16	מערכת	מערכת	NOUN	NOUN	Definite=Cons|Gender=Fem|Number=Sing	12	nmod	_	_
-17-18	הבחירות	_	_	_	_	_	_	_	_
+17-18	הבחירות	_	_	_	_	_	_	_	SpaceAfter=No
 17	ה	ה	DET	DET	PronType=Art	18	det:def	_	_
 18	בחירות	בחירות	NOUN	NOUN	Gender=Fem|Number=Plur	16	compound:smixut	_	_
 19	.	_	PUNCT	PUNCT	_	6	punct	_	_
 
 # sent_id = 378
-# text = בושוויץ ניסה לשכנע יהודים במינסוטה להצביע נגד וולסטון , באשר אין הוא יהודי נאמן , וילדיו אינם גדלים כיהודים .
+# text = בושוויץ ניסה לשכנע יהודים במינסוטה להצביע נגד וולסטון, באשר אין הוא יהודי נאמן, וילדיו אינם גדלים כיהודים.
 1	בושוויץ	בושוויץ	PROPN	PROPN	_	2	nsubj	_	_
 2	ניסה	ניסה	VERB	VERB	Gender=Masc|HebBinyan=PIEL|Number=Sing|Person=3|Tense=Past|Voice=Act	0	root	_	_
 3	לשכנע	שכנע	VERB	VERB	HebBinyan=PIEL|VerbForm=Inf|Voice=Act	2	xcomp	_	_
@@ -12627,13 +12627,13 @@
 6	מינסוטה	מינסוטה	PROPN	PROPN	_	4	nmod	_	_
 7	להצביע	הצביע	VERB	VERB	HebBinyan=HIFIL|HebSource=ConvUncertainHead|VerbForm=Inf|Voice=Act	3	dep	_	_
 8	נגד	נגד	ADP	ADP	_	9	case	_	_
-9	וולסטון	וולסטון	PROPN	PROPN	HebSource=ConvUncertainHead	7	dep	_	_
+9	וולסטון	וולסטון	PROPN	PROPN	HebSource=ConvUncertainHead	7	dep	_	SpaceAfter=No
 10	,	_	PUNCT	PUNCT	HebSource=ConvUncertainHead	7	dep	_	_
 11	באשר	באשר	CCONJ	CCONJ	_	14	mark	_	_
 12	אין	_	ADV	ADV	Polarity=Neg	14	advmod	_	_
 13	הוא	הוא	PRON	PRON	Gender=Masc|Number=Sing|Person=3|PronType=Prs	14	nsubj	_	_
 14	יהודי	יהודי	NOUN	NOUN	Gender=Masc|HebSource=ConvUncertainHead|Number=Sing	7	dep	_	_
-15	נאמן	נאמן	ADJ	ADJ	Gender=Masc|Number=Sing	14	amod	_	_
+15	נאמן	נאמן	ADJ	ADJ	Gender=Masc|Number=Sing	14	amod	_	SpaceAfter=No
 16	,	_	PUNCT	PUNCT	_	14	punct	_	_
 17-20	וילדיו	_	_	_	_	_	_	_	_
 17	ו	ו	CCONJ	CCONJ	_	22	cc	_	_
@@ -12642,13 +12642,13 @@
 20	_הוא	הוא	PRON	PRON	Case=Gen|Gender=Masc|Number=Sing|Person=3|PronType=Prs	18	nmod:poss	_	_
 21	אינם	אינו	VERB	VERB	Gender=Masc|Number=Plur|Person=3|Polarity=Neg|VerbForm=Part|VerbType=Cop	22	advmod	_	_
 22	גדלים	גדל	VERB	VERB	Gender=Masc|HebBinyan=PAAL|Number=Plur|Person=1,2,3|VerbForm=Part|Voice=Act	14	conj	_	_
-23-24	כיהודים	_	_	_	_	_	_	_	_
+23-24	כיהודים	_	_	_	_	_	_	_	SpaceAfter=No
 23	כ	כ	ADP	ADP	_	24	case	_	_
 24	יהודים	יהודי	NOUN	NOUN	Gender=Masc|Number=Plur	22	iobj	_	_
 25	.	_	PUNCT	PUNCT	_	2	punct	_	_
 
 # sent_id = 379
-# text = מומחים פוליטיים במינסוטה העריכו ביום ד כי ההתקפה על נאמנויותיו הדתיות של וולסטון היתה גורם מרכזי בתבוסת בושוויץ .
+# text = מומחים פוליטיים במינסוטה העריכו ביום ד כי ההתקפה על נאמנויותיו הדתיות של וולסטון היתה גורם מרכזי בתבוסת בושוויץ.
 1	מומחים	מומחה	NOUN	NOUN	Gender=Masc|Number=Plur	5	nsubj	_	_
 2	פוליטיים	פוליטי	ADJ	ADJ	Gender=Masc|Number=Plur	1	amod	_	_
 3-4	במינסוטה	_	_	_	_	_	_	_	_
@@ -12679,11 +12679,11 @@
 23-24	בתבוסת	_	_	_	_	_	_	_	_
 23	ב	ב	ADP	ADP	_	24	case	_	_
 24	תבוסת	תבוסה	NOUN	NOUN	Definite=Cons|Gender=Fem|Number=Sing	21	nmod	_	_
-25	בושוויץ	בושוויץ	PROPN	PROPN	_	24	compound:smixut	_	_
+25	בושוויץ	בושוויץ	PROPN	PROPN	_	24	compound:smixut	_	SpaceAfter=No
 26	.	_	PUNCT	PUNCT	_	5	punct	_	_
 
 # sent_id = 380
-# text = לפני ההתקפה הוביל בושוויץ ביתרון של 9 % .
+# text = לפני ההתקפה הוביל בושוויץ ביתרון של 9 %.
 1	לפני	לפני	ADP	ADP	_	3	case	_	_
 2-3	ההתקפה	_	_	_	_	_	_	_	_
 2	ה	ה	DET	DET	PronType=Art	3	det:def	_	_
@@ -12695,26 +12695,26 @@
 7	יתרון	יתרון	NOUN	NOUN	Gender=Masc|Number=Sing	4	obl	_	_
 8	של	של	PART	PART	Case=Gen	10	case:gen	_	_
 9	9	_	NUM	NUM	_	10	nummod	_	_
-10	%	%	NOUN	NOUN	Gender=Masc|Number=Plur,Sing	7	nmod:poss	_	_
+10	%	%	NOUN	NOUN	Gender=Masc|Number=Plur,Sing	7	nmod:poss	_	SpaceAfter=No
 11	.	_	PUNCT	PUNCT	_	4	punct	_	_
 
 # sent_id = 381
-# text = בתוך 84 שעות התפוגג היתרון .
+# text = בתוך 84 שעות התפוגג היתרון.
 1	בתוך	בתוך	ADP	ADP	_	3	case	_	_
 2	84	_	NUM	NUM	_	3	nummod	_	_
 3	שעות	שעה	NOUN	NOUN	Gender=Fem|Number=Plur	4	obl	_	_
 4	התפוגג	התפוגג	VERB	VERB	Gender=Masc|HebBinyan=HITPAEL|Number=Sing|Person=3|Tense=Past	0	root	_	_
-5-6	היתרון	_	_	_	_	_	_	_	_
+5-6	היתרון	_	_	_	_	_	_	_	SpaceAfter=No
 5	ה	ה	DET	DET	PronType=Art	6	det:def	_	_
 6	יתרון	יתרון	NOUN	NOUN	Gender=Masc|Number=Sing	4	nsubj	_	_
 7	.	_	PUNCT	PUNCT	_	4	punct	_	_
 
 # sent_id = 382
-# text = במוצאי הבחירות , לפני שהודה בתבוסתו , הופיע בושוויץ בשידור טלוויזיה והטיל את האשמה בקשייו על שורה של גורמים חיצוניים .
+# text = במוצאי הבחירות, לפני שהודה בתבוסתו, הופיע בושוויץ בשידור טלוויזיה והטיל את האשמה בקשייו על שורה של גורמים חיצוניים.
 1-2	במוצאי	_	_	_	_	_	_	_	_
 1	ב	ב	ADP	ADP	_	2	case	_	_
 2	מוצאי	מוצאי	NOUN	NOUN	Definite=Cons|Gender=Masc|Number=Plur	14	obl	_	_
-3-4	הבחירות	_	_	_	_	_	_	_	_
+3-4	הבחירות	_	_	_	_	_	_	_	SpaceAfter=No
 3	ה	ה	DET	DET	PronType=Art	4	det:def	_	_
 4	בחירות	בחירות	NOUN	NOUN	Gender=Fem|Number=Plur	2	compound:smixut	_	_
 5	,	_	PUNCT	PUNCT	_	14	punct	_	_
@@ -12722,7 +12722,7 @@
 7-8	שהודה	_	_	_	_	_	_	_	_
 7	ש	ש	SCONJ	SCONJ	_	8	mark	_	_
 8	הודה	הודה	VERB	VERB	Gender=Masc|HebBinyan=HIFIL|Number=Sing|Person=3|Tense=Past|Voice=Act	14	obl	_	_
-9-12	בתבוסתו	_	_	_	_	_	_	_	_
+9-12	בתבוסתו	_	_	_	_	_	_	_	SpaceAfter=No
 9	ב	ב	ADP	ADP	_	10	case	_	_
 10	תבוסה_	תבוסה	NOUN	NOUN	Definite=Def|Gender=Fem|Number=Sing	8	iobj	_	_
 11	_של_	של	ADP	ADP	_	12	case:gen	_	_
@@ -12750,11 +12750,11 @@
 29	שורה	שורה	NOUN	NOUN	Gender=Fem|Number=Sing	20	iobj	_	_
 30	של	של	PART	PART	Case=Gen	31	case:gen	_	_
 31	גורמים	גורם	NOUN	NOUN	Gender=Masc|Number=Plur	29	nmod:poss	_	_
-32	חיצוניים	חיצוני	ADJ	ADJ	Gender=Masc|Number=Plur	31	amod	_	_
+32	חיצוניים	חיצוני	ADJ	ADJ	Gender=Masc|Number=Plur	31	amod	_	SpaceAfter=No
 33	.	_	PUNCT	PUNCT	_	14	punct	_	_
 
 # sent_id = 383
-# text = הוא לא חשב שהיה משהו פגום בהתנהגותו שלו .
+# text = הוא לא חשב שהיה משהו פגום בהתנהגותו שלו.
 1	הוא	הוא	PRON	PRON	Gender=Masc|Number=Sing|Person=3|PronType=Prs	3	nsubj	_	_
 2	לא	לא	ADV	ADV	Polarity=Neg	3	advmod	_	_
 3	חשב	חשב	VERB	VERB	Gender=Masc|Number=Sing|Person=3|Tense=Past	0	root	_	_
@@ -12768,14 +12768,14 @@
 9	התנהגות_	התנהגות	NOUN	NOUN	Definite=Def|Gender=Fem|Number=Sing	5	iobj	_	_
 10	_של_	של	ADP	ADP	_	11	case:gen	_	_
 11	_הוא	הוא	PRON	PRON	Case=Gen|Gender=Masc|Number=Sing|Person=3|PronType=Prs	9	nmod:poss	_	_
-12-13	שלו	_	_	_	_	_	_	_	_
+12-13	שלו	_	_	_	_	_	_	_	SpaceAfter=No
 12	של_	של	ADP	ADP	Case=Gen	13	case:gen	_	_
 13	_הוא	הוא	PRON	PRON	Gender=Masc|Number=Sing|Person=3|PronType=Prs	9	nmod:poss	_	_
 14	.	_	PUNCT	PUNCT	_	3	punct	_	_
 
 # sent_id = 384
-# text = וולסטון , פרופסור למדע המדינה באוניברסיטה מקומית , השכיל לנצל מצב רוח לאומי בארה"ב נגד בעלי כהונות פוליטיות .
-1	וולסטון	וולסטון	PROPN	PROPN	_	12	nsubj	_	_
+# text = וולסטון, פרופסור למדע המדינה באוניברסיטה מקומית, השכיל לנצל מצב רוח לאומי בארה"ב נגד בעלי כהונות פוליטיות.
+1	וולסטון	וולסטון	PROPN	PROPN	_	12	nsubj	_	SpaceAfter=No
 2	,	_	PUNCT	PUNCT	_	1	punct	_	_
 3	פרופסור	פרופסור	NOUN	NOUN	Gender=Masc|Number=Sing	1	appos	_	_
 4-5	למדע	_	_	_	_	_	_	_	_
@@ -12787,7 +12787,7 @@
 8-9	באוניברסיטה	_	_	_	_	_	_	_	_
 8	ב	ב	ADP	ADP	_	9	case	_	_
 9	אוניברסיטה	אוניברסיטה	NOUN	NOUN	Gender=Fem|Number=Sing	3	nmod	_	_
-10	מקומית	מקומי	ADJ	ADJ	Gender=Fem|Number=Sing	9	amod	_	_
+10	מקומית	מקומי	ADJ	ADJ	Gender=Fem|Number=Sing	9	amod	_	SpaceAfter=No
 11	,	_	PUNCT	PUNCT	_	12	punct	_	_
 12	השכיל	השכיל	VERB	VERB	Gender=Masc|HebBinyan=HIFIL|Number=Sing|Person=3|Tense=Past|Voice=Act	0	root	_	_
 13	לנצל	ניצל	VERB	VERB	HebBinyan=PIEL|VerbForm=Inf|Voice=Act	12	xcomp	_	_
@@ -12800,11 +12800,11 @@
 19	נגד	נגד	ADP	ADP	_	20	case	_	_
 20	בעלי	בעל	NOUN	NOUN	Definite=Cons|Gender=Masc|Number=Plur	14	nmod	_	_
 21	כהונות	כהונה	NOUN	NOUN	Gender=Fem|Number=Plur	20	compound:smixut	_	_
-22	פוליטיות	פוליטי	ADJ	ADJ	Gender=Fem|Number=Plur	21	amod	_	_
+22	פוליטיות	פוליטי	ADJ	ADJ	Gender=Fem|Number=Plur	21	amod	_	SpaceAfter=No
 23	.	_	PUNCT	PUNCT	_	12	punct	_	_
 
 # sent_id = 385
-# text = תשדירי הבחירות שלו תוארו כשנונים ביותר בארה"ב .
+# text = תשדירי הבחירות שלו תוארו כשנונים ביותר בארה"ב.
 1	תשדירי	תשדיר	NOUN	NOUN	Definite=Cons|Gender=Masc|Number=Plur	6	nsubj	_	_
 2-3	הבחירות	_	_	_	_	_	_	_	_
 2	ה	ה	DET	DET	PronType=Art	3	det:def	_	_
@@ -12818,24 +12818,24 @@
 8	ה_	ה	DET	DET	PronType=Art	9	det:def	_	_
 9	שנונים	שנון	ADJ	ADJ	Gender=Masc|Number=Plur	6	iobj	_	_
 10	ביותר	ביותר	ADV	ADV	_	9	advmod	_	_
-11-12	בארה"ב	_	_	_	_	_	_	_	_
+11-12	בארה"ב	_	_	_	_	_	_	_	SpaceAfter=No
 11	ב	ב	ADP	ADP	_	12	case	_	_
 12	ארה"ב	ארה"ב	PROPN	PROPN	Abbr=Yes	9	advmod	_	_
 13	.	_	PUNCT	PUNCT	_	6	punct	_	_
 
 # sent_id = 386
-# text = שניים מהם היו מערכונים קומיים .
+# text = שניים מהם היו מערכונים קומיים.
 1	שניים	שני	NUM	NUM	Gender=Masc|Number=Plur	3	det	_	_
 2-3	מהם	_	_	_	_	_	_	_	_
 2	מהם	מן	ADP	ADP	_	3	case	_	_
 3	_הם	הוא	PRON	PRON	Gender=Masc|Number=Plur|Person=3|PronType=Prs	5	nsubj	_	_
 4	היו	היה	VERB	VERB	Gender=Fem,Masc|Number=Plur|Person=3|Polarity=Pos|Tense=Past|VerbType=Cop	5	aux	_	_
 5	מערכונים	מערכון	NOUN	NOUN	Gender=Masc|Number=Plur	0	root	_	_
-6	קומיים	קומי	ADJ	ADJ	Gender=Masc|Number=Plur	5	amod	_	_
+6	קומיים	קומי	ADJ	ADJ	Gender=Masc|Number=Plur	5	amod	_	SpaceAfter=No
 7	.	_	PUNCT	PUNCT	_	5	punct	_	_
 
 # sent_id = 387
-# text = באחד נראה וולסטון מחפש את רודי בושוויץ על פני כל מינסוטה , בניסיון לקיים אתו ויכוח פומבי .
+# text = באחד נראה וולסטון מחפש את רודי בושוויץ על פני כל מינסוטה, בניסיון לקיים אתו ויכוח פומבי.
 1-2	באחד	_	_	_	_	_	_	_	_
 1	ב	ב	ADP	ADP	_	2	case	_	_
 2	אחד	אחד	NUM	NUM	Gender=Masc|Number=Sing	3	obl	_	_
@@ -12848,7 +12848,7 @@
 9	על	על	ADP	ADP	_	10	case	_	_
 10	פני	פנים	NOUN	NOUN	Definite=Cons|Gender=Fem,Masc|Number=Plur	5	obl	_	_
 11	כל	כול	DET	DET	Definite=Cons	12	det	_	_
-12	מינסוטה	מינסוטה	PROPN	PROPN	_	10	compound:smixut	_	_
+12	מינסוטה	מינסוטה	PROPN	PROPN	_	10	compound:smixut	_	SpaceAfter=No
 13	,	_	PUNCT	PUNCT	_	5	punct	_	_
 14-15	בניסיון	_	_	_	_	_	_	_	_
 14	ב	ב	ADP	ADP	_	15	case	_	_
@@ -12858,11 +12858,11 @@
 17	אתו	את	ADP	ADP	_	18	case	_	_
 18	_הוא	הוא	PRON	PRON	Gender=Masc|Number=Sing|Person=3|PronType=Prs	16	obl	_	_
 19	ויכוח	ויכוח	NOUN	NOUN	Gender=Masc|Number=Sing	16	obj	_	_
-20	פומבי	פומבי	ADJ	ADJ	Gender=Masc|Number=Sing	19	amod	_	_
+20	פומבי	פומבי	ADJ	ADJ	Gender=Masc|Number=Sing	19	amod	_	SpaceAfter=No
 21	.	_	PUNCT	PUNCT	_	3	punct	_	_
 
 # sent_id = 388
-# text = בשני הוא נראה רץ בקפיצות נוירוטיות על פני ציוני דרך בחייו , ומתנצל שאין לו זמן ללכת בנחת מפני שתקציב הפרסום שלו עומד להיגמר .
+# text = בשני הוא נראה רץ בקפיצות נוירוטיות על פני ציוני דרך בחייו, ומתנצל שאין לו זמן ללכת בנחת מפני שתקציב הפרסום שלו עומד להיגמר.
 1-3	בשני	_	_	_	_	_	_	_	_
 1	ב	ב	ADP	ADP	_	3	case	_	_
 2	ה_	ה	DET	DET	PronType=Art	3	det:def	_	_
@@ -12878,7 +12878,7 @@
 11	פני	פנים	NOUN	NOUN	Definite=Cons|Gender=Fem,Masc|Number=Plur	8	nmod	_	_
 12	ציוני	ציון	NOUN	NOUN	Definite=Cons|Gender=Masc|Number=Plur	11	compound:smixut	_	_
 13	דרך	דרך	NOUN	NOUN	Gender=Fem|Number=Sing	12	compound:smixut	_	_
-14-17	בחייו	_	_	_	_	_	_	_	_
+14-17	בחייו	_	_	_	_	_	_	_	SpaceAfter=No
 14	ב	ב	ADP	ADP	_	15	case	_	_
 15	חיים_	חיים	NOUN	NOUN	Definite=Def|Gender=Masc|Number=Plur	12	nmod	_	_
 16	_של_	של	ADP	ADP	_	17	case:gen	_	_
@@ -12909,29 +12909,29 @@
 34	של_	של	ADP	ADP	Case=Gen	35	case:gen	_	_
 35	_הוא	הוא	PRON	PRON	Gender=Masc|Number=Sing|Person=3|PronType=Prs	31	nmod:poss	_	_
 36	עומד	עמד	VERB	VERB	Gender=Masc|HebBinyan=PAAL|Number=Sing|Person=1,2,3|VerbForm=Part|Voice=Act	22	obl	_	_
-37	להיגמר	נגמר	VERB	VERB	HebBinyan=NIFAL|VerbForm=Inf|Voice=Mid	36	xcomp	_	_
+37	להיגמר	נגמר	VERB	VERB	HebBinyan=NIFAL|VerbForm=Inf|Voice=Mid	36	xcomp	_	SpaceAfter=No
 38	.	_	PUNCT	PUNCT	_	5	punct	_	_
 
 # sent_id = 389
-# text = בושוויץ לא סבל מבעיות כאלה .
+# text = בושוויץ לא סבל מבעיות כאלה.
 1	בושוויץ	בושוויץ	PROPN	PROPN	_	3	dep	_	_
 2	לא	לא	ADV	ADV	Polarity=Neg	3	advmod	_	_
 3	סבל	סבל	VERB	VERB	Gender=Masc|HebBinyan=PAAL|Number=Sing|Person=3|Tense=Past|Voice=Act	0	root	_	_
 4-5	מבעיות	_	_	_	_	_	_	_	_
 4	מ	מ	ADP	ADP	_	5	case	_	_
 5	בעיות	בעיה	NOUN	NOUN	Gender=Fem|Number=Plur	3	iobj	_	_
-6-8	כאלה	_	_	_	_	_	_	_	_
+6-8	כאלה	_	_	_	_	_	_	_	SpaceAfter=No
 6	כ	כ	ADP	ADP	_	8	case	_	_
 7	ה_	ה	DET	DET	PronType=Art	8	det:def	_	_
 8	אלה	אלה	PRON	PRON	Gender=Masc|Number=Plur|Person=3|PronType=Dem	5	nmod	_	_
 9	.	_	PUNCT	PUNCT	_	3	punct	_	_
 
 # sent_id = 390
-# text = הוא מולטי - מיליונר , המסוגל תמיד להלוות לעצמו כסף .
+# text = הוא מולטי - מיליונר, המסוגל תמיד להלוות לעצמו כסף.
 1	הוא	הוא	PRON	PRON	Gender=Masc|Number=Sing|Person=3|PronType=Prs	4	nsubj	_	_
 2	מולטי	מולטי	ADV	ADV	HebSource=ConvUncertainHead|Prefix=Yes	4	dep	_	_
 3	-	_	PUNCT	PUNCT	_	4	punct	_	_
-4	מיליונר	מיליונר	NOUN	NOUN	Gender=Masc|Number=Sing	0	root	_	_
+4	מיליונר	מיליונר	NOUN	NOUN	Gender=Masc|Number=Sing	0	root	_	SpaceAfter=No
 5	,	_	PUNCT	PUNCT	_	4	punct	_	_
 6-7	המסוגל	_	_	_	_	_	_	_	_
 6	ה	ה	SCONJ	SCONJ	_	7	mark	_	_
@@ -12941,13 +12941,13 @@
 10-11	לעצמו	_	_	_	_	_	_	_	_
 10	ל	ל	ADP	ADP	_	11	case	_	_
 11	עצמו	עצמו	PRON	PRON	Gender=Masc|Number=Sing|Person=3|PronType=Prs|Reflex=Yes	9	iobj	_	_
-12	כסף	כסף	NOUN	NOUN	Gender=Masc|Number=Sing	9	obj	_	_
+12	כסף	כסף	NOUN	NOUN	Gender=Masc|Number=Sing	9	obj	_	SpaceAfter=No
 13	.	_	PUNCT	PUNCT	_	4	punct	_	_
 
 # sent_id = 391
-# text = חוץ מזה , מכוח מעמדו כסנאטור הצליח לאסוף תרומות של 7 מיליון דולר .
+# text = חוץ מזה, מכוח מעמדו כסנאטור הצליח לאסוף תרומות של 7 מיליון דולר.
 1	חוץ	חוץ	ADV	ADV	_	3	case	_	_
-2-3	מזה	_	_	_	_	_	_	_	_
+2-3	מזה	_	_	_	_	_	_	_	SpaceAfter=No
 2	מ	מ	ADP	ADP	_	3	case	_	_
 3	זה	זה	PRON	PRON	Gender=Masc|Number=Sing|Person=3|PronType=Prs	12	parataxis	_	_
 4	,	_	PUNCT	PUNCT	_	12	punct	_	_
@@ -12967,11 +12967,11 @@
 15	של	של	PART	PART	Case=Gen	18	case:gen	_	_
 16	7	_	NUM	NUM	_	17	nummod	_	_
 17	מיליון	מיליון	NUM	NUM	Gender=Masc|Number=Sing	18	nummod	_	_
-18	דולר	דולר	NOUN	NOUN	Gender=Masc|Number=Sing	14	nmod:poss	_	_
+18	דולר	דולר	NOUN	NOUN	Gender=Masc|Number=Sing	14	nmod:poss	_	SpaceAfter=No
 19	.	_	PUNCT	PUNCT	_	12	punct	_	_
 
 # sent_id = 392
-# text = וולסטון היה המועמד היחיד לסנאט השבוע שהצליח להביס סנאטור מכהן .
+# text = וולסטון היה המועמד היחיד לסנאט השבוע שהצליח להביס סנאטור מכהן.
 1	וולסטון	וולסטון	PROPN	PROPN	_	4	nsubj	_	_
 2	היה	היה	VERB	VERB	Gender=Masc|Number=Sing|Person=3|Polarity=Pos|Tense=Past|VerbType=Cop	4	aux	_	_
 3-4	המועמד	_	_	_	_	_	_	_	_
@@ -12990,14 +12990,14 @@
 12	הצליח	הצליח	VERB	VERB	Gender=Masc|HebBinyan=HIFIL|Number=Sing|Person=3|Tense=Past|Voice=Act	4	acl:relcl	_	_
 13	להביס	הביס	VERB	VERB	HebBinyan=HIFIL|VerbForm=Inf|Voice=Act	12	xcomp	_	_
 14	סנאטור	סנטור	NOUN	NOUN	Gender=Masc|Number=Sing	13	obj	_	_
-15	מכהן	כיהן	VERB	VERB	Gender=Masc|HebBinyan=PIEL|Number=Sing|Person=1,2,3|VerbForm=Part|Voice=Act	14	amod	_	_
+15	מכהן	כיהן	VERB	VERB	Gender=Masc|HebBinyan=PIEL|Number=Sing|Person=1,2,3|VerbForm=Part|Voice=Act	14	amod	_	SpaceAfter=No
 16	.	_	PUNCT	PUNCT	_	4	punct	_	_
 
 # sent_id = 393
-# text = " יתרון הכהונה " הוא עכשיו כל כך מוחלט , עד שבכמה מירוצים לא טרחה המפלגה היריבה להציג אפילו מועמד נומינלי .
-1	"	_	PUNCT	PUNCT	_	2	punct	_	_
+# text = "יתרון הכהונה" הוא עכשיו כל כך מוחלט, עד שבכמה מירוצים לא טרחה המפלגה היריבה להציג אפילו מועמד נומינלי.
+1	"	_	PUNCT	PUNCT	_	2	punct	_	SpaceAfter=No
 2	יתרון	יתרון	NOUN	NOUN	Definite=Cons|Gender=Masc|Number=Sing	10	nsubj:cop	_	_
-3-4	הכהונה	_	_	_	_	_	_	_	_
+3-4	הכהונה	_	_	_	_	_	_	_	SpaceAfter=No
 3	ה	ה	DET	DET	PronType=Art	4	det:def	_	_
 4	כהונה	כהונה	NOUN	NOUN	Gender=Fem|Number=Sing	2	compound:smixut	_	_
 5	"	_	PUNCT	PUNCT	_	2	punct	_	_
@@ -13005,7 +13005,7 @@
 7	עכשיו	עכשיו	ADV	ADV	_	10	dep	_	_
 8	כל	כול	DET	DET	Definite=Cons	10	advmod	_	_
 9	כך	כך	ADV	ADV	_	8	fixed	_	_
-10	מוחלט	מוחלט	ADJ	ADJ	Gender=Masc|Number=Sing	0	root	_	_
+10	מוחלט	מוחלט	ADJ	ADJ	Gender=Masc|Number=Sing	0	root	_	SpaceAfter=No
 11	,	_	PUNCT	PUNCT	_	10	punct	_	_
 12	עד	עד	ADP	ADP	_	18	case	_	_
 13-15	שבכמה	_	_	_	_	_	_	_	_
@@ -13024,11 +13024,11 @@
 23	להציג	הציג	VERB	VERB	HebBinyan=HIFIL|VerbForm=Inf|Voice=Act	18	xcomp	_	_
 24	אפילו	אפילו	CCONJ	CCONJ	_	25	det	_	_
 25	מועמד	מועמד	NOUN	NOUN	Gender=Masc|Number=Sing	23	obj	_	_
-26	נומינלי	נומינלי	ADJ	ADJ	Gender=Masc|Number=Sing	25	amod	_	_
+26	נומינלי	נומינלי	ADJ	ADJ	Gender=Masc|Number=Sing	25	amod	_	SpaceAfter=No
 27	.	_	PUNCT	PUNCT	_	10	punct	_	_
 
 # sent_id = 394
-# text = סנאטורים וצירי בית נבחרים מנצלים את הכהונה כדי לאסוף כמויות עצומות של כסף , ולהטביע בהן כל יריב פוטנציאלי .
+# text = סנאטורים וצירי בית נבחרים מנצלים את הכהונה כדי לאסוף כמויות עצומות של כסף, ולהטביע בהן כל יריב פוטנציאלי.
 1	סנאטורים	סנטור	NOUN	NOUN	Gender=Masc|Number=Plur	6	nsubj	_	_
 2-3	וצירי	_	_	_	_	_	_	_	_
 2	ו	ו	CCONJ	CCONJ	_	3	cc	_	_
@@ -13045,7 +13045,7 @@
 12	כמויות	כמות	NOUN	NOUN	Gender=Fem|Number=Plur	11	obj	_	_
 13	עצומות	עצום	ADJ	ADJ	Gender=Fem|Number=Plur	12	amod	_	_
 14	של	של	PART	PART	Case=Gen	15	case:gen	_	_
-15	כסף	כסף	NOUN	NOUN	Gender=Masc|Number=Sing	12	nmod	_	_
+15	כסף	כסף	NOUN	NOUN	Gender=Masc|Number=Sing	12	nmod	_	SpaceAfter=No
 16	,	_	PUNCT	PUNCT	_	11	punct	_	_
 17-18	ולהטביע	_	_	_	_	_	_	_	_
 17	ו	ו	CCONJ	CCONJ	_	18	cc	_	_
@@ -13055,17 +13055,17 @@
 20	_הן	הוא	PRON	PRON	Gender=Fem|Number=Plur|Person=3|PronType=Prs	18	iobj	_	_
 21	כל	כול	DET	DET	Definite=Cons	22	det	_	_
 22	יריב	יריב	NOUN	NOUN	Gender=Masc|Number=Sing	18	obj	_	_
-23	פוטנציאלי	פוטנציאלי	ADJ	ADJ	Gender=Masc|Number=Sing	22	amod	_	_
+23	פוטנציאלי	פוטנציאלי	ADJ	ADJ	Gender=Masc|Number=Sing	22	amod	_	SpaceAfter=No
 24	.	_	PUNCT	PUNCT	_	6	punct	_	_
 
 # sent_id = 395
-# text = תמוהה , בלשון המעטה , הערתו של הנשיא מיטראן לפני שבועות אחדים בלבד , שלדעתו העמדתו של בוסקה לדין תגרום נזק ציבורי .
-1	תמוהה	תמוה	ADJ	ADJ	Gender=Fem|Number=Sing	0	root	_	_
+# text = תמוהה, בלשון המעטה, הערתו של הנשיא מיטראן לפני שבועות אחדים בלבד, שלדעתו העמדתו של בוסקה לדין תגרום נזק ציבורי.
+1	תמוהה	תמוה	ADJ	ADJ	Gender=Fem|Number=Sing	0	root	_	SpaceAfter=No
 2	,	_	PUNCT	PUNCT	_	1	punct	_	_
 3-4	בלשון	_	_	_	_	_	_	_	_
 3	ב	ב	ADP	ADP	_	4	case	_	_
 4	לשון	לשון	NOUN	NOUN	Definite=Cons|Gender=Fem|Number=Sing	1	advmod	_	_
-5	המעטה	המעטה	NOUN	NOUN	Gender=Fem|Number=Sing	4	compound:smixut	_	_
+5	המעטה	המעטה	NOUN	NOUN	Gender=Fem|Number=Sing	4	compound:smixut	_	SpaceAfter=No
 6	,	_	PUNCT	PUNCT	_	1	punct	_	_
 7-9	הערתו	_	_	_	_	_	_	_	_
 7	הערה_	הערה	NOUN	NOUN	Definite=Def|Gender=Fem|Number=Sing	1	nsubj	_	_
@@ -13079,7 +13079,7 @@
 14	לפני	לפני	ADP	ADP	_	15	case	_	_
 15	שבועות	שבוע	NOUN	NOUN	Gender=Masc|Number=Plur	7	nmod	_	_
 16	אחדים	אחדים	ADJ	ADJ	Gender=Masc|Number=Plur	15	amod	_	_
-17	בלבד	בלבד	ADV	ADV	_	15	advmod	_	_
+17	בלבד	בלבד	ADV	ADV	_	15	advmod	_	SpaceAfter=No
 18	,	_	PUNCT	PUNCT	_	7	punct	_	_
 19-23	שלדעתו	_	_	_	_	_	_	_	_
 19	ש	ש	SCONJ	SCONJ	_	31	mark	_	_
@@ -13098,22 +13098,22 @@
 30	דין	דין	NOUN	NOUN	Gender=Masc|Number=Sing	24	nmod	_	_
 31	תגרום	גרם	VERB	VERB	Gender=Fem|HebBinyan=PAAL|Number=Sing|Person=3|Tense=Fut|Voice=Act	7	acl:relcl	_	_
 32	נזק	נזק	NOUN	NOUN	Gender=Masc|Number=Sing	31	obj	_	_
-33	ציבורי	ציבורי	ADJ	ADJ	Gender=Masc|Number=Sing	32	amod	_	_
+33	ציבורי	ציבורי	ADJ	ADJ	Gender=Masc|Number=Sing	32	amod	_	SpaceAfter=No
 34	.	_	PUNCT	PUNCT	_	1	punct	_	_
 
 # sent_id = 396
-# text = דמות מרכזית אחרת בפרשה זו , דרקייה דה פלפואה , מי שהיה הנציב הכללי לשאלות היהודים , נמלט מארצו אחרי שחרורה .
+# text = דמות מרכזית אחרת בפרשה זו, דרקייה דה פלפואה, מי שהיה הנציב הכללי לשאלות היהודים, נמלט מארצו אחרי שחרורה.
 1	דמות	דמות	NOUN	NOUN	Gender=Fem|Number=Sing	24	nsubj	_	_
 2	מרכזית	מרכזי	ADJ	ADJ	Gender=Fem|Number=Sing	1	amod	_	_
 3	אחרת	אחר	ADJ	ADJ	Gender=Fem|Number=Sing	1	amod	_	_
 4-5	בפרשה	_	_	_	_	_	_	_	_
 4	ב	ב	ADP	ADP	_	5	case	_	_
 5	פרשה	פרשה	NOUN	NOUN	Gender=Fem|Number=Sing	1	nmod	_	_
-6	זו	זו	PRON	PRON	Gender=Fem|Number=Sing|Person=3|PronType=Dem	5	amod	_	_
+6	זו	זו	PRON	PRON	Gender=Fem|Number=Sing|Person=3|PronType=Dem	5	amod	_	SpaceAfter=No
 7	,	_	PUNCT	PUNCT	_	1	punct	_	_
 8	דרקייה	דרקייה	PROPN	PROPN	HebSource=ConvUncertainHead	1	dep	_	_
 9	דה	דה	PROPN	PROPN	_	8	flat:name	_	_
-10	פלפואה	פלפואה	PROPN	PROPN	_	9	flat:name	_	_
+10	פלפואה	פלפואה	PROPN	PROPN	_	9	flat:name	_	SpaceAfter=No
 11	,	_	PUNCT	PUNCT	_	1	punct	_	_
 12	מי	מי	ADV	ADV	HebSource=ConvUncertainHead|PronType=Int	1	dep	_	_
 13-14	שהיה	_	_	_	_	_	_	_	_
@@ -13128,7 +13128,7 @@
 19-20	לשאלות	_	_	_	_	_	_	_	_
 19	ל	ל	ADP	ADP	_	20	case	_	_
 20	שאלות	שאלה	NOUN	NOUN	Definite=Cons|Gender=Fem|Number=Plur	16	nmod	_	_
-21-22	היהודים	_	_	_	_	_	_	_	_
+21-22	היהודים	_	_	_	_	_	_	_	SpaceAfter=No
 21	ה	ה	DET	DET	PronType=Art	22	det:def	_	_
 22	יהודים	יהודי	NOUN	NOUN	Gender=Masc|Number=Plur	20	compound:smixut	_	_
 23	,	_	PUNCT	PUNCT	_	24	punct	_	_
@@ -13139,14 +13139,14 @@
 27	_של_	של	ADP	ADP	_	28	case:gen	_	_
 28	_הוא	הוא	PRON	PRON	Case=Gen|Gender=Masc|Number=Sing|Person=3|PronType=Prs	26	nmod:poss	_	_
 29	אחרי	אחרי	ADP	ADP	_	30	case	_	_
-30-32	שחרורה	_	_	_	_	_	_	_	_
+30-32	שחרורה	_	_	_	_	_	_	_	SpaceAfter=No
 30	שחרור_	שחרור	NOUN	NOUN	Definite=Def|Gender=Masc|Number=Sing	24	obl	_	_
 31	_של_	של	ADP	ADP	_	32	case:gen	_	_
 32	_היא	הוא	PRON	PRON	Case=Gen|Gender=Fem|Number=Sing|Person=3|PronType=Prs	30	nmod:poss	_	_
 33	.	_	PUNCT	PUNCT	_	24	punct	_	_
 
 # sent_id = 397
-# text = שלא בפניו נידון למוות , אך הדבר לא הפריע לו לחיות בגלות נינוחה בספרד .
+# text = שלא בפניו נידון למוות, אך הדבר לא הפריע לו לחיות בגלות נינוחה בספרד.
 1	שלא	שלא	ADV	ADV	_	2	advmod	_	_
 2-5	בפניו	_	_	_	_	_	_	_	_
 2	ב	ב	ADP	ADP	_	3	case	_	_
@@ -13154,7 +13154,7 @@
 4	_של_	של	ADP	ADP	_	5	case:gen	_	_
 5	_הוא	הוא	PRON	PRON	Case=Gen|Gender=Masc|Number=Sing|Person=3|PronType=Prs	3	nmod:poss	_	_
 6	נידון	נידון	VERB	VERB	Gender=Masc|HebBinyan=NIFAL|Number=Sing|Person=3|Tense=Past|Voice=Mid	0	root	_	_
-7-9	למוות	_	_	_	_	_	_	_	_
+7-9	למוות	_	_	_	_	_	_	_	SpaceAfter=No
 7	ל	ל	ADP	ADP	_	9	case	_	_
 8	ה_	ה	DET	DET	PronType=Art	9	det:def	_	_
 9	מוות	מוות	NOUN	NOUN	Gender=Masc|Number=Sing	6	iobj	_	_
@@ -13173,13 +13173,13 @@
 19	ב	ב	ADP	ADP	_	20	case	_	_
 20	גלות	גלות	NOUN	NOUN	Gender=Fem|Number=Sing	18	obl	_	_
 21	נינוחה	נינוח	ADJ	ADJ	Gender=Fem|Number=Sing	20	amod	_	_
-22-23	בספרד	_	_	_	_	_	_	_	_
+22-23	בספרד	_	_	_	_	_	_	_	SpaceAfter=No
 22	ב	ב	ADP	ADP	_	23	case	_	_
 23	ספרד	ספרד	PROPN	PROPN	_	18	obl	_	_
 24	.	_	PUNCT	PUNCT	_	6	punct	_	_
 
 # sent_id = 398
-# text = ב8791 הכריז בראיון ענק לשבועון " לאקספרס " , שאמנם באושוויץ עסקו הנאצים בהגזה , אך לא בהגזת בני - אדם , אלא בהגזת כינים .
+# text = ב8791 הכריז בראיון ענק לשבועון "לאקספרס", שאמנם באושוויץ עסקו הנאצים בהגזה, אך לא בהגזת בני - אדם, אלא בהגזת כינים.
 1-2	ב8791	_	_	_	_	_	_	_	_
 1	ב	ב	ADP	ADP	_	2	case	_	_
 2	8791	_	NUM	NUM	_	3	obl	_	_
@@ -13192,9 +13192,9 @@
 7	ל	ל	ADP	ADP	_	9	case	_	_
 8	ה_	ה	DET	DET	PronType=Art	9	det:def	_	_
 9	שבועון	שבועון	NOUN	NOUN	Gender=Masc|Number=Sing	5	nmod	_	_
-10	"	_	PUNCT	PUNCT	_	11	punct	_	_
-11	לאקספרס	לאקספרס	PROPN	PROPN	_	9	appos	_	_
-12	"	_	PUNCT	PUNCT	_	11	punct	_	_
+10	"	_	PUNCT	PUNCT	_	11	punct	_	SpaceAfter=No
+11	לאקספרס	לאקספרס	PROPN	PROPN	_	9	appos	_	SpaceAfter=No
+12	"	_	PUNCT	PUNCT	_	11	punct	_	SpaceAfter=No
 13	,	_	PUNCT	PUNCT	_	3	punct	_	_
 14-15	שאמנם	_	_	_	_	_	_	_	_
 14	ש	ש	SCONJ	SCONJ	_	18	mark	_	_
@@ -13206,7 +13206,7 @@
 19-20	הנאצים	_	_	_	_	_	_	_	_
 19	ה	ה	DET	DET	PronType=Art	20	det:def	_	_
 20	נאצים	נאצי	NOUN	NOUN	Gender=Masc|Number=Plur	18	nsubj	_	_
-21-22	בהגזה	_	_	_	_	_	_	_	_
+21-22	בהגזה	_	_	_	_	_	_	_	SpaceAfter=No
 21	ב	_	ADP	ADP	_	22	case	_	_
 22	הגזה	_	VERB	VERB	Gender=Fem|HebBinyan=PAAL|Number=Sing|Person=1,2,3|VerbForm=Part|Voice=Act	18	iobj	_	_
 23	,	_	PUNCT	PUNCT	_	22	punct	_	_
@@ -13217,29 +13217,29 @@
 27	הגזת	_	NOUN	NOUN	Definite=Cons	22	conj	_	_
 28	בני	בן	NOUN	NOUN	Definite=Cons|Gender=Masc|Number=Plur	30	nmod	_	_
 29	-	_	PUNCT	PUNCT	_	30	punct	_	_
-30	אדם	אדם	NOUN	NOUN	Gender=Masc|Number=Sing	27	compound:smixut	_	_
+30	אדם	אדם	NOUN	NOUN	Gender=Masc|Number=Sing	27	compound:smixut	_	SpaceAfter=No
 31	,	_	PUNCT	PUNCT	_	22	punct	_	_
 32	אלא	אלא	CCONJ	CCONJ	_	34	cc	_	_
 33-34	בהגזת	_	_	_	_	_	_	_	_
 33	ב	ב	ADP	ADP	_	34	case	_	_
 34	הגזת	_	NOUN	NOUN	Definite=Cons	22	conj	_	_
-35	כינים	כינה	NOUN	NOUN	Gender=Fem|Number=Plur	34	compound:smixut	_	_
+35	כינים	כינה	NOUN	NOUN	Gender=Fem|Number=Plur	34	compound:smixut	_	SpaceAfter=No
 36	.	_	PUNCT	PUNCT	_	3	punct	_	_
 
 # sent_id = 399
-# text = הוא מת לפני כמה שנים בספרד .
+# text = הוא מת לפני כמה שנים בספרד.
 1	הוא	הוא	PRON	PRON	Gender=Masc|Number=Sing|Person=3|PronType=Prs	2	nsubj	_	_
 2	מת	מת	VERB	VERB	Gender=Masc|HebBinyan=PAAL|Number=Sing|Person=3|Tense=Past|Voice=Act	0	root	_	_
 3	לפני	לפני	ADP	ADP	_	5	case	_	_
 4	כמה	כמה	DET	DET	Definite=Cons	5	det	_	_
 5	שנים	שנה	NOUN	NOUN	Gender=Fem|Number=Plur	2	obl	_	_
-6-7	בספרד	_	_	_	_	_	_	_	_
+6-7	בספרד	_	_	_	_	_	_	_	SpaceAfter=No
 6	ב	ב	ADP	ADP	_	7	case	_	_
 7	ספרד	ספרד	PROPN	PROPN	_	2	obl	_	_
 8	.	_	PUNCT	PUNCT	_	2	punct	_	_
 
 # sent_id = 400
-# text = הוא לא הטריד את הממסד הצרפתי בהצהרות מביכות , ושלטונות צרפת לא טרחו שיוסגר לידיהם לצורך העמדתו לדין .
+# text = הוא לא הטריד את הממסד הצרפתי בהצהרות מביכות, ושלטונות צרפת לא טרחו שיוסגר לידיהם לצורך העמדתו לדין.
 1	הוא	הוא	PRON	PRON	Gender=Masc|Number=Sing|Person=3|PronType=Prs	3	nsubj	_	_
 2	לא	לא	ADV	ADV	Polarity=Neg	3	advmod	_	_
 3	הטריד	הטריד	VERB	VERB	Gender=Masc|HebBinyan=HIFIL|Number=Sing|Person=3|Tense=Past|Voice=Act	0	root	_	_
@@ -13253,7 +13253,7 @@
 9-10	בהצהרות	_	_	_	_	_	_	_	_
 9	ב	ב	ADP	ADP	_	10	case	_	_
 10	הצהרות	הצהרה	NOUN	NOUN	Gender=Fem|Number=Plur	3	iobj	_	_
-11	מביכות	מביך	ADJ	ADJ	Gender=Fem|Number=Plur	10	amod	_	_
+11	מביכות	מביך	ADJ	ADJ	Gender=Fem|Number=Plur	10	amod	_	SpaceAfter=No
 12	,	_	PUNCT	PUNCT	_	3	punct	_	_
 13-14	ושלטונות	_	_	_	_	_	_	_	_
 13	ו	ו	CCONJ	CCONJ	_	17	cc	_	_
@@ -13276,23 +13276,23 @@
 26	העמדה_	העמדה	NOUN	NOUN	Definite=Def|Gender=Fem|Number=Sing	25	compound:smixut	_	_
 27	_של_	של	ADP	ADP	_	28	case:gen	_	_
 28	_הוא	הוא	PRON	PRON	Case=Gen|Gender=Masc|Number=Sing|Person=3|PronType=Prs	26	nmod:poss	_	_
-29-30	לדין	_	_	_	_	_	_	_	_
+29-30	לדין	_	_	_	_	_	_	_	SpaceAfter=No
 29	ל	ל	ADP	ADP	_	30	case	_	_
 30	דין	דין	NOUN	NOUN	Gender=Masc|Number=Sing	26	nmod	_	_
 31	.	_	PUNCT	PUNCT	_	3	punct	_	_
 
 # sent_id = 401
-# text = שתי פרשיות אחרות , נוסף על זו של רנה בוסקה , נמצאות אף הן כיום בדיון משפטי מוקדם שנמשך זמן רב : זו של מוריס פאפון וזו של פול טובייה .
+# text = שתי פרשיות אחרות, נוסף על זו של רנה בוסקה, נמצאות אף הן כיום בדיון משפטי מוקדם שנמשך זמן רב: זו של מוריס פאפון וזו של פול טובייה.
 1	שתי	שתיים	NUM	NUM	Definite=Cons|Gender=Fem|Number=Plur	2	nummod	_	_
 2	פרשיות	פרשייה	NOUN	NOUN	Gender=Fem|Number=Plur	12	nsubj	_	_
-3	אחרות	אחר	ADJ	ADJ	Gender=Fem|Number=Plur	2	amod	_	_
+3	אחרות	אחר	ADJ	ADJ	Gender=Fem|Number=Plur	2	amod	_	SpaceAfter=No
 4	,	_	PUNCT	PUNCT	_	2	punct	_	_
 5	נוסף	נוסף	VERB	VERB	Gender=Masc|Number=Sing|Person=1,2,3|VerbForm=Part	7	case	_	_
 6	על	על	ADP	ADP	_	7	case	_	_
 7	זו	זו	PRON	PRON	Gender=Fem|Number=Sing|Person=3|PronType=Dem	2	advmod	_	_
 8	של	של	PART	PART	Case=Gen	9	case:gen	_	_
 9	רנה	רנה	PROPN	PROPN	_	7	nmod:poss	_	_
-10	בוסקה	בוסקה	PROPN	PROPN	_	9	flat:name	_	_
+10	בוסקה	בוסקה	PROPN	PROPN	_	9	flat:name	_	SpaceAfter=No
 11	,	_	PUNCT	PUNCT	_	12	punct	_	_
 12	נמצאות	נמצא	VERB	VERB	Gender=Fem|HebBinyan=NIFAL|Number=Plur|Person=1,2,3|VerbForm=Part|Voice=Mid	0	root	_	_
 13	אף	אף	CCONJ	CCONJ	_	14	det	_	_
@@ -13307,7 +13307,7 @@
 20	ש	ש	SCONJ	SCONJ	_	21	mark	_	_
 21	נמשך	נמשך	VERB	VERB	Gender=Masc|HebBinyan=NIFAL|Number=Sing|Person=3|Tense=Past|Voice=Mid	17	acl:relcl	_	_
 22	זמן	זמן	NOUN	NOUN	Gender=Masc|Number=Sing	21	obj	_	_
-23	רב	רב	ADJ	ADJ	Gender=Masc|Number=Sing	22	amod	_	_
+23	רב	רב	ADJ	ADJ	Gender=Masc|Number=Sing	22	amod	_	SpaceAfter=No
 24	:	_	PUNCT	PUNCT	_	12	punct	_	_
 25	זו	זו	PRON	PRON	Gender=Fem|Number=Sing|Person=3|PronType=Dem	12	dep	_	_
 26	של	של	PART	PART	Case=Gen	27	case:gen	_	_
@@ -13318,12 +13318,12 @@
 30	זו	זו	PRON	PRON	Gender=Fem|Number=Sing|Person=3|PronType=Dem	25	conj	_	_
 31	של	של	PART	PART	Case=Gen	32	case:gen	_	_
 32	פול	פול	PROPN	PROPN	_	30	nmod:poss	_	_
-33	טובייה	טובייה	PROPN	PROPN	_	32	flat:name	_	_
+33	טובייה	טובייה	PROPN	PROPN	_	32	flat:name	_	SpaceAfter=No
 34	.	_	PUNCT	PUNCT	_	12	punct	_	_
 
 # sent_id = 402
-# text = פאפון , שכאמור שימש ממונה על מחוז זירונד בזמן המלחמה , הורה על ביצוע האקציות נגד היהודים ביולי 2491 .
-1	פאפון	פאפון	PROPN	PROPN	_	15	nsubj	_	_
+# text = פאפון, שכאמור שימש ממונה על מחוז זירונד בזמן המלחמה, הורה על ביצוע האקציות נגד היהודים ביולי 2491.
+1	פאפון	פאפון	PROPN	PROPN	_	15	nsubj	_	SpaceAfter=No
 2	,	_	PUNCT	PUNCT	_	1	punct	_	_
 3-4	שכאמור	_	_	_	_	_	_	_	_
 3	ש	ש	SCONJ	SCONJ	_	5	mark	_	_
@@ -13336,7 +13336,7 @@
 10-11	בזמן	_	_	_	_	_	_	_	_
 10	ב	ב	ADP	ADP	_	11	case	_	_
 11	זמן	זמן	NOUN	NOUN	Definite=Cons|Gender=Masc|Number=Sing	5	obl	_	_
-12-13	המלחמה	_	_	_	_	_	_	_	_
+12-13	המלחמה	_	_	_	_	_	_	_	SpaceAfter=No
 12	ה	ה	DET	DET	PronType=Art	13	det:def	_	_
 13	מלחמה	מלחמה	NOUN	NOUN	Gender=Fem|Number=Sing	11	compound:smixut	_	_
 14	,	_	PUNCT	PUNCT	_	15	punct	_	_
@@ -13353,31 +13353,31 @@
 23-24	ביולי	_	_	_	_	_	_	_	_
 23	ב	ב	ADP	ADP	_	24	case	_	_
 24	יולי	יולי	PROPN	PROPN	_	15	obl	_	_
-25	2491	_	NUM	NUM	_	24	nummod	_	_
+25	2491	_	NUM	NUM	_	24	nummod	_	SpaceAfter=No
 26	.	_	PUNCT	PUNCT	_	15	punct	_	_
 
 # sent_id = 403
-# text = אחרי המלחמה , בשנת 8591 , הוא היה ממונה על מחוז פאריס .
+# text = אחרי המלחמה, בשנת 8591, הוא היה ממונה על מחוז פאריס.
 1	אחרי	אחרי	ADP	ADP	_	3	case	_	_
-2-3	המלחמה	_	_	_	_	_	_	_	_
+2-3	המלחמה	_	_	_	_	_	_	_	SpaceAfter=No
 2	ה	ה	DET	DET	PronType=Art	3	det:def	_	_
 3	מלחמה	מלחמה	NOUN	NOUN	Gender=Fem|Number=Sing	11	nmod	_	_
 4	,	_	PUNCT	PUNCT	_	11	punct	_	_
 5-6	בשנת	_	_	_	_	_	_	_	_
 5	ב	ב	ADP	ADP	_	6	case	_	_
 6	שנת	שנה	NOUN	NOUN	Definite=Cons|Gender=Fem|Number=Sing	11	nmod	_	_
-7	8591	_	NUM	NUM	_	6	compound:smixut	_	_
+7	8591	_	NUM	NUM	_	6	compound:smixut	_	SpaceAfter=No
 8	,	_	PUNCT	PUNCT	_	11	punct	_	_
 9	הוא	הוא	PRON	PRON	Gender=Masc|Number=Sing|Person=3|PronType=Prs	11	nsubj	_	_
 10	היה	היה	VERB	VERB	Gender=Masc|Number=Sing|Person=3|Polarity=Pos|Tense=Past|VerbType=Cop	11	aux	_	_
 11	ממונה	ממונה	NOUN	NOUN	Gender=Masc|Number=Sing	0	root	_	_
 12	על	על	ADP	ADP	_	13	case	_	_
 13	מחוז	מחוז	NOUN	NOUN	Definite=Cons|Gender=Masc|Number=Sing	11	nmod	_	_
-14	פאריס	פריז	PROPN	PROPN	_	13	compound:smixut	_	_
+14	פאריס	פריז	PROPN	PROPN	_	13	compound:smixut	_	SpaceAfter=No
 15	.	_	PUNCT	PUNCT	_	11	punct	_	_
 
 # sent_id = 404
-# text = מאוחר יותר שימש שר בממשלת ריימון באר בימי נשיאותו של ואלרי זיסקאר - דאסטאן .
+# text = מאוחר יותר שימש שר בממשלת ריימון באר בימי נשיאותו של ואלרי זיסקאר - דאסטאן.
 1	מאוחר	מאוחר	ADV	ADV	_	3	advmod:phrase	_	_
 2	יותר	יותר	ADV	ADV	HebSource=ConvUncertainHead	1	dep	_	_
 3	שימש	שימש	VERB	VERB	Gender=Masc|HebBinyan=PIEL|Number=Sing|Person=3|Tense=Past|Voice=Act	0	root	_	_
@@ -13398,18 +13398,18 @@
 15	ואלרי	ואלרי	PROPN	PROPN	_	11	nmod:poss	_	_
 16	זיסקאר	זיסקאר	PROPN	PROPN	_	15	flat:name	_	_
 17	-	_	PUNCT	PUNCT	_	16	flat:name	_	_
-18	דאסטאן	דאסטאן	PROPN	PROPN	_	16	flat:name	_	_
+18	דאסטאן	דאסטאן	PROPN	PROPN	_	16	flat:name	_	SpaceAfter=No
 19	.	_	PUNCT	PUNCT	_	3	punct	_	_
 
 # sent_id = 405
-# text = ב3891 , בעקבות חקירה מחודשת , נקבע כי יש מקום להגיש נגדו כתב אישום בגין סיוע למעצרם של יהודים כדרישת הגרמנים .
-1-2	ב3891	_	_	_	_	_	_	_	_
+# text = ב3891, בעקבות חקירה מחודשת, נקבע כי יש מקום להגיש נגדו כתב אישום בגין סיוע למעצרם של יהודים כדרישת הגרמנים.
+1-2	ב3891	_	_	_	_	_	_	_	SpaceAfter=No
 1	ב	ב	ADP	ADP	_	2	case	_	_
 2	3891	_	NUM	NUM	_	8	obl	_	_
 3	,	_	PUNCT	PUNCT	_	8	punct	_	_
 4	בעקבות	בעקבות	ADP	ADP	_	5	case	_	_
 5	חקירה	חקירה	NOUN	NOUN	Gender=Fem|Number=Sing	8	obl	_	_
-6	מחודשת	מחודש	ADJ	ADJ	Gender=Fem|Number=Sing	5	amod	_	_
+6	מחודשת	מחודש	ADJ	ADJ	Gender=Fem|Number=Sing	5	amod	_	SpaceAfter=No
 7	,	_	PUNCT	PUNCT	_	8	punct	_	_
 8	נקבע	נקבע	VERB	VERB	Gender=Masc|HebBinyan=NIFAL|Number=Sing|Person=3|Tense=Past|Voice=Mid	0	root	_	_
 9	כי	כי	SCONJ	SCONJ	_	10	mark	_	_
@@ -13433,13 +13433,13 @@
 25-26	כדרישת	_	_	_	_	_	_	_	_
 25	כ	כ	ADP	ADP	_	26	case	_	_
 26	דרישת	דרישה	NOUN	NOUN	Definite=Cons|Gender=Fem|Number=Sing	18	nmod	_	_
-27-28	הגרמנים	_	_	_	_	_	_	_	_
+27-28	הגרמנים	_	_	_	_	_	_	_	SpaceAfter=No
 27	ה	ה	DET	DET	PronType=Art	28	det:def	_	_
 28	גרמנים	גרמני	NOUN	NOUN	Gender=Masc|Number=Plur	26	compound:smixut	_	_
 29	.	_	PUNCT	PUNCT	_	8	punct	_	_
 
 # sent_id = 406
-# text = ב4891 הודיע לו שופט - חוקר כי הוגשו נגדו תלונות נוספות .
+# text = ב4891 הודיע לו שופט - חוקר כי הוגשו נגדו תלונות נוספות.
 1-2	ב4891	_	_	_	_	_	_	_	_
 1	ב	ב	ADP	ADP	_	2	case	_	_
 2	4891	_	NUM	NUM	_	3	obl	_	_
@@ -13456,11 +13456,11 @@
 11	נגדו	נגד	ADP	ADP	_	12	case	_	_
 12	_הוא	הוא	PRON	PRON	Gender=Masc|Number=Sing|Person=3|PronType=Prs	10	iobj	_	_
 13	תלונות	תלונה	NOUN	NOUN	Gender=Fem|Number=Plur	10	nsubj	_	_
-14	נוספות	נוסף	ADJ	ADJ	Gender=Fem|Number=Plur	13	amod	_	_
+14	נוספות	נוסף	ADJ	ADJ	Gender=Fem|Number=Plur	13	amod	_	SpaceAfter=No
 15	.	_	PUNCT	PUNCT	_	3	punct	_	_
 
 # sent_id = 407
-# text = עד היום נמצאות תלונות הללו בשלב מוקדם של דיון בפני שופט - חוקר .
+# text = עד היום נמצאות תלונות הללו בשלב מוקדם של דיון בפני שופט - חוקר.
 1	עד	עד	ADP	ADP	_	2	case	_	_
 2	היום	היום	ADV	ADV	_	3	obl	_	_
 3	נמצאות	נמצא	VERB	VERB	Gender=Fem|HebBinyan=NIFAL|Number=Plur|Person=1,2,3|VerbForm=Part|Voice=Mid	0	root	_	_
@@ -13475,11 +13475,11 @@
 11	בפני	בפני	ADP	ADP	_	12	case	_	_
 12	שופט	שופט	NOUN	NOUN	Gender=Masc|Number=Sing	10	nmod	_	_
 13	-	_	PUNCT	PUNCT	_	12	punct	_	_
-14	חוקר	חוקר	NOUN	NOUN	Gender=Masc|Number=Sing	12	nmod	_	_
+14	חוקר	חוקר	NOUN	NOUN	Gender=Masc|Number=Sing	12	nmod	_	SpaceAfter=No
 15	.	_	PUNCT	PUNCT	_	3	punct	_	_
 
 # sent_id = 408
-# text = בעקבות המשפט נגד ראש הגסטאפו בלין , קלאוס ברבי , עלה מחדש שמו של פול טביה .
+# text = בעקבות המשפט נגד ראש הגסטאפו בלין, קלאוס ברבי, עלה מחדש שמו של פול טביה.
 1	בעקבות	בעקבות	ADP	ADP	_	3	case	_	_
 2-3	המשפט	_	_	_	_	_	_	_	_
 2	ה	ה	DET	DET	PronType=Art	3	det:def	_	_
@@ -13489,12 +13489,12 @@
 6-7	הגסטאפו	_	_	_	_	_	_	_	_
 6	ה	ה	DET	DET	PronType=Art	7	det:def	_	_
 7	גסטאפו	גסטפו	NOUN	NOUN	Gender=Masc|Number=Sing	5	compound:smixut	_	_
-8-9	בלין	_	_	_	_	_	_	_	_
+8-9	בלין	_	_	_	_	_	_	_	SpaceAfter=No
 8	ב	ב	ADP	ADP	_	9	case	_	_
 9	לין	לין	PROPN	PROPN	_	7	nmod	_	_
 10	,	_	PUNCT	PUNCT	_	5	punct	_	_
 11	קלאוס	קלאוס	PROPN	PROPN	_	5	appos	_	_
-12	ברבי	ברבי	PROPN	PROPN	_	11	flat:name	_	_
+12	ברבי	ברבי	PROPN	PROPN	_	11	flat:name	_	SpaceAfter=No
 13	,	_	PUNCT	PUNCT	_	14	punct	_	_
 14	עלה	עלה	VERB	VERB	Gender=Masc|HebBinyan=PAAL|Number=Sing|Person=3|Tense=Past|Voice=Act	0	root	_	_
 15	מחדש	מחדש	ADV	ADV	_	14	advmod	_	_
@@ -13504,11 +13504,11 @@
 18	_הוא	הוא	PRON	PRON	Case=Gen|Gender=Masc|Number=Sing|Person=3|PronType=Prs	16	nmod:poss	_	_
 19	של	של	PART	PART	Case=Gen	20	case:gen	_	_
 20	פול	פול	PROPN	PROPN	_	16	nmod:poss	_	_
-21	טביה	טביה	PROPN	PROPN	_	20	flat:name	_	_
+21	טביה	טביה	PROPN	PROPN	_	20	flat:name	_	SpaceAfter=No
 22	.	_	PUNCT	PUNCT	_	14	punct	_	_
 
 # sent_id = 409
-# text = הוא היה ממפקדי המיליציה הצרפתית הידועה לשמצה בליון , נטל חלק פעיל באקציות של הגסטאפו נגד לוחמי מחתרת ויהודים , עינה עצורים , שדד את רכושם , והורה על הוצאתם להורג של כמה מקורבנותיו בלי משפט .
+# text = הוא היה ממפקדי המיליציה הצרפתית הידועה לשמצה בליון, נטל חלק פעיל באקציות של הגסטאפו נגד לוחמי מחתרת ויהודים, עינה עצורים, שדד את רכושם, והורה על הוצאתם להורג של כמה מקורבנותיו בלי משפט.
 1	הוא	הוא	PRON	PRON	Gender=Masc|Number=Sing|Person=3|PronType=Prs	4	nsubj	_	_
 2	היה	היה	VERB	VERB	Gender=Masc|Number=Sing|Person=3|Polarity=Pos|Tense=Past|VerbType=Cop	4	aux	_	_
 3-4	ממפקדי	_	_	_	_	_	_	_	_
@@ -13526,7 +13526,7 @@
 11-12	לשמצה	_	_	_	_	_	_	_	_
 11	ל	ל	ADP	ADP	_	12	case	_	_
 12	שמצה	שמצה	NOUN	NOUN	Gender=Fem|Number=Sing	10	advmod	_	_
-13-14	בליון	_	_	_	_	_	_	_	_
+13-14	בליון	_	_	_	_	_	_	_	SpaceAfter=No
 13	ב	ב	ADP	ADP	_	14	case	_	_
 14	ליון	ליון	PROPN	PROPN	_	6	nmod	_	_
 15	,	_	PUNCT	PUNCT	_	4	punct	_	_
@@ -13544,16 +13544,16 @@
 25	נגד	נגד	ADP	ADP	_	26	case	_	_
 26	לוחמי	לוחם	NOUN	NOUN	Definite=Cons|Gender=Masc|Number=Plur	21	nmod	_	_
 27	מחתרת	מחתרת	NOUN	NOUN	Gender=Fem|Number=Sing	26	compound:smixut	_	_
-28-29	ויהודים	_	_	_	_	_	_	_	_
+28-29	ויהודים	_	_	_	_	_	_	_	SpaceAfter=No
 28	ו	ו	CCONJ	CCONJ	_	29	cc	_	_
 29	יהודים	יהודי	NOUN	NOUN	Gender=Masc|Number=Plur	26	conj	_	_
 30	,	_	PUNCT	PUNCT	_	4	punct	_	_
 31	עינה	עינה	VERB	VERB	Gender=Masc|HebBinyan=PIEL|Number=Sing|Person=3|Tense=Past|Voice=Act	4	conj	_	_
-32	עצורים	עצר	VERB	VERB	Gender=Masc|HebBinyan=PAAL|Number=Plur|Person=1,2,3|VerbForm=Part|Voice=Act	31	obj	_	_
+32	עצורים	עצר	VERB	VERB	Gender=Masc|HebBinyan=PAAL|Number=Plur|Person=1,2,3|VerbForm=Part|Voice=Act	31	obj	_	SpaceAfter=No
 33	,	_	PUNCT	PUNCT	_	4	punct	_	_
 34	שדד	שדד	VERB	VERB	Gender=Masc|Number=Sing|Person=3|Tense=Past	4	conj	_	_
 35	את	את	PART	PART	Case=Acc	36	case:acc	_	_
-36-38	רכושם	_	_	_	_	_	_	_	_
+36-38	רכושם	_	_	_	_	_	_	_	SpaceAfter=No
 36	רכוש_	רכוש	NOUN	NOUN	Definite=Def|Gender=Masc|Number=Sing	34	obj	_	_
 37	_של_	של	ADP	ADP	_	38	case:gen	_	_
 38	_הם	הוא	PRON	PRON	Case=Gen|Gender=Masc|Number=Plur|Person=3|PronType=Prs	36	nmod:poss	_	_
@@ -13578,24 +13578,24 @@
 53	_של_	של	ADP	ADP	_	54	case:gen	_	_
 54	_הוא	הוא	PRON	PRON	Case=Gen|Gender=Masc|Number=Sing|Person=3|PronType=Prs	52	nmod:poss	_	_
 55	בלי	בלי	ADP	ADP	_	56	case	_	_
-56	משפט	משפט	NOUN	NOUN	Gender=Masc|Number=Sing	43	nmod	_	_
+56	משפט	משפט	NOUN	NOUN	Gender=Masc|Number=Sing	43	nmod	_	SpaceAfter=No
 57	.	_	PUNCT	PUNCT	_	4	punct	_	_
 
 # sent_id = 410
-# text = אחרי השחרור נעלמו עקבותיו .
+# text = אחרי השחרור נעלמו עקבותיו.
 1	אחרי	אחרי	ADP	ADP	_	3	case	_	_
 2-3	השחרור	_	_	_	_	_	_	_	_
 2	ה	ה	DET	DET	PronType=Art	3	det:def	_	_
 3	שחרור	שחרור	NOUN	NOUN	Gender=Masc|Number=Sing	4	obl	_	_
 4	נעלמו	נעלם	VERB	VERB	Gender=Fem,Masc|HebBinyan=NIFAL|Number=Plur|Person=3|Tense=Past|Voice=Mid	0	root	_	_
-5-7	עקבותיו	_	_	_	_	_	_	_	_
+5-7	עקבותיו	_	_	_	_	_	_	_	SpaceAfter=No
 5	עקבה_	עקבה	NOUN	NOUN	Definite=Def|Gender=Fem|Number=Plur	4	nsubj	_	_
 6	_של_	של	ADP	ADP	_	7	case:gen	_	_
 7	_הוא	הוא	PRON	PRON	Case=Gen|Gender=Masc|Number=Sing|Person=3|PronType=Prs	5	nmod:poss	_	_
 8	.	_	PUNCT	PUNCT	_	4	punct	_	_
 
 # sent_id = 411
-# text = בית משפט בליון דן אותו למוות שלא בפניו .
+# text = בית משפט בליון דן אותו למוות שלא בפניו.
 1	בית	בית	NOUN	NOUN	Definite=Cons|Gender=Masc|Number=Sing	5	nsubj	_	_
 2	משפט	משפט	NOUN	NOUN	Gender=Masc|Number=Sing	1	compound:smixut	_	_
 3-4	בליון	_	_	_	_	_	_	_	_
@@ -13610,7 +13610,7 @@
 9	ה_	ה	DET	DET	PronType=Art	10	det:def	_	_
 10	מוות	מוות	NOUN	NOUN	Gender=Masc|Number=Sing	5	iobj	_	_
 11	שלא	שלא	ADV	ADV	_	12	advmod	_	_
-12-15	בפניו	_	_	_	_	_	_	_	_
+12-15	בפניו	_	_	_	_	_	_	_	SpaceAfter=No
 12	ב	ב	ADP	ADP	_	13	case	_	_
 13	פנים_	פנים	NOUN	NOUN	Definite=Def|Gender=Fem,Masc|Number=Plur	5	obl	_	_
 14	_של_	של	ADP	ADP	_	15	case:gen	_	_
@@ -13618,7 +13618,7 @@
 16	.	_	PUNCT	PUNCT	_	5	punct	_	_
 
 # sent_id = 412
-# text = בשנת 1972 גילה תחקיר עיתונאי שבנובמבר 1971 העניק לו הנשיא זורז פומפידו חנינה , וכי במשך כל השנים נהנה הפושע מחסות ראשי הכנסייה הקתולית בצרפת ובאיטליה .
+# text = בשנת 1972 גילה תחקיר עיתונאי שבנובמבר 1971 העניק לו הנשיא זורז פומפידו חנינה, וכי במשך כל השנים נהנה הפושע מחסות ראשי הכנסייה הקתולית בצרפת ובאיטליה.
 1-2	בשנת	_	_	_	_	_	_	_	_
 1	ב	ב	ADP	ADP	_	2	case	_	_
 2	שנת	שנה	NOUN	NOUN	Definite=Cons|Gender=Fem|Number=Sing	4	obl	_	_
@@ -13640,7 +13640,7 @@
 15	נשיא	נשיא	NOUN	NOUN	Gender=Masc|Number=Sing	11	nsubj	_	_
 16	זורז	זורז	PROPN	PROPN	_	15	appos	_	_
 17	פומפידו	פומפידו	PROPN	PROPN	_	16	flat:name	_	_
-18	חנינה	חנינה	NOUN	NOUN	Gender=Fem|Number=Sing	11	obj	_	_
+18	חנינה	חנינה	NOUN	NOUN	Gender=Fem|Number=Sing	11	obj	_	SpaceAfter=No
 19	,	_	PUNCT	PUNCT	_	11	punct	_	_
 20-21	וכי	_	_	_	_	_	_	_	_
 20	ו	ו	CCONJ	CCONJ	_	26	cc	_	_
@@ -13667,14 +13667,14 @@
 36-37	בצרפת	_	_	_	_	_	_	_	_
 36	ב	ב	ADP	ADP	_	37	case	_	_
 37	צרפת	צרפת	PROPN	PROPN	_	33	nmod	_	_
-38-40	ובאיטליה	_	_	_	_	_	_	_	_
+38-40	ובאיטליה	_	_	_	_	_	_	_	SpaceAfter=No
 38	ו	ו	CCONJ	CCONJ	_	40	cc	_	_
 39	ב	ב	ADP	ADP	_	40	case	_	_
 40	איטליה	איטליה	PROPN	PROPN	_	37	conj	_	_
 41	.	_	PUNCT	PUNCT	_	4	punct	_	_
 
 # sent_id = 413
-# text = בשנת 3891 נתחדשה החקירה נגד טובייה , אך הוא שוב נעלם .
+# text = בשנת 3891 נתחדשה החקירה נגד טובייה, אך הוא שוב נעלם.
 1-2	בשנת	_	_	_	_	_	_	_	_
 1	ב	ב	ADP	ADP	_	2	case	_	_
 2	שנת	שנה	NOUN	NOUN	Definite=Cons|Gender=Fem|Number=Sing	4	obl	_	_
@@ -13684,16 +13684,16 @@
 5	ה	ה	DET	DET	PronType=Art	6	det:def	_	_
 6	חקירה	חקירה	NOUN	NOUN	Gender=Fem|Number=Sing	4	nsubj	_	_
 7	נגד	נגד	ADP	ADP	_	8	case	_	_
-8	טובייה	טובייה	PROPN	PROPN	_	6	nmod	_	_
+8	טובייה	טובייה	PROPN	PROPN	_	6	nmod	_	SpaceAfter=No
 9	,	_	PUNCT	PUNCT	_	4	punct	_	_
 10	אך	אך	CCONJ	CCONJ	_	13	cc	_	_
 11	הוא	הוא	PRON	PRON	Gender=Masc|Number=Sing|Person=3|PronType=Prs	13	nsubj	_	_
 12	שוב	שוב	ADV	ADV	_	13	advmod	_	_
-13	נעלם	נעלם	VERB	VERB	Gender=Masc|HebBinyan=NIFAL|Number=Sing|Person=3|Tense=Past|Voice=Mid	4	conj	_	_
+13	נעלם	נעלם	VERB	VERB	Gender=Masc|HebBinyan=NIFAL|Number=Sing|Person=3|Tense=Past|Voice=Mid	4	conj	_	SpaceAfter=No
 14	.	_	PUNCT	PUNCT	_	4	punct	_	_
 
 # sent_id = 414
-# text = בספטמבר 1984 פורסמה בעיתון אזורי מודעה על מותו כביכול , ואף נמצא " מקום קבורתו " .
+# text = בספטמבר 1984 פורסמה בעיתון אזורי מודעה על מותו כביכול, ואף נמצא "מקום קבורתו".
 1-2	בספטמבר	_	_	_	_	_	_	_	_
 1	ב	ב	ADP	ADP	_	2	case	_	_
 2	ספטמבר	ספטמבר	PROPN	PROPN	_	4	obl	_	_
@@ -13709,35 +13709,35 @@
 10	מוות_	מוות	NOUN	NOUN	Definite=Def|Gender=Masc|Number=Sing	8	nmod	_	_
 11	_של_	של	ADP	ADP	_	12	case:gen	_	_
 12	_הוא	הוא	PRON	PRON	Case=Gen|Gender=Masc|Number=Sing|Person=3|PronType=Prs	10	nmod:poss	_	_
-13	כביכול	כביכול	ADV	ADV	HebSource=ConvUncertainHead	10	dep	_	_
+13	כביכול	כביכול	ADV	ADV	HebSource=ConvUncertainHead	10	dep	_	SpaceAfter=No
 14	,	_	PUNCT	PUNCT	_	4	punct	_	_
 15-16	ואף	_	_	_	_	_	_	_	_
 15	ו	ו	CCONJ	CCONJ	_	17	cc	_	_
 16	אף	אף	CCONJ	CCONJ	_	17	advmod	_	_
 17	נמצא	נמצא	VERB	VERB	Gender=Masc|HebBinyan=NIFAL|Number=Sing|Person=3|Tense=Past|Voice=Mid	4	conj	_	_
-18	"	_	PUNCT	PUNCT	_	19	punct	_	_
+18	"	_	PUNCT	PUNCT	_	19	punct	_	SpaceAfter=No
 19	מקום	מקום	NOUN	NOUN	Definite=Cons|Gender=Masc|Number=Sing	17	nsubj	_	_
-20-22	קבורתו	_	_	_	_	_	_	_	_
+20-22	קבורתו	_	_	_	_	_	_	_	SpaceAfter=No
 20	קבורה_	קבורה	NOUN	NOUN	Definite=Def|Gender=Fem|Number=Sing	19	compound:smixut	_	_
 21	_של_	של	ADP	ADP	_	22	case:gen	_	_
 22	_הוא	הוא	PRON	PRON	Case=Gen|Gender=Masc|Number=Sing|Person=3|PronType=Prs	20	nmod:poss	_	_
-23	"	_	PUNCT	PUNCT	_	19	punct	_	_
+23	"	_	PUNCT	PUNCT	_	19	punct	_	SpaceAfter=No
 24	.	_	PUNCT	PUNCT	_	4	punct	_	_
 
 # sent_id = 415
-# text = אך עדיין מחפשים אחרי טובייה החי .
+# text = אך עדיין מחפשים אחרי טובייה החי.
 1	אך	אך	CCONJ	CCONJ	_	3	cc	_	_
 2	עדיין	עדיין	ADV	ADV	_	3	advmod	_	_
 3	מחפשים	חיפש	VERB	VERB	Gender=Masc|HebBinyan=PIEL|Number=Plur|Person=1,2,3|VerbForm=Part|Voice=Act	0	root	_	_
 4	אחרי	אחרי	ADP	ADP	_	5	case	_	_
 5	טובייה	טובייה	PROPN	PROPN	_	3	iobj	_	_
-6-7	החי	_	_	_	_	_	_	_	_
+6-7	החי	_	_	_	_	_	_	_	SpaceAfter=No
 6	ה	ה	DET	DET	PronType=Art	7	det:def	_	_
 7	חי	חי	ADJ	ADJ	Gender=Masc|Number=Sing	5	amod	_	_
 8	.	_	PUNCT	PUNCT	_	3	punct	_	_
 
 # sent_id = 416
-# text = אין פלא שפרשת בוסקה הזכירה גם את פרשיות פאפון וטובייה .
+# text = אין פלא שפרשת בוסקה הזכירה גם את פרשיות פאפון וטובייה.
 1	אין	אין	VERB	VERB	HebExistential=True	0	root	_	_
 2	פלא	פלא	NOUN	NOUN	Gender=Masc|Number=Sing	1	nsubj	_	_
 3-4	שפרשת	_	_	_	_	_	_	_	_
@@ -13749,13 +13749,13 @@
 8	את	את	PART	PART	Case=Acc	9	case:acc	_	_
 9	פרשיות	פרשייה	NOUN	NOUN	Definite=Cons|Gender=Fem|Number=Plur	6	obj	_	_
 10	פאפון	פאפון	PROPN	PROPN	_	9	compound:smixut	_	_
-11-12	וטובייה	_	_	_	_	_	_	_	_
+11-12	וטובייה	_	_	_	_	_	_	_	SpaceAfter=No
 11	ו	_	CCONJ	CCONJ	_	12	cc	_	_
 12	טובייה	וטובייה	PROPN	PROPN	_	10	conj	_	_
 13	.	_	PUNCT	PUNCT	_	1	punct	_	_
 
 # sent_id = 417
-# text = במסיבת עיתונאים שנערכה ב81 באוקטובר השנה בפאריס דיבר נשיא הליגה לזכויות האדם , עו"ד איב זפה , על " חוסר הרצון הפוליטי להביא לידי בירור את שלוש הפרשיות של בוסקה , פאפון וטובייה " .
+# text = במסיבת עיתונאים שנערכה ב81 באוקטובר השנה בפאריס דיבר נשיא הליגה לזכויות האדם, עו"ד איב זפה, על "חוסר הרצון הפוליטי להביא לידי בירור את שלוש הפרשיות של בוסקה, פאפון וטובייה".
 1-2	במסיבת	_	_	_	_	_	_	_	_
 1	ב	ב	ADP	ADP	_	2	case	_	_
 2	מסיבת	מסיבה	NOUN	NOUN	Definite=Cons|Gender=Fem|Number=Sing	14	obl	_	_
@@ -13782,16 +13782,16 @@
 18-19	לזכויות	_	_	_	_	_	_	_	_
 18	ל	ל	ADP	ADP	_	19	case	_	_
 19	זכויות	זכות	NOUN	NOUN	Definite=Cons|Gender=Fem|Number=Plur	17	nmod	_	_
-20-21	האדם	_	_	_	_	_	_	_	_
+20-21	האדם	_	_	_	_	_	_	_	SpaceAfter=No
 20	ה	ה	DET	DET	PronType=Art	21	det:def	_	_
 21	אדם	אדם	NOUN	NOUN	Gender=Masc|Number=Sing	19	compound:smixut	_	_
 22	,	_	PUNCT	PUNCT	_	15	punct	_	_
 23	עו"ד	עו"ד	NOUN	NOUN	Abbr=Yes|Gender=Masc|Number=Sing	15	appos	_	_
 24	איב	איב	PROPN	PROPN	_	23	appos	_	_
-25	זפה	זפה	PROPN	PROPN	_	24	flat:name	_	_
+25	זפה	זפה	PROPN	PROPN	_	24	flat:name	_	SpaceAfter=No
 26	,	_	PUNCT	PUNCT	_	14	punct	_	_
 27	על	על	ADP	ADP	_	29	case	_	_
-28	"	_	PUNCT	PUNCT	_	29	punct	_	_
+28	"	_	PUNCT	PUNCT	_	29	punct	_	SpaceAfter=No
 29	חוסר	חוסר	NOUN	NOUN	Definite=Cons|Gender=Masc|Number=Sing	14	iobj	_	_
 30-31	הרצון	_	_	_	_	_	_	_	_
 30	ה	ה	DET	DET	PronType=Art	31	det:def	_	_
@@ -13808,21 +13808,21 @@
 39	ה	ה	DET	DET	PronType=Art	40	det:def	_	_
 40	פרשיות	פרשייה	NOUN	NOUN	Gender=Fem|Number=Plur	34	obj	_	_
 41	של	של	PART	PART	Case=Gen	42	case:gen	_	_
-42	בוסקה	בוסקה	PROPN	PROPN	_	40	nmod:poss	_	_
+42	בוסקה	בוסקה	PROPN	PROPN	_	40	nmod:poss	_	SpaceAfter=No
 43	,	_	PUNCT	PUNCT	_	42	punct	_	_
 44	פאפון	פאפון	PROPN	PROPN	_	42	conj	_	_
-45-46	וטובייה	_	_	_	_	_	_	_	_
+45-46	וטובייה	_	_	_	_	_	_	_	SpaceAfter=No
 45	ו	_	CCONJ	CCONJ	_	46	cc	_	_
 46	טובייה	וטובייה	PROPN	PROPN	_	42	conj	_	_
-47	"	_	PUNCT	PUNCT	_	29	punct	_	_
+47	"	_	PUNCT	PUNCT	_	29	punct	_	SpaceAfter=No
 48	.	_	PUNCT	PUNCT	_	14	punct	_	_
 
 # sent_id = 418
-# text = הוא אמר : " שלושה תיקים אלה נמצאים בנקודה מתה .
+# text = הוא אמר: "שלושה תיקים אלה נמצאים בנקודה מתה.
 1	הוא	הוא	PRON	PRON	Gender=Masc|Number=Sing|Person=3|PronType=Prs	2	nsubj	_	_
-2	אמר	אמר	VERB	VERB	Gender=Masc|HebBinyan=PAAL|Number=Sing|Person=3|Tense=Past|Voice=Act	0	root	_	_
+2	אמר	אמר	VERB	VERB	Gender=Masc|HebBinyan=PAAL|Number=Sing|Person=3|Tense=Past|Voice=Act	0	root	_	SpaceAfter=No
 3	:	_	PUNCT	PUNCT	_	8	punct	_	_
-4	"	_	PUNCT	PUNCT	_	8	punct	_	_
+4	"	_	PUNCT	PUNCT	_	8	punct	_	SpaceAfter=No
 5	שלושה	שלושה	NUM	NUM	Gender=Masc|Number=Sing	6	nummod	_	_
 6	תיקים	תיק	NOUN	NOUN	Gender=Masc|Number=Plur	8	nsubj	_	_
 7	אלה	אלה	PRON	PRON	Gender=Masc|Number=Plur|Person=3|PronType=Dem	6	amod	_	_
@@ -13830,11 +13830,11 @@
 9-10	בנקודה	_	_	_	_	_	_	_	_
 9	ב	ב	ADP	ADP	_	10	case	_	_
 10	נקודה	נקודה	NOUN	NOUN	Gender=Fem|Number=Sing	8	iobj	_	_
-11	מתה	מת	ADJ	ADJ	Gender=Fem|Number=Sing	10	amod	_	_
+11	מתה	מת	ADJ	ADJ	Gender=Fem|Number=Sing	10	amod	_	SpaceAfter=No
 12	.	_	PUNCT	PUNCT	_	2	punct	_	_
 
 # sent_id = 419
-# text = אין זה מקרה ששלושת האנשים הללו לא נשפטו עד כה .
+# text = אין זה מקרה ששלושת האנשים הללו לא נשפטו עד כה.
 1	אין	_	ADV	ADV	Polarity=Neg	3	advmod	_	_
 2	זה	זה	PRON	PRON	Gender=Masc|Number=Sing|Person=3	3	nsubj	_	_
 3	מקרה	מקרה	NOUN	NOUN	Gender=Masc|Number=Sing	0	root	_	_
@@ -13848,11 +13848,11 @@
 9	לא	לא	ADV	ADV	Polarity=Neg	10	advmod	_	_
 10	נשפטו	נשפט	VERB	VERB	Gender=Fem,Masc|HebBinyan=NIFAL|Number=Plur|Person=3|Tense=Past|Voice=Mid	3	ccomp	_	_
 11	עד	עד	ADP	ADP	_	12	case	_	_
-12	כה	כה	ADV	ADV	_	10	obl	_	_
+12	כה	כה	ADV	ADV	_	10	obl	_	SpaceAfter=No
 13	.	_	PUNCT	PUNCT	_	3	punct	_	_
 
 # sent_id = 420
-# text = אישים אלה מילאו תפקידים רמים ובעלי חשיבות בפוליטיקה , במינהל ובעולם העסקים .
+# text = אישים אלה מילאו תפקידים רמים ובעלי חשיבות בפוליטיקה, במינהל ובעולם העסקים.
 1	אישים	אישים	NOUN	NOUN	Gender=Masc|Number=Plur	3	nsubj	_	_
 2	אלה	אלה	PRON	PRON	Gender=Masc|Number=Plur|Person=3|PronType=Dem	1	amod	_	_
 3	מילאו	מילא	VERB	VERB	Gender=Fem,Masc|HebBinyan=PIEL|Number=Plur|Person=3|Tense=Past|Voice=Act	0	root	_	_
@@ -13862,7 +13862,7 @@
 6	ו	ו	CCONJ	CCONJ	_	5	dep	_	_
 7	בעלי	בעל	NOUN	NOUN	Definite=Cons|Gender=Masc|Number=Plur	5	dep	_	_
 8	חשיבות	חשיבות	NOUN	NOUN	Gender=Fem|Number=Sing	7	compound:smixut	_	_
-9-11	בפוליטיקה	_	_	_	_	_	_	_	_
+9-11	בפוליטיקה	_	_	_	_	_	_	_	SpaceAfter=No
 9	ב	ב	ADP	ADP	_	11	case	_	_
 10	ה_	ה	DET	DET	PronType=Art	11	det:def	_	_
 11	פוליטיקה	פוליטיקה	NOUN	NOUN	Gender=Fem|Number=Sing	4	nmod	_	_
@@ -13875,13 +13875,13 @@
 16	ו	ו	CCONJ	CCONJ	_	18	cc	_	_
 17	ב	ב	ADP	ADP	_	18	case	_	_
 18	עולם	עולם	NOUN	NOUN	Definite=Cons|Gender=Masc|Number=Sing	11	conj	_	_
-19-20	העסקים	_	_	_	_	_	_	_	_
+19-20	העסקים	_	_	_	_	_	_	_	SpaceAfter=No
 19	ה	ה	DET	DET	PronType=Art	20	det:def	_	_
 20	עסקים	עסק	NOUN	NOUN	Gender=Masc|Number=Plur	18	compound:smixut	_	_
 21	.	_	PUNCT	PUNCT	_	3	punct	_	_
 
 # sent_id = 421
-# text = אני סבור שהם נהנים מהזדהות מעמדית אמיתית .
+# text = אני סבור שהם נהנים מהזדהות מעמדית אמיתית.
 1	אני	הוא	PRON	PRON	Gender=Fem,Masc|Number=Sing|Person=1|PronType=Prs	2	nsubj	_	_
 2	סבור	סבר	VERB	VERB	Gender=Masc|HebBinyan=PAAL|Number=Sing|Person=1,2,3|VerbForm=Part|Voice=Act	0	root	_	_
 3-4	שהם	_	_	_	_	_	_	_	_
@@ -13892,11 +13892,11 @@
 6	מ	מ	ADP	ADP	_	7	case	_	_
 7	הזדהות	הזדהות	NOUN	NOUN	Gender=Fem|Number=Sing	5	iobj	_	_
 8	מעמדית	מעמדי	ADJ	ADJ	Gender=Fem|Number=Sing	7	amod	_	_
-9	אמיתית	אמיתי	ADJ	ADJ	Gender=Fem|Number=Sing	7	amod	_	_
+9	אמיתית	אמיתי	ADJ	ADJ	Gender=Fem|Number=Sing	7	amod	_	SpaceAfter=No
 10	.	_	PUNCT	PUNCT	_	2	punct	_	_
 
 # sent_id = 422
-# text = לא תובעים לדין שר או ממונה על המשטרה , משום שהוא שייך לחוג של אנשים שאינו רוצה שיכבסו את הכביסה המלוכלכת " .
+# text = לא תובעים לדין שר או ממונה על המשטרה, משום שהוא שייך לחוג של אנשים שאינו רוצה שיכבסו את הכביסה המלוכלכת".
 1	לא	לא	ADV	ADV	Polarity=Neg	2	advmod	_	_
 2	תובעים	תבע	VERB	VERB	Gender=Masc|HebBinyan=PAAL|Number=Plur|Person=1,2,3|VerbForm=Part|Voice=Act	0	root	_	_
 3-4	לדין	_	_	_	_	_	_	_	_
@@ -13906,7 +13906,7 @@
 6	או	או	CCONJ	CCONJ	_	7	cc	_	_
 7	ממונה	ממונה	NOUN	NOUN	Gender=Masc|Number=Sing	5	conj	_	_
 8	על	על	ADP	ADP	_	10	case	_	_
-9-10	המשטרה	_	_	_	_	_	_	_	_
+9-10	המשטרה	_	_	_	_	_	_	_	SpaceAfter=No
 9	ה	ה	DET	DET	PronType=Art	10	det:def	_	_
 10	משטרה	משטרה	NOUN	NOUN	Gender=Fem|Number=Sing	7	nmod	_	_
 11	,	_	PUNCT	PUNCT	_	2	punct	_	_
@@ -13931,33 +13931,33 @@
 26-27	הכביסה	_	_	_	_	_	_	_	_
 26	ה	ה	DET	DET	PronType=Art	27	det:def	_	_
 27	כביסה	כביסה	NOUN	NOUN	Gender=Fem|Number=Sing	24	obj	_	_
-28-29	המלוכלכת	_	_	_	_	_	_	_	_
+28-29	המלוכלכת	_	_	_	_	_	_	_	SpaceAfter=No
 28	ה	ה	DET	DET	PronType=Art	29	det:def	_	_
 29	מלוכלכת	מלוכלך	ADJ	ADJ	Gender=Fem|Number=Sing	27	amod	_	_
-30	"	_	PUNCT	PUNCT	_	2	punct	_	_
+30	"	_	PUNCT	PUNCT	_	2	punct	_	SpaceAfter=No
 31	.	_	PUNCT	PUNCT	_	2	punct	_	_
 
 # sent_id = 423
-# text = ומה בינתיים ?
+# text = ומה בינתיים?
 1-2	ומה	_	_	_	_	_	_	_	_
 1	ו	ו	CCONJ	CCONJ	_	2	cc	_	_
 2	מה	מה	ADV	ADV	PronType=Int	0	root	_	_
-3	בינתיים	בינתיים	ADV	ADV	_	2	advmod	_	_
+3	בינתיים	בינתיים	ADV	ADV	_	2	advmod	_	SpaceAfter=No
 4	?	_	PUNCT	PUNCT	_	2	punct	_	_
 
 # sent_id = 424
-# text = פאפון , טובייה ובוסקה חופשיים .
-1	פאפון	פאפון	PROPN	PROPN	_	6	nsubj	_	_
+# text = פאפון, טובייה ובוסקה חופשיים.
+1	פאפון	פאפון	PROPN	PROPN	_	6	nsubj	_	SpaceAfter=No
 2	,	_	PUNCT	PUNCT	_	1	punct	_	_
 3	טובייה	טובייה	PROPN	PROPN	_	1	conj	_	_
 4-5	ובוסקה	_	_	_	_	_	_	_	_
 4	ו	_	CCONJ	CCONJ	_	5	cc	_	_
 5	בוסקה	ובוסקה	PROPN	PROPN	_	1	conj	_	_
-6	חופשיים	חופשי	ADJ	ADJ	Gender=Masc|Number=Plur	0	root	_	_
+6	חופשיים	חופשי	ADJ	ADJ	Gender=Masc|Number=Plur	0	root	_	SpaceAfter=No
 7	.	_	PUNCT	PUNCT	_	6	punct	_	_
 
 # sent_id = 425
-# text = כל אחד מהם מתקרב לגיל שמונים .
+# text = כל אחד מהם מתקרב לגיל שמונים.
 1	כל	כול	DET	DET	Definite=Cons	2	det	_	_
 2	אחד	אחד	NUM	NUM	Gender=Masc|Number=Sing	5	nsubj	_	_
 3-4	מהם	_	_	_	_	_	_	_	_
@@ -13967,11 +13967,11 @@
 6-7	לגיל	_	_	_	_	_	_	_	_
 6	ל	ל	ADP	ADP	_	7	case	_	_
 7	גיל	גיל	NOUN	NOUN	Definite=Cons|Gender=Masc|Number=Sing	5	iobj	_	_
-8	שמונים	שמונים	NUM	NUM	Gender=Fem,Masc|Number=Sing	7	compound:smixut	_	_
+8	שמונים	שמונים	NUM	NUM	Gender=Fem,Masc|Number=Sing	7	compound:smixut	_	SpaceAfter=No
 9	.	_	PUNCT	PUNCT	_	5	punct	_	_
 
 # sent_id = 426
-# text = הרושם הוא שהממסד הצרפתי מצפה שימותו בשקט .
+# text = הרושם הוא שהממסד הצרפתי מצפה שימותו בשקט.
 1-2	הרושם	_	_	_	_	_	_	_	_
 1	ה	ה	DET	DET	PronType=Art	2	det:def	_	_
 2	רושם	רושם	NOUN	NOUN	Gender=Masc|Number=Sing	9	nsubj:cop	_	_
@@ -13987,15 +13987,15 @@
 10-11	שימותו	_	_	_	_	_	_	_	_
 10	ש	ש	SCONJ	SCONJ	_	11	mark	_	_
 11	ימותו	מת	VERB	VERB	Gender=Fem,Masc|HebBinyan=PAAL|Number=Plur|Person=3|Tense=Fut|Voice=Act	9	ccomp	_	_
-12-13	בשקט	_	_	_	_	_	_	_	_
+12-13	בשקט	_	_	_	_	_	_	_	SpaceAfter=No
 12	ב	ב	ADP	ADP	_	13	case	_	_
 13	שקט	שקט	NOUN	NOUN	Gender=Masc|Number=Sing	11	obl	_	_
 14	.	_	PUNCT	PUNCT	_	9	punct	_	_
 
 # sent_id = 427
-# text = מה שברור , שהוא אינו מעוניין בהעמדתם לדין .
+# text = מה שברור, שהוא אינו מעוניין בהעמדתם לדין.
 1	מה	מה	ADV	ADV	PronType=Int	8	nsubj	_	_
-2-3	שברור	_	_	_	_	_	_	_	_
+2-3	שברור	_	_	_	_	_	_	_	SpaceAfter=No
 2	ש	ש	SCONJ	SCONJ	_	3	mark	_	_
 3	ברור	ברור	ADJ	ADJ	Gender=Masc|Number=Sing	1	acl:relcl	_	_
 4	,	_	PUNCT	PUNCT	_	8	punct	_	_
@@ -14009,14 +14009,14 @@
 10	העמדה_	העמדה	NOUN	NOUN	Definite=Def|Gender=Fem|Number=Sing	8	iobj	_	_
 11	_של_	של	ADP	ADP	_	12	case:gen	_	_
 12	_הם	הוא	PRON	PRON	Case=Gen|Gender=Masc|Number=Plur|Person=3|PronType=Prs	10	nmod:poss	_	_
-13-15	לדין	_	_	_	_	_	_	_	_
+13-15	לדין	_	_	_	_	_	_	_	SpaceAfter=No
 13	ל	ל	ADP	ADP	_	15	case	_	_
 14	ה_	ה	DET	DET	PronType=Art	15	det:def	_	_
 15	דין	דין	NOUN	NOUN	Gender=Masc|Number=Sing	10	iobj	_	_
 16	.	_	PUNCT	PUNCT	_	8	punct	_	_
 
 # sent_id = 428
-# text = הוא חושש מחשיפת סודות החבויים בכספות , מפני עדויות חדשות , ומפני זכרונות העלולים לגלות שלדים החבויים שנים כה רבות בארונות שונים .
+# text = הוא חושש מחשיפת סודות החבויים בכספות, מפני עדויות חדשות, ומפני זכרונות העלולים לגלות שלדים החבויים שנים כה רבות בארונות שונים.
 1	הוא	הוא	PRON	PRON	Gender=Masc|Number=Sing|Person=3|PronType=Prs	2	nsubj	_	_
 2	חושש	חשש	VERB	VERB	Gender=Masc|HebBinyan=PAAL|Number=Sing|Person=1,2,3|VerbForm=Part|Voice=Act	0	root	_	_
 3-4	מחשיפת	_	_	_	_	_	_	_	_
@@ -14026,13 +14026,13 @@
 6-7	החבויים	_	_	_	_	_	_	_	_
 6	ה	ה	SCONJ	SCONJ	_	7	mark	_	_
 7	חבויים	חבוי	ADJ	ADJ	Gender=Masc|Number=Plur	5	acl:relcl	_	_
-8-9	בכספות	_	_	_	_	_	_	_	_
+8-9	בכספות	_	_	_	_	_	_	_	SpaceAfter=No
 8	ב	ב	ADP	ADP	_	9	case	_	_
 9	כספות	כספת	NOUN	NOUN	Gender=Fem|Number=Plur	7	iobj	_	_
 10	,	_	PUNCT	PUNCT	_	4	punct	_	_
 11	מפני	מפני	ADP	ADP	_	12	case	_	_
 12	עדויות	עדות	NOUN	NOUN	Gender=Fem|Number=Plur	4	conj	_	_
-13	חדשות	חדש	ADJ	ADJ	Gender=Fem|Number=Plur	12	amod	_	_
+13	חדשות	חדש	ADJ	ADJ	Gender=Fem|Number=Plur	12	amod	_	SpaceAfter=No
 14	,	_	PUNCT	PUNCT	_	4	punct	_	_
 15-16	ומפני	_	_	_	_	_	_	_	_
 15	ו	ו	CCONJ	CCONJ	_	17	cc	_	_
@@ -14052,11 +14052,11 @@
 27-28	בארונות	_	_	_	_	_	_	_	_
 27	ב	ב	ADP	ADP	_	28	case	_	_
 28	ארונות	ארון	NOUN	NOUN	Gender=Masc|Number=Plur	23	iobj	_	_
-29	שונים	שונה	ADJ	ADJ	Gender=Masc|Number=Plur	28	amod	_	_
+29	שונים	שונה	ADJ	ADJ	Gender=Masc|Number=Plur	28	amod	_	SpaceAfter=No
 30	.	_	PUNCT	PUNCT	_	2	punct	_	_
 
 # sent_id = 429
-# text = ארבע וחצי שעות צעדו אתמול בירושלים עשרות אלפים אחרי ארונו של מאיר כהנא במסע הלווייה פרוע , רצוף קריאות הסתה לפגיעות בערבים , בעיתונאים ובשוטרים .
+# text = ארבע וחצי שעות צעדו אתמול בירושלים עשרות אלפים אחרי ארונו של מאיר כהנא במסע הלווייה פרוע, רצוף קריאות הסתה לפגיעות בערבים, בעיתונאים ובשוטרים.
 1	ארבע	ארבע	NUM	NUM	Gender=Fem|Number=Sing	4	nummod	_	_
 2-3	וחצי	_	_	_	_	_	_	_	_
 2	ו	ו	CCONJ	CCONJ	_	3	cc	_	_
@@ -14081,7 +14081,7 @@
 18	ב	ב	ADP	ADP	_	19	case	_	_
 19	מסע	מסע	NOUN	NOUN	Definite=Cons|Gender=Masc|Number=Sing	5	obl	_	_
 20	הלווייה	הלוויה	NOUN	NOUN	Gender=Fem|Number=Sing	19	compound:smixut	_	_
-21	פרוע	פרוע	ADJ	ADJ	Gender=Masc|Number=Sing	19	amod	_	_
+21	פרוע	פרוע	ADJ	ADJ	Gender=Masc|Number=Sing	19	amod	_	SpaceAfter=No
 22	,	_	PUNCT	PUNCT	_	19	punct	_	_
 23	רצוף	רצוף	ADJ	ADJ	Definite=Cons|Gender=Masc|Number=Sing	19	amod	_	_
 24	קריאות	קריאה	NOUN	NOUN	Definite=Cons|Gender=Fem|Number=Plur	23	compound:smixut	_	_
@@ -14089,25 +14089,25 @@
 26-27	לפגיעות	_	_	_	_	_	_	_	_
 26	ל	ל	ADP	ADP	_	27	case	_	_
 27	פגיעות	פגיעה	NOUN	NOUN	Gender=Fem|Number=Plur	25	nmod	_	_
-28-29	בערבים	_	_	_	_	_	_	_	_
+28-29	בערבים	_	_	_	_	_	_	_	SpaceAfter=No
 28	ב	ב	ADP	ADP	_	29	case	_	_
 29	ערבים	ערבי	NOUN	NOUN	Gender=Masc|Number=Plur	27	nmod	_	_
 30	,	_	PUNCT	PUNCT	_	29	punct	_	_
 31-32	בעיתונאים	_	_	_	_	_	_	_	_
 31	ב	ב	ADP	ADP	_	32	case	_	_
 32	עיתונאים	עיתונאי	NOUN	NOUN	Gender=Masc|Number=Plur	29	conj	_	_
-33-35	ובשוטרים	_	_	_	_	_	_	_	_
+33-35	ובשוטרים	_	_	_	_	_	_	_	SpaceAfter=No
 33	ו	ו	CCONJ	CCONJ	_	35	cc	_	_
 34	ב	ב	ADP	ADP	_	35	case	_	_
 35	שוטרים	שוטר	NOUN	NOUN	Gender=Masc|Number=Plur	29	conj	_	_
 36	.	_	PUNCT	PUNCT	_	5	punct	_	_
 
 # sent_id = 430
-# text = בשעה 1200 , כשהחל הקהל להתפזר , מנתה המשטרה שלושה שוטרים פצועים , אחד מהם קשה , וארבעה ערבים עוברי - אורח שנפצעו אף הם .
+# text = בשעה 1200, כשהחל הקהל להתפזר, מנתה המשטרה שלושה שוטרים פצועים, אחד מהם קשה, וארבעה ערבים עוברי - אורח שנפצעו אף הם.
 1-2	בשעה	_	_	_	_	_	_	_	_
 1	ב	ב	ADP	ADP	_	2	case	_	_
 2	שעה	שעה	NOUN	NOUN	Gender=Fem|Number=Sing	11	obl	_	_
-3	1200	_	NUM	NUM	_	2	nummod	_	_
+3	1200	_	NUM	NUM	_	2	nummod	_	SpaceAfter=No
 4	,	_	PUNCT	PUNCT	_	11	punct	_	_
 5-6	כשהחל	_	_	_	_	_	_	_	_
 5	כש	כש	SCONJ	SCONJ	Case=Tem	6	mark	_	_
@@ -14115,7 +14115,7 @@
 7-8	הקהל	_	_	_	_	_	_	_	_
 7	ה	ה	DET	DET	PronType=Art	8	det:def	_	_
 8	קהל	קהל	NOUN	NOUN	Gender=Masc|Number=Sing	6	nsubj	_	_
-9	להתפזר	התפזר	VERB	VERB	HebBinyan=HITPAEL|VerbForm=Inf	6	xcomp	_	_
+9	להתפזר	התפזר	VERB	VERB	HebBinyan=HITPAEL|VerbForm=Inf	6	xcomp	_	SpaceAfter=No
 10	,	_	PUNCT	PUNCT	_	11	punct	_	_
 11	מנתה	מנה	VERB	VERB	Gender=Fem|HebBinyan=PAAL|Number=Sing|Person=3|Tense=Past|Voice=Act	0	root	_	_
 12-13	המשטרה	_	_	_	_	_	_	_	_
@@ -14123,13 +14123,13 @@
 13	משטרה	משטרה	NOUN	NOUN	Gender=Fem|Number=Sing	11	nsubj	_	_
 14	שלושה	שלושה	NUM	NUM	Gender=Masc|Number=Sing	15	nummod	_	_
 15	שוטרים	שוטר	NOUN	NOUN	Gender=Masc|Number=Plur	11	obj	_	_
-16	פצועים	פצוע	ADJ	ADJ	Gender=Masc|Number=Plur	15	amod	_	_
+16	פצועים	פצוע	ADJ	ADJ	Gender=Masc|Number=Plur	15	amod	_	SpaceAfter=No
 17	,	_	PUNCT	PUNCT	_	20	punct	_	_
 18	אחד	אחד	NUM	NUM	Gender=Masc|Number=Sing	20	det	_	_
 19-20	מהם	_	_	_	_	_	_	_	_
 19	מהם	מן	ADP	ADP	_	20	case	_	_
 20	_הם	הוא	PRON	PRON	Gender=Masc|Number=Plur|Person=3|PronType=Prs	15	appos	_	_
-21	קשה	קשה	ADV	ADV	HebSource=ConvUncertainHead	20	dep	_	_
+21	קשה	קשה	ADV	ADV	HebSource=ConvUncertainHead	20	dep	_	SpaceAfter=No
 22	,	_	PUNCT	PUNCT	_	20	punct	_	_
 23-24	וארבעה	_	_	_	_	_	_	_	_
 23	ו	ו	CCONJ	CCONJ	_	25	cc	_	_
@@ -14142,11 +14142,11 @@
 29	ש	ש	SCONJ	SCONJ	_	30	mark	_	_
 30	נפצעו	נפצע	VERB	VERB	Gender=Fem,Masc|HebBinyan=NIFAL|Number=Plur|Person=3|Tense=Past|Voice=Mid	25	acl:relcl	_	_
 31	אף	אף	CCONJ	CCONJ	_	32	det	_	_
-32	הם	הוא	PRON	PRON	Gender=Masc|Number=Plur|Person=3|PronType=Prs	30	dep	_	_
+32	הם	הוא	PRON	PRON	Gender=Masc|Number=Plur|Person=3|PronType=Prs	30	dep	_	SpaceAfter=No
 33	.	_	PUNCT	PUNCT	_	11	punct	_	_
 
 # sent_id = 431
-# text = בשעה 1400 עדיין נמצא קהל הרבבות תחת שליטה ובקרה .
+# text = בשעה 1400 עדיין נמצא קהל הרבבות תחת שליטה ובקרה.
 1-2	בשעה	_	_	_	_	_	_	_	_
 1	ב	ב	ADP	ADP	_	2	case	_	_
 2	שעה	שעה	NOUN	NOUN	Gender=Fem|Number=Sing	5	obl	_	_
@@ -14159,13 +14159,13 @@
 8	רבבות	_	NUM	NUM	Definite=Cons	6	compound:smixut	_	_
 9	תחת	תחת	ADP	ADP	_	10	case	_	_
 10	שליטה	שליטה	NOUN	NOUN	Gender=Fem|Number=Sing	5	obl	_	_
-11-12	ובקרה	_	_	_	_	_	_	_	_
+11-12	ובקרה	_	_	_	_	_	_	_	SpaceAfter=No
 11	ו	ו	CCONJ	CCONJ	_	12	cc	_	_
 12	בקרה	בקרה	NOUN	NOUN	Gender=Fem|Number=Sing	10	conj	_	_
 13	.	_	PUNCT	PUNCT	_	5	punct	_	_
 
 # sent_id = 432
-# text = החל משעות הצהרים התקבצו אלפים סביב ישיבת הרעיון היהודי בשכונת שמואל הנביא .
+# text = החל משעות הצהרים התקבצו אלפים סביב ישיבת הרעיון היהודי בשכונת שמואל הנביא.
 1	החל	_	ADP	ADP	_	3	case	_	_
 2-3	משעות	_	_	_	_	_	_	_	_
 2	מ	מ	ADP	ADP	_	3	case	_	_
@@ -14187,13 +14187,13 @@
 14	ב	ב	ADP	ADP	_	15	case	_	_
 15	שכונת	שכונה	NOUN	NOUN	Definite=Cons|Gender=Fem|Number=Sing	6	obl	_	_
 16	שמואל	שמואל	PROPN	PROPN	_	15	compound:smixut	_	_
-17-18	הנביא	_	_	_	_	_	_	_	_
+17-18	הנביא	_	_	_	_	_	_	_	SpaceAfter=No
 17	ה	ה	DET	DET	PronType=Art	18	det:def	_	_
 18	נביא	נביא	NOUN	NOUN	Gender=Masc|Number=Sing	16	flat:name	_	_
 19	.	_	PUNCT	PUNCT	_	6	punct	_	_
 
 # sent_id = 433
-# text = בני משפחת כהנא ישבו על מרפסת המשקיפה על פתח הישיבה .
+# text = בני משפחת כהנא ישבו על מרפסת המשקיפה על פתח הישיבה.
 1	בני	בן	NOUN	NOUN	Definite=Cons|Gender=Masc|Number=Plur	4	nsubj	_	_
 2	משפחת	משפחה	NOUN	NOUN	Definite=Cons|Gender=Fem|Number=Sing	1	compound:smixut	_	_
 3	כהנא	כהנא	PROPN	PROPN	_	2	compound:smixut	_	_
@@ -14205,13 +14205,13 @@
 8	משקיפה	השקיף	VERB	VERB	Gender=Fem|HebBinyan=HIFIL|Number=Sing|Person=1,2,3|VerbForm=Part|Voice=Act	6	acl:relcl	_	_
 9	על	על	ADP	ADP	_	10	case	_	_
 10	פתח	פתח	NOUN	NOUN	Definite=Cons|Gender=Masc|Number=Sing	8	iobj	_	_
-11-12	הישיבה	_	_	_	_	_	_	_	_
+11-12	הישיבה	_	_	_	_	_	_	_	SpaceAfter=No
 11	ה	ה	DET	DET	PronType=Art	12	det:def	_	_
 12	ישיבה	ישיבה	NOUN	NOUN	Gender=Fem|Number=Sing	10	compound:smixut	_	_
 13	.	_	PUNCT	PUNCT	_	4	punct	_	_
 
 # sent_id = 434
-# text = צלמי עיתונות רבים נדחקו על גג בטון סמוך .
+# text = צלמי עיתונות רבים נדחקו על גג בטון סמוך.
 1	צלמי	צלם	NOUN	NOUN	Definite=Cons|Gender=Masc|Number=Plur	4	nsubj	_	_
 2	עיתונות	עיתונות	NOUN	NOUN	Gender=Fem|Number=Sing	1	compound:smixut	_	_
 3	רבים	רב	ADJ	ADJ	Gender=Masc|Number=Plur	1	amod	_	_
@@ -14219,22 +14219,22 @@
 5	על	על	ADP	ADP	_	6	case	_	_
 6	גג	גג	NOUN	NOUN	Definite=Cons|Gender=Masc|Number=Sing	4	obl	_	_
 7	בטון	בטון	NOUN	NOUN	_	6	compound:smixut	_	_
-8	סמוך	סמוך	ADJ	ADJ	Gender=Masc|Number=Sing	6	amod	_	_
+8	סמוך	סמוך	ADJ	ADJ	Gender=Masc|Number=Sing	6	amod	_	SpaceAfter=No
 9	.	_	PUNCT	PUNCT	_	4	punct	_	_
 
 # sent_id = 435
-# text = צוותי תקשורת אחרים הושמו מאחורי גדירות משטרה .
+# text = צוותי תקשורת אחרים הושמו מאחורי גדירות משטרה.
 1	צוותי	צוות	NOUN	NOUN	Definite=Cons|Gender=Fem|Number=Plur	4	nsubj	_	_
 2	תקשורת	תקשורת	NOUN	NOUN	Gender=Fem|Number=Sing	1	compound:smixut	_	_
 3	אחרים	אחר	ADJ	ADJ	Gender=Masc|Number=Plur	1	amod	_	_
 4	הושמו	הושם	VERB	VERB	Gender=Fem,Masc|HebBinyan=HUFAL|Number=Plur|Person=3|Tense=Past|Voice=Pass	0	root	_	_
 5	מאחורי	מאחורי	ADP	ADP	_	6	case	_	_
 6	גדירות	גדירות	NOUN	NOUN	Definite=Cons	4	iobj	_	_
-7	משטרה	משטרה	NOUN	NOUN	Gender=Fem|Number=Sing	6	compound:smixut	_	_
+7	משטרה	משטרה	NOUN	NOUN	Gender=Fem|Number=Sing	6	compound:smixut	_	SpaceAfter=No
 8	.	_	PUNCT	PUNCT	_	4	punct	_	_
 
 # sent_id = 436
-# text = בשעה 1500 הגיע הארון למקום .
+# text = בשעה 1500 הגיע הארון למקום.
 1-2	בשעה	_	_	_	_	_	_	_	_
 1	ב	ב	ADP	ADP	_	2	case	_	_
 2	שעה	שעה	NOUN	NOUN	Gender=Fem|Number=Sing	4	obl	_	_
@@ -14243,14 +14243,14 @@
 5-6	הארון	_	_	_	_	_	_	_	_
 5	ה	ה	DET	DET	PronType=Art	6	det:def	_	_
 6	ארון	ארון	NOUN	NOUN	Gender=Masc|Number=Sing	4	nsubj	_	_
-7-9	למקום	_	_	_	_	_	_	_	_
+7-9	למקום	_	_	_	_	_	_	_	SpaceAfter=No
 7	ל	ל	ADP	ADP	_	9	case	_	_
 8	ה_	ה	DET	DET	PronType=Art	9	det:def	_	_
 9	מקום	מקום	NOUN	NOUN	Gender=Masc|Number=Sing	4	iobj	_	_
 10	.	_	PUNCT	PUNCT	_	4	punct	_	_
 
 # sent_id = 437
-# text = מהרמקול בקע קולו של אחד מתלמידי הישיבה , שקרא פסוקי תהילים .
+# text = מהרמקול בקע קולו של אחד מתלמידי הישיבה, שקרא פסוקי תהילים.
 1-3	מהרמקול	_	_	_	_	_	_	_	_
 1	מ	מ	ADP	ADP	_	3	case	_	_
 2	ה	ה	DET	DET	PronType=Art	3	det:def	_	_
@@ -14265,7 +14265,7 @@
 10-11	מתלמידי	_	_	_	_	_	_	_	_
 10	מ	מ	ADP	ADP	_	11	case	_	_
 11	תלמידי	תלמיד	NOUN	NOUN	Definite=Cons|Gender=Masc|Number=Plur	5	nmod:poss	_	_
-12-13	הישיבה	_	_	_	_	_	_	_	_
+12-13	הישיבה	_	_	_	_	_	_	_	SpaceAfter=No
 12	ה	ה	DET	DET	PronType=Art	13	det:def	_	_
 13	ישיבה	ישיבה	NOUN	NOUN	Gender=Fem|Number=Sing	11	compound:smixut	_	_
 14	,	_	PUNCT	PUNCT	_	11	punct	_	_
@@ -14273,11 +14273,11 @@
 15	ש	ש	SCONJ	SCONJ	_	16	mark	_	_
 16	קרא	קרא	VERB	VERB	Gender=Masc|HebBinyan=PAAL|Number=Sing|Person=3|Tense=Past|Voice=Act	11	acl:relcl	_	_
 17	פסוקי	פסוק	NOUN	NOUN	Definite=Cons|Gender=Masc|Number=Plur	16	obj	_	_
-18	תהילים	תהילים	PROPN	PROPN	_	17	compound:smixut	_	_
+18	תהילים	תהילים	PROPN	PROPN	_	17	compound:smixut	_	SpaceAfter=No
 19	.	_	PUNCT	PUNCT	_	4	punct	_	_
 
 # sent_id = 438
-# text = הציבור חזר אחריו בדבקות .
+# text = הציבור חזר אחריו בדבקות.
 1-2	הציבור	_	_	_	_	_	_	_	_
 1	ה	ה	DET	DET	PronType=Art	2	det:def	_	_
 2	ציבור	ציבור	NOUN	NOUN	Gender=Masc|Number=Sing	3	nsubj	_	_
@@ -14285,22 +14285,22 @@
 4-5	אחריו	_	_	_	_	_	_	_	_
 4	אחריו	אחרי	ADP	ADP	_	5	case	_	_
 5	_הוא	הוא	PRON	PRON	Gender=Masc|Number=Sing|Person=3|PronType=Prs	3	iobj	_	_
-6-7	בדבקות	_	_	_	_	_	_	_	_
+6-7	בדבקות	_	_	_	_	_	_	_	SpaceAfter=No
 6	ב	ב	ADP	ADP	_	7	case	_	_
 7	דבקות	דבקות	NOUN	NOUN	Gender=Fem|Number=Sing	3	obl	_	_
 8	.	_	PUNCT	PUNCT	_	3	punct	_	_
 
 # sent_id = 439
-# text = קהל הרבבות כלל כיפות סרוגות , חרדים , יהודים דתיים מארה"ב ואנשי שכונות .
+# text = קהל הרבבות כלל כיפות סרוגות, חרדים, יהודים דתיים מארה"ב ואנשי שכונות.
 1	קהל	קהל	NOUN	NOUN	Definite=Cons|Gender=Masc|Number=Sing	4	nsubj	_	_
 2-3	הרבבות	_	_	_	_	_	_	_	_
 2	ה	ה	DET	DET	PronType=Art	3	det:def	_	_
 3	רבבות	_	NUM	NUM	Definite=Cons	1	compound:smixut	_	_
 4	כלל	כלל	VERB	VERB	Gender=Masc|HebBinyan=PAAL|Number=Sing|Person=3|Tense=Past|Voice=Act	0	root	_	_
 5	כיפות	כיפה	NOUN	NOUN	Gender=Fem|Number=Plur	4	obj	_	_
-6	סרוגות	סרוג	ADJ	ADJ	Gender=Fem|Number=Plur	5	amod	_	_
+6	סרוגות	סרוג	ADJ	ADJ	Gender=Fem|Number=Plur	5	amod	_	SpaceAfter=No
 7	,	_	PUNCT	PUNCT	_	5	punct	_	_
-8	חרדים	חרדי	NOUN	NOUN	Gender=Masc|Number=Plur	5	conj	_	_
+8	חרדים	חרדי	NOUN	NOUN	Gender=Masc|Number=Plur	5	conj	_	SpaceAfter=No
 9	,	_	PUNCT	PUNCT	_	5	punct	_	_
 10	יהודים	יהודי	NOUN	NOUN	Gender=Masc|Number=Plur	5	conj	_	_
 11	דתיים	דתי	ADJ	ADJ	Gender=Masc|Number=Plur	10	amod	_	_
@@ -14310,11 +14310,11 @@
 14-15	ואנשי	_	_	_	_	_	_	_	_
 14	ו	ו	CCONJ	CCONJ	_	15	cc	_	_
 15	אנשי	איש	NOUN	NOUN	Definite=Cons|Gender=Masc|Number=Plur	5	conj	_	_
-16	שכונות	שכונה	NOUN	NOUN	Gender=Fem|Number=Plur	15	compound:smixut	_	_
+16	שכונות	שכונה	NOUN	NOUN	Gender=Fem|Number=Plur	15	compound:smixut	_	SpaceAfter=No
 17	.	_	PUNCT	PUNCT	_	4	punct	_	_
 
 # sent_id = 440
-# text = אנשי החברה קדישא ביקשו להעביר את אלונקת הנפטר מהרכב אל הישיבה .
+# text = אנשי החברה קדישא ביקשו להעביר את אלונקת הנפטר מהרכב אל הישיבה.
 1	אנשי	איש	NOUN	NOUN	Definite=Cons|Gender=Masc|Number=Plur	5	nsubj	_	_
 2-3	החברה	_	_	_	_	_	_	_	_
 2	ה	ה	DET	DET	PronType=Art	3	det:def	_	_
@@ -14332,13 +14332,13 @@
 12	ה	ה	DET	DET	PronType=Art	13	det:def	_	_
 13	רכב	רכב	NOUN	NOUN	Gender=Masc|Number=Sing	6	obl	_	_
 14	אל	אל	ADP	ADP	_	16	case	_	_
-15-16	הישיבה	_	_	_	_	_	_	_	_
+15-16	הישיבה	_	_	_	_	_	_	_	SpaceAfter=No
 15	ה	ה	DET	DET	PronType=Art	16	det:def	_	_
 16	ישיבה	ישיבה	NOUN	NOUN	Gender=Fem|Number=Sing	6	obl	_	_
 17	.	_	PUNCT	PUNCT	_	5	punct	_	_
 
 # sent_id = 441
-# text = למעלה מחצי שעה הם ניסו לעשות זאת , אך ללא הצלחה .
+# text = למעלה מחצי שעה הם ניסו לעשות זאת, אך ללא הצלחה.
 1	למעלה	למעלה	ADV	ADV	HebSource=ConvUncertainHead	3	dep	_	_
 2-3	מחצי	_	_	_	_	_	_	_	_
 2	מ	מ	ADP	ADP	_	3	det	_	_
@@ -14347,21 +14347,21 @@
 5	הם	הוא	PRON	PRON	Gender=Masc|Number=Plur|Person=3|PronType=Prs	6	nsubj	_	_
 6	ניסו	ניסה	VERB	VERB	Gender=Fem,Masc|HebBinyan=PIEL|Number=Plur|Person=3|Tense=Past|Voice=Act	0	root	_	_
 7	לעשות	עשה	VERB	VERB	HebBinyan=PAAL|VerbForm=Inf|Voice=Act	6	xcomp	_	_
-8	זאת	זאת	PRON	PRON	Gender=Fem|Number=Sing|Person=3|PronType=Dem	7	obj	_	_
+8	זאת	זאת	PRON	PRON	Gender=Fem|Number=Sing|Person=3|PronType=Dem	7	obj	_	SpaceAfter=No
 9	,	_	PUNCT	PUNCT	_	6	punct	_	_
 10	אך	אך	CCONJ	CCONJ	_	6	cc	_	_
 11	ללא	ללא	ADP	ADP	_	12	case	_	_
-12	הצלחה	הצלחה	NOUN	NOUN	Gender=Fem|Number=Sing	6	dep	_	_
+12	הצלחה	הצלחה	NOUN	NOUN	Gender=Fem|Number=Sing	6	dep	_	SpaceAfter=No
 13	.	_	PUNCT	PUNCT	_	6	punct	_	_
 
 # sent_id = 442
-# text = בני המשפחה , הרבנים , ראשי כך ואפילו הרב הראשי לישראל , הראשון לציון הרב מרדכי אליהו , התחננו בפני הקהל לפנות מעט דרך , אך לשווא .
+# text = בני המשפחה, הרבנים, ראשי כך ואפילו הרב הראשי לישראל, הראשון לציון הרב מרדכי אליהו, התחננו בפני הקהל לפנות מעט דרך, אך לשווא.
 1	בני	בן	NOUN	NOUN	Definite=Cons|Gender=Masc|Number=Plur	28	nsubj	_	_
-2-3	המשפחה	_	_	_	_	_	_	_	_
+2-3	המשפחה	_	_	_	_	_	_	_	SpaceAfter=No
 2	ה	ה	DET	DET	PronType=Art	3	det:def	_	_
 3	משפחה	משפחה	NOUN	NOUN	Gender=Fem|Number=Sing	1	compound:smixut	_	_
 4	,	_	PUNCT	PUNCT	_	1	punct	_	_
-5-6	הרבנים	_	_	_	_	_	_	_	_
+5-6	הרבנים	_	_	_	_	_	_	_	SpaceAfter=No
 5	ה	ה	DET	DET	PronType=Art	6	det:def	_	_
 6	רבנים	רב	NOUN	NOUN	Gender=Masc|Number=Plur	1	conj	_	_
 7	,	_	PUNCT	PUNCT	_	1	punct	_	_
@@ -14376,7 +14376,7 @@
 14-15	הראשי	_	_	_	_	_	_	_	_
 14	ה	ה	DET	DET	PronType=Art	15	det:def	_	_
 15	ראשי	ראשי	ADJ	ADJ	Gender=Masc|Number=Sing	13	amod	_	_
-16-17	לישראל	_	_	_	_	_	_	_	_
+16-17	לישראל	_	_	_	_	_	_	_	SpaceAfter=No
 16	ל	ל	ADP	ADP	_	17	case	_	_
 17	ישראל	ישראל	PROPN	PROPN	_	13	nmod	_	_
 18	,	_	PUNCT	PUNCT	_	13	punct	_	_
@@ -14390,7 +14390,7 @@
 23	ה	ה	DET	DET	PronType=Art	24	det:def	_	_
 24	רב	רב	NOUN	NOUN	Gender=Masc|Number=Sing	20	nmod	_	_
 25	מרדכי	מרדכי	PROPN	PROPN	_	24	appos	_	_
-26	אליהו	אליהו	PROPN	PROPN	_	25	flat:name	_	_
+26	אליהו	אליהו	PROPN	PROPN	_	25	flat:name	_	SpaceAfter=No
 27	,	_	PUNCT	PUNCT	_	1	punct	_	_
 28	התחננו	התחנן	VERB	VERB	Gender=Fem,Masc|HebBinyan=HITPAEL|Number=Plur|Person=3|Tense=Past	0	root	_	_
 29-30	בפני	_	_	_	_	_	_	_	_
@@ -14401,14 +14401,14 @@
 32	קהל	קהל	NOUN	NOUN	Gender=Masc|Number=Sing	30	compound:smixut	_	_
 33	לפנות	פינה	VERB	VERB	VerbForm=Inf	28	xcomp	_	_
 34	מעט	מעט	DET	DET	Definite=Cons	35	det	_	_
-35	דרך	דרך	NOUN	NOUN	Gender=Fem|Number=Sing	33	obj	_	_
+35	דרך	דרך	NOUN	NOUN	Gender=Fem|Number=Sing	33	obj	_	SpaceAfter=No
 36	,	_	PUNCT	PUNCT	_	28	punct	_	_
 37	אך	אך	CCONJ	CCONJ	_	38	cc	_	_
-38	לשווא	לשווא	ADV	ADV	_	28	conj	_	_
+38	לשווא	לשווא	ADV	ADV	_	28	conj	_	SpaceAfter=No
 39	.	_	PUNCT	PUNCT	_	28	punct	_	_
 
 # sent_id = 443
-# text = מאות צרו על רכב החברה קדישא , תוך שהם דוחפים איש את רעהו ומשלחים קללות וגידופים לעבר אנשי התקשורת הרבים .
+# text = מאות צרו על רכב החברה קדישא, תוך שהם דוחפים איש את רעהו ומשלחים קללות וגידופים לעבר אנשי התקשורת הרבים.
 1	מאות	מאה	NUM	NUM	Gender=Fem|Number=Plur	2	nsubj	_	_
 2	צרו	צר	VERB	VERB	Gender=Fem,Masc|HebBinyan=PAAL|Number=Plur|Person=3|Tense=Past|Voice=Act	0	root	_	_
 3	על	על	ADP	ADP	_	4	case	_	_
@@ -14416,7 +14416,7 @@
 5-6	החברה	_	_	_	_	_	_	_	_
 5	ה	ה	DET	DET	PronType=Art	6	det:def	_	_
 6	חברה	חברה	NOUN	NOUN	Gender=Fem|Number=Sing	4	compound:smixut	_	_
-7	קדישא	קדישא	PROPN	PROPN	_	6	appos	_	_
+7	קדישא	קדישא	PROPN	PROPN	_	6	appos	_	SpaceAfter=No
 8	,	_	PUNCT	PUNCT	_	2	punct	_	_
 9	תוך	תוך	ADP	ADP	_	12	case	_	_
 10-11	שהם	_	_	_	_	_	_	_	_
@@ -14438,13 +14438,13 @@
 23-24	התקשורת	_	_	_	_	_	_	_	_
 23	ה	ה	DET	DET	PronType=Art	24	det:def	_	_
 24	תקשורת	תקשורת	NOUN	NOUN	Gender=Fem|Number=Sing	22	compound:smixut	_	_
-25-26	הרבים	_	_	_	_	_	_	_	_
+25-26	הרבים	_	_	_	_	_	_	_	SpaceAfter=No
 25	ה	ה	DET	DET	PronType=Art	26	det:def	_	_
 26	רבים	רב	ADJ	ADJ	Gender=Masc|Number=Plur	22	amod	_	_
 27	.	_	PUNCT	PUNCT	_	2	punct	_	_
 
 # sent_id = 444
-# text = השר יובל נאמן וסגניתו גאולה כהן , שביקשו להספיד את הרב כהנא , גורשו מהמקום .
+# text = השר יובל נאמן וסגניתו גאולה כהן, שביקשו להספיד את הרב כהנא, גורשו מהמקום.
 1-2	השר	_	_	_	_	_	_	_	_
 1	ה	ה	DET	DET	PronType=Art	2	det:def	_	_
 2	שר	שר	NOUN	NOUN	Gender=Masc|Number=Sing	20	nsubj	_	_
@@ -14456,7 +14456,7 @@
 7	_של_	של	ADP	ADP	_	8	case:gen	_	_
 8	_הוא	הוא	PRON	PRON	Case=Gen|Gender=Masc|Number=Sing|Person=3|PronType=Prs	6	nmod:poss	_	_
 9	גאולה	גאולה	PROPN	PROPN	_	6	appos	_	_
-10	כהן	כהן	PROPN	PROPN	_	9	flat:name	_	_
+10	כהן	כהן	PROPN	PROPN	_	9	flat:name	_	SpaceAfter=No
 11	,	_	PUNCT	PUNCT	_	2	punct	_	_
 12-13	שביקשו	_	_	_	_	_	_	_	_
 12	ש	ש	SCONJ	SCONJ	_	13	mark	_	_
@@ -14466,17 +14466,17 @@
 16-17	הרב	_	_	_	_	_	_	_	_
 16	ה	ה	DET	DET	PronType=Art	17	det:def	_	_
 17	רב	רב	NOUN	NOUN	Gender=Masc|Number=Sing	14	obj	_	_
-18	כהנא	כהנא	PROPN	PROPN	_	17	appos	_	_
+18	כהנא	כהנא	PROPN	PROPN	_	17	appos	_	SpaceAfter=No
 19	,	_	PUNCT	PUNCT	_	20	punct	_	_
 20	גורשו	גורש	VERB	VERB	Gender=Fem,Masc|HebBinyan=PUAL|Number=Plur|Person=3|Tense=Past|Voice=Pass	0	root	_	_
-21-23	מהמקום	_	_	_	_	_	_	_	_
+21-23	מהמקום	_	_	_	_	_	_	_	SpaceAfter=No
 21	מ	מ	ADP	ADP	_	23	case	_	_
 22	ה	ה	DET	DET	PronType=Art	23	det:def	_	_
 23	מקום	מקום	NOUN	NOUN	Gender=Masc|Number=Sing	20	iobj	_	_
 24	.	_	PUNCT	PUNCT	_	20	punct	_	_
 
 # sent_id = 445
-# text = בקהל נראו חבר הכנסת אליקים העצני , השר יצחק פרץ , הח"ך לשעבר מאיר כהן אבידוב , ד"ר ישראל אלדד ודמויות רבות נוספות מחוגי הימין .
+# text = בקהל נראו חבר הכנסת אליקים העצני, השר יצחק פרץ, הח"ך לשעבר מאיר כהן אבידוב, ד"ר ישראל אלדד ודמויות רבות נוספות מחוגי הימין.
 1-3	בקהל	_	_	_	_	_	_	_	_
 1	ב	ב	ADP	ADP	_	3	case	_	_
 2	ה_	ה	DET	DET	PronType=Art	3	det:def	_	_
@@ -14487,13 +14487,13 @@
 6	ה	ה	DET	DET	PronType=Art	7	det:def	_	_
 7	כנסת	כנסת	PROPN	PROPN	_	5	compound:smixut	_	_
 8	אליקים	אליקים	PROPN	PROPN	_	5	appos	_	_
-9	העצני	העצני	PROPN	PROPN	_	8	flat:name	_	_
+9	העצני	העצני	PROPN	PROPN	_	8	flat:name	_	SpaceAfter=No
 10	,	_	PUNCT	PUNCT	_	5	punct	_	_
 11-12	השר	_	_	_	_	_	_	_	_
 11	ה	ה	DET	DET	PronType=Art	12	det:def	_	_
 12	שר	שר	NOUN	NOUN	Gender=Masc|Number=Sing	5	conj	_	_
 13	יצחק	יצחק	PROPN	PROPN	_	12	appos	_	_
-14	פרץ	פרץ	PROPN	PROPN	_	13	flat:name	_	_
+14	פרץ	פרץ	PROPN	PROPN	_	13	flat:name	_	SpaceAfter=No
 15	,	_	PUNCT	PUNCT	_	5	punct	_	_
 16-17	הח"ך	_	_	_	_	_	_	_	_
 16	ה	_	DET	DET	PronType=Art	17	det:def	_	_
@@ -14501,7 +14501,7 @@
 18	לשעבר	לשעבר	ADV	ADV	_	17	advmod	_	_
 19	מאיר	מאיר	PROPN	PROPN	_	17	appos	_	_
 20	כהן	כהן	PROPN	PROPN	_	19	flat:name	_	_
-21	אבידוב	אבידוב	PROPN	PROPN	_	20	flat:name	_	_
+21	אבידוב	אבידוב	PROPN	PROPN	_	20	flat:name	_	SpaceAfter=No
 22	,	_	PUNCT	PUNCT	_	5	punct	_	_
 23	ד"ר	ד"ר	NOUN	NOUN	Abbr=Yes|Gender=Masc|Number=Sing	5	conj	_	_
 24	ישראל	ישראל	PROPN	PROPN	_	23	appos	_	_
@@ -14514,13 +14514,13 @@
 30-31	מחוגי	_	_	_	_	_	_	_	_
 30	מ	מ	ADP	ADP	_	31	case	_	_
 31	חוגי	חוג	NOUN	NOUN	Definite=Cons|Gender=Masc|Number=Plur	27	nmod	_	_
-32-33	הימין	_	_	_	_	_	_	_	_
+32-33	הימין	_	_	_	_	_	_	_	SpaceAfter=No
 32	ה	ה	DET	DET	PronType=Art	33	det:def	_	_
 33	ימין	ימין	NOUN	NOUN	Gender=Masc|Number=Sing	31	compound:smixut	_	_
 34	.	_	PUNCT	PUNCT	_	4	punct	_	_
 
 # sent_id = 446
-# text = ב2115 ניסה רכב החברה קדישא לדחוף בעדינות את הצרים עליו .
+# text = ב2115 ניסה רכב החברה קדישא לדחוף בעדינות את הצרים עליו.
 1-2	ב2115	_	_	_	_	_	_	_	_
 1	ב	ב	ADP	ADP	_	2	case	_	_
 2	2115	_	NUM	NUM	_	3	obl	_	_
@@ -14538,25 +14538,25 @@
 12-13	הצרים	_	_	_	_	_	_	_	_
 12	ה	ה	SCONJ	SCONJ	_	13	mark	_	_
 13	צרים	צר	VERB	VERB	Gender=Masc|HebBinyan=PAAL|Number=Plur|Person=1,2,3|VerbForm=Part|Voice=Act	8	obj	_	_
-14-15	עליו	_	_	_	_	_	_	_	_
+14-15	עליו	_	_	_	_	_	_	_	SpaceAfter=No
 14	עליו	על	ADP	ADP	_	15	case	_	_
 15	_הוא	הוא	PRON	PRON	Gender=Masc|Number=Sing|Person=3|PronType=Prs	13	iobj	_	_
 16	.	_	PUNCT	PUNCT	_	3	punct	_	_
 
 # sent_id = 447
-# text = התוצאה : פצוע שנדרס .
-1-2	התוצאה	_	_	_	_	_	_	_	_
+# text = התוצאה: פצוע שנדרס.
+1-2	התוצאה	_	_	_	_	_	_	_	SpaceAfter=No
 1	ה	ה	DET	DET	PronType=Art	2	det:def	_	_
 2	תוצאה	תוצאה	NOUN	NOUN	Gender=Fem|Number=Sing	4	nsubj	_	_
 3	:	_	PUNCT	PUNCT	_	4	punct	_	_
 4	פצוע	פצוע	NOUN	NOUN	Gender=Masc|Number=Sing	0	root	_	_
-5-6	שנדרס	_	_	_	_	_	_	_	_
+5-6	שנדרס	_	_	_	_	_	_	_	SpaceAfter=No
 5	ש	ש	SCONJ	SCONJ	_	6	mark	_	_
 6	נדרס	נדרס	VERB	VERB	Gender=Masc|HebBinyan=NIFAL|Number=Sing|Person=3|Tense=Past|Voice=Mid	4	acl:relcl	_	_
 7	.	_	PUNCT	PUNCT	_	4	punct	_	_
 
 # sent_id = 448
-# text = לקול צפירות האמבולנס שמיהר עמו לבית החולים , פתח הרב הראשי את שורת ההספדים .
+# text = לקול צפירות האמבולנס שמיהר עמו לבית החולים, פתח הרב הראשי את שורת ההספדים.
 1-2	לקול	_	_	_	_	_	_	_	_
 1	ל	ל	ADP	ADP	_	2	case	_	_
 2	קול	קול	NOUN	NOUN	Definite=Cons|Gender=Masc|Number=Sing	15	obl	_	_
@@ -14573,7 +14573,7 @@
 10-11	לבית	_	_	_	_	_	_	_	_
 10	ל	ל	ADP	ADP	_	11	case	_	_
 11	בית	בית	NOUN	NOUN	Definite=Cons|Gender=Masc|Number=Sing	7	iobj	_	_
-12-13	החולים	_	_	_	_	_	_	_	_
+12-13	החולים	_	_	_	_	_	_	_	SpaceAfter=No
 12	ה	ה	DET	DET	PronType=Art	13	det:def	_	_
 13	חולים	חלה	VERB	VERB	Gender=Masc|HebBinyan=PAAL|Number=Plur|Person=1,2,3|VerbForm=Part|Voice=Act	11	compound:smixut	_	_
 14	,	_	PUNCT	PUNCT	_	15	punct	_	_
@@ -14586,13 +14586,13 @@
 19	ראשי	ראשי	ADJ	ADJ	Gender=Masc|Number=Sing	17	amod	_	_
 20	את	את	PART	PART	Case=Acc	21	case:acc	_	_
 21	שורת	שורה	NOUN	NOUN	Definite=Cons|Gender=Fem|Number=Sing	15	obj	_	_
-22-23	ההספדים	_	_	_	_	_	_	_	_
+22-23	ההספדים	_	_	_	_	_	_	_	SpaceAfter=No
 22	ה	ה	DET	DET	PronType=Art	23	det:def	_	_
 23	הספדים	הספד	NOUN	NOUN	Gender=Masc|Number=Plur	21	compound:smixut	_	_
 24	.	_	PUNCT	PUNCT	_	15	punct	_	_
 
 # sent_id = 449
-# text = הרב הראשי עמד על תכונותיו של כהנא : " החסד שלו , הצדקה שלו וראיית החיים שלו " , ואחר כך פונה לקהל : " הקב"ה יקום דמו .
+# text = הרב הראשי עמד על תכונותיו של כהנא: "החסד שלו, הצדקה שלו וראיית החיים שלו", ואחר כך פונה לקהל: "הקב"ה יקום דמו.
 1-2	הרב	_	_	_	_	_	_	_	_
 1	ה	ה	DET	DET	PronType=Art	2	det:def	_	_
 2	רב	רב	NOUN	NOUN	Gender=Masc|Number=Sing	5	nsubj	_	_
@@ -14606,13 +14606,13 @@
 8	_של_	של	ADP	ADP	_	9	case:gen	_	_
 9	_הוא	הוא	PRON	PRON	Case=Gen|Gender=Masc|Number=Sing|Person=3|PronType=Prs	7	nmod:poss	_	_
 10	של	של	PART	PART	Case=Gen	11	case:gen	_	_
-11	כהנא	כהנא	PROPN	PROPN	_	7	nmod:poss	_	_
+11	כהנא	כהנא	PROPN	PROPN	_	7	nmod:poss	_	SpaceAfter=No
 12	:	_	PUNCT	PUNCT	_	7	punct	_	_
-13	"	_	PUNCT	PUNCT	_	15	punct	_	_
+13	"	_	PUNCT	PUNCT	_	15	punct	_	SpaceAfter=No
 14-15	החסד	_	_	_	_	_	_	_	_
 14	ה	ה	DET	DET	PronType=Art	15	det:def	_	_
 15	חסד	חסד	NOUN	NOUN	Gender=Masc|Number=Sing	7	appos	_	_
-16-17	שלו	_	_	_	_	_	_	_	_
+16-17	שלו	_	_	_	_	_	_	_	SpaceAfter=No
 16	של_	של	ADP	ADP	Case=Gen	17	case:gen	_	_
 17	_הוא	הוא	PRON	PRON	Gender=Masc|Number=Sing|Person=3|PronType=Prs	15	nmod:poss	_	_
 18	,	_	PUNCT	PUNCT	_	15	punct	_	_
@@ -14628,64 +14628,64 @@
 25-26	החיים	_	_	_	_	_	_	_	_
 25	ה	ה	DET	DET	PronType=Art	26	det:def	_	_
 26	חיים	חיים	NOUN	NOUN	Gender=Masc|Number=Plur	24	compound:smixut	_	_
-27-28	שלו	_	_	_	_	_	_	_	_
+27-28	שלו	_	_	_	_	_	_	_	SpaceAfter=No
 27	של_	של	ADP	ADP	Case=Gen	28	case:gen	_	_
 28	_הוא	הוא	PRON	PRON	Gender=Masc|Number=Sing|Person=3|PronType=Prs	24	nmod:poss	_	_
-29	"	_	PUNCT	PUNCT	_	15	punct	_	_
+29	"	_	PUNCT	PUNCT	_	15	punct	_	SpaceAfter=No
 30	,	_	PUNCT	PUNCT	_	5	punct	_	_
 31-32	ואחר	_	_	_	_	_	_	_	_
 31	ו	ו	CCONJ	CCONJ	_	34	cc	_	_
 32	אחר	אחר	ADP	ADP	_	33	case	_	_
 33	כך	כך	PRON	PRON	Person=3|PronType=Dem	34	obl	_	_
 34	פונה	פנה	VERB	VERB	Gender=Masc|HebBinyan=PAAL|Number=Sing|Person=1,2,3|VerbForm=Part|Voice=Act	5	conj	_	_
-35-37	לקהל	_	_	_	_	_	_	_	_
+35-37	לקהל	_	_	_	_	_	_	_	SpaceAfter=No
 35	ל	ל	ADP	ADP	_	37	case	_	_
 36	ה_	ה	DET	DET	PronType=Art	37	det:def	_	_
 37	קהל	קהל	NOUN	NOUN	Gender=Masc|Number=Sing	34	iobj	_	_
 38	:	_	PUNCT	PUNCT	_	42	punct	_	_
-39	"	_	PUNCT	PUNCT	_	42	punct	_	_
+39	"	_	PUNCT	PUNCT	_	42	punct	_	SpaceAfter=No
 40-41	הקב"ה	_	_	_	_	_	_	_	_
 40	ה	ה	DET	DET	PronType=Art	41	det:def	_	_
 41	קב"ה	קב"ה	PROPN	PROPN	Abbr=Yes	42	nsubj	_	_
 42	יקום	קם	VERB	VERB	Gender=Masc|HebBinyan=PAAL|Number=Sing|Person=3|Tense=Fut|Voice=Act	34	advcl	_	_
-43-45	דמו	_	_	_	_	_	_	_	_
+43-45	דמו	_	_	_	_	_	_	_	SpaceAfter=No
 43	דם_	דם	NOUN	NOUN	Definite=Def|Gender=Masc|Number=Sing	42	obj	_	_
 44	_של_	של	ADP	ADP	_	45	case:gen	_	_
 45	_הוא	הוא	PRON	PRON	Case=Gen|Gender=Masc|Number=Sing|Person=3|PronType=Prs	43	nmod:poss	_	_
 46	.	_	PUNCT	PUNCT	_	5	punct	_	_
 
 # sent_id = 450
-# text = לא להפריע לכוחות הביטחון .
+# text = לא להפריע לכוחות הביטחון.
 1	לא	לא	ADV	ADV	Polarity=Neg	0	root	_	_
 2	להפריע	הפריע	VERB	VERB	HebBinyan=HIFIL|HebSource=ConvUncertainHead|VerbForm=Inf|Voice=Act	1	dep	_	_
 3-4	לכוחות	_	_	_	_	_	_	_	_
 3	ל	ל	ADP	ADP	_	4	case	_	_
 4	כוחות	כוח	NOUN	NOUN	Definite=Cons|Gender=Masc|Number=Plur	2	obl	_	_
-5-6	הביטחון	_	_	_	_	_	_	_	_
+5-6	הביטחון	_	_	_	_	_	_	_	SpaceAfter=No
 5	ה	ה	DET	DET	PronType=Art	6	det:def	_	_
 6	ביטחון	ביטחון	NOUN	NOUN	Gender=Masc|Number=Sing	4	compound:smixut	_	_
 7	.	_	PUNCT	PUNCT	HebSource=ConvUncertainHead	1	dep	_	_
 
 # sent_id = 451
-# text = להשאיר את הנקמה לאלוקים " .
+# text = להשאיר את הנקמה לאלוקים".
 1	להשאיר	השאיר	VERB	VERB	HebBinyan=HIFIL|VerbForm=Inf|Voice=Act	0	root	_	_
 2	את	את	PART	PART	Case=Acc	4	case:acc	_	_
 3-4	הנקמה	_	_	_	_	_	_	_	_
 3	ה	ה	DET	DET	PronType=Art	4	det:def	_	_
 4	נקמה	נקמה	NOUN	NOUN	Gender=Fem|Number=Sing	1	obj	_	_
-5-6	לאלוקים	_	_	_	_	_	_	_	_
+5-6	לאלוקים	_	_	_	_	_	_	_	SpaceAfter=No
 5	ל	ל	ADP	ADP	_	6	case	_	_
 6	אלוקים	אלוקים	NOUN	NOUN	Gender=Masc|Number=Sing	1	obl	_	_
-7	"	_	PUNCT	PUNCT	_	1	punct	_	_
+7	"	_	PUNCT	PUNCT	_	1	punct	_	SpaceAfter=No
 8	.	_	PUNCT	PUNCT	_	1	punct	_	_
 
 # sent_id = 452
-# text = הרב נחמן כהנא , אחיו של מאיר כהנא , הזכיר לציבור תוך בכי , כי " דמו של כהנא נשפך על רקע הר - הבית .
+# text = הרב נחמן כהנא, אחיו של מאיר כהנא, הזכיר לציבור תוך בכי, כי " דמו של כהנא נשפך על רקע הר - הבית.
 1-2	הרב	_	_	_	_	_	_	_	_
 1	ה	ה	DET	DET	PronType=Art	2	det:def	_	_
 2	רב	רב	NOUN	NOUN	Gender=Masc|Number=Sing	13	nsubj	_	_
 3	נחמן	נחמן	PROPN	PROPN	_	2	appos	_	_
-4	כהנא	כהנא	PROPN	PROPN	_	3	flat:name	_	_
+4	כהנא	כהנא	PROPN	PROPN	_	3	flat:name	_	SpaceAfter=No
 5	,	_	PUNCT	PUNCT	_	2	punct	_	_
 6-8	אחיו	_	_	_	_	_	_	_	_
 6	__	_	NOUN	NOUN	Definite=Def|Number=Sing	2	appos	_	_
@@ -14693,7 +14693,7 @@
 8	_הוא	הוא	PRON	PRON	Case=Gen|Gender=Masc|Number=Sing|Person=3|PronType=Prs	6	nmod:poss	_	_
 9	של	של	PART	PART	Case=Gen	10	case:gen	_	_
 10	מאיר	מאיר	PROPN	PROPN	_	6	nmod:poss	_	_
-11	כהנא	כהנא	PROPN	PROPN	_	10	flat:name	_	_
+11	כהנא	כהנא	PROPN	PROPN	_	10	flat:name	_	SpaceAfter=No
 12	,	_	PUNCT	PUNCT	_	2	punct	_	_
 13	הזכיר	הזכיר	VERB	VERB	Gender=Masc|HebBinyan=HIFIL|Number=Sing|Person=3|Tense=Past|Voice=Act	0	root	_	_
 14-16	לציבור	_	_	_	_	_	_	_	_
@@ -14701,7 +14701,7 @@
 15	ה_	ה	DET	DET	PronType=Art	16	det:def	_	_
 16	ציבור	ציבור	NOUN	NOUN	Gender=Masc|Number=Sing	13	iobj	_	_
 17	תוך	תוך	ADP	ADP	_	18	case	_	_
-18	בכי	בכי	NOUN	NOUN	Gender=Masc|Number=Sing	13	obl	_	_
+18	בכי	בכי	NOUN	NOUN	Gender=Masc|Number=Sing	13	obl	_	SpaceAfter=No
 19	,	_	PUNCT	PUNCT	_	13	punct	_	_
 20	כי	כי	SCONJ	SCONJ	_	27	mark	_	_
 21	"	_	PUNCT	PUNCT	_	27	punct	_	_
@@ -14716,24 +14716,24 @@
 29	רקע	רקע	NOUN	NOUN	Definite=Cons|Gender=Masc|Number=Sing	27	obl	_	_
 30	הר	הר	NOUN	NOUN	Definite=Cons|Gender=Masc|Number=Sing	29	compound:smixut	_	_
 31	-	_	PUNCT	PUNCT	_	30	punct	_	_
-32-33	הבית	_	_	_	_	_	_	_	_
+32-33	הבית	_	_	_	_	_	_	_	SpaceAfter=No
 32	ה	ה	DET	DET	PronType=Art	33	det:def	_	_
 33	בית	בית	NOUN	NOUN	Gender=Masc|HebSource=ConvUncertainLabel|Number=Sing	30	nmod	_	_
 34	.	_	PUNCT	PUNCT	_	13	punct	_	_
 
 # sent_id = 453
-# text = הדם הזה רותח .
+# text = הדם הזה רותח.
 1-2	הדם	_	_	_	_	_	_	_	_
 1	ה	ה	DET	DET	PronType=Art	2	det:def	_	_
 2	דם	דם	NOUN	NOUN	Gender=Masc|Number=Sing	5	nsubj	_	_
 3-4	הזה	_	_	_	_	_	_	_	_
 3	ה	ה	DET	DET	PronType=Art	4	det:def	_	_
 4	זה	זה	PRON	PRON	Gender=Masc|Number=Sing|Person=3|PronType=Dem	2	amod	_	_
-5	רותח	רתח	VERB	VERB	Gender=Masc|HebBinyan=PAAL|Number=Sing|Person=1,2,3|VerbForm=Part|Voice=Act	0	root	_	_
+5	רותח	רתח	VERB	VERB	Gender=Masc|HebBinyan=PAAL|Number=Sing|Person=1,2,3|VerbForm=Part|Voice=Act	0	root	_	SpaceAfter=No
 6	.	_	PUNCT	PUNCT	_	5	punct	_	_
 
 # sent_id = 454
-# text = על הדם הזה אין כפרה " .
+# text = על הדם הזה אין כפרה ".
 1	על	על	ADP	ADP	_	3	case	_	_
 2-3	הדם	_	_	_	_	_	_	_	_
 2	ה	ה	DET	DET	PronType=Art	3	det:def	_	_
@@ -14743,11 +14743,11 @@
 5	זה	זה	PRON	PRON	Gender=Masc|Number=Sing|Person=3|PronType=Dem	3	amod	_	_
 6	אין	אין	VERB	VERB	HebExistential=True	0	root	_	_
 7	כפרה	כפרה	NOUN	NOUN	Gender=Fem|Number=Sing	6	nsubj	_	_
-8	"	_	PUNCT	PUNCT	_	6	punct	_	_
+8	"	_	PUNCT	PUNCT	_	6	punct	_	SpaceAfter=No
 9	.	_	PUNCT	PUNCT	_	6	punct	_	_
 
 # sent_id = 455
-# text = רק בדבריו של הרב אברהם טולדאנו , משגיח בישיבת הרעיון היהודי ומספר 4 ברשימת כך לכנסת , היו כבר הוראות מעשיות : " אלוקים ייקום דמו ואנו ניקום אותו .
+# text = רק בדבריו של הרב אברהם טולדאנו, משגיח בישיבת הרעיון היהודי ומספר 4 ברשימת כך לכנסת, היו כבר הוראות מעשיות: " אלוקים ייקום דמו ואנו ניקום אותו.
 1	רק	רק	ADV	ADV	_	2	advmod	_	_
 2-5	בדבריו	_	_	_	_	_	_	_	_
 2	ב	ב	ADP	ADP	_	3	case	_	_
@@ -14759,7 +14759,7 @@
 7	ה	ה	DET	DET	PronType=Art	8	det:def	_	_
 8	רב	רב	NOUN	NOUN	Gender=Masc|Number=Sing	3	nmod:poss	_	_
 9	אברהם	אברהם	PROPN	PROPN	_	8	appos	_	_
-10	טולדאנו	טולדאנו	PROPN	PROPN	_	9	flat:name	_	_
+10	טולדאנו	טולדאנו	PROPN	PROPN	_	9	flat:name	_	SpaceAfter=No
 11	,	_	PUNCT	PUNCT	_	8	punct	_	_
 12	משגיח	משגיח	NOUN	NOUN	Gender=Masc|Number=Sing	8	appos	_	_
 13-14	בישיבת	_	_	_	_	_	_	_	_
@@ -14779,7 +14779,7 @@
 22	ב	ב	ADP	ADP	_	23	case	_	_
 23	רשימת	רשימה	NOUN	NOUN	Definite=Cons|Gender=Fem|Number=Sing	20	nmod	_	_
 24	כך	כך	PROPN	PROPN	_	23	compound:smixut	_	_
-25-27	לכנסת	_	_	_	_	_	_	_	_
+25-27	לכנסת	_	_	_	_	_	_	_	SpaceAfter=No
 25	ל	ל	ADP	ADP	_	27	case	_	_
 26	ה_	ה	DET	DET	PronType=Art	27	det:def	_	_
 27	כנסת	כנסת	PROPN	PROPN	_	23	nmod	_	_
@@ -14787,7 +14787,7 @@
 29	היו	היה	VERB	VERB	Gender=Fem,Masc|Number=Plur|Person=3|Polarity=Pos|Tense=Past|VerbType=Cop	0	root	_	_
 30	כבר	כבר	ADV	ADV	_	29	advmod	_	_
 31	הוראות	הוראה	NOUN	NOUN	Gender=Fem|Number=Plur	29	nsubj	_	_
-32	מעשיות	מעשי	ADJ	ADJ	Gender=Fem|Number=Plur	31	amod	_	_
+32	מעשיות	מעשי	ADJ	ADJ	Gender=Fem|Number=Plur	31	amod	_	SpaceAfter=No
 33	:	_	PUNCT	PUNCT	_	36	punct	_	_
 34	"	_	PUNCT	PUNCT	_	36	punct	_	_
 35	אלוקים	אלוקים	NOUN	NOUN	Gender=Masc|Number=Sing	36	nsubj	_	_
@@ -14800,42 +14800,42 @@
 40	ו	ו	CCONJ	CCONJ	_	42	cc	_	_
 41	אנו	הוא	PRON	PRON	Gender=Fem,Masc|Number=Plur|Person=1|PronType=Prs	42	nsubj	_	_
 42	ניקום	נקם	VERB	VERB	Gender=Fem,Masc|HebBinyan=PAAL|Number=Plur|Person=1|Tense=Fut|Voice=Act	36	conj	_	_
-43-44	אותו	_	_	_	_	_	_	_	_
+43-44	אותו	_	_	_	_	_	_	_	SpaceAfter=No
 43	את_	את	PART	PART	Case=Acc	44	case:acc	_	_
 44	_הוא	הוא	PRON	PRON	Gender=Masc|Number=Sing|Person=3|PronType=Prs	42	obj	_	_
 45	.	_	PUNCT	PUNCT	_	29	punct	_	_
 
 # sent_id = 456
-# text = אל נקמות ה .
+# text = אל נקמות ה.
 1	אל	אל	NOUN	NOUN	Definite=Cons|Gender=Masc|Number=Sing	0	root	_	_
 2	נקמות	נקמה	NOUN	NOUN	Gender=Fem|Number=Plur	1	compound:smixut	_	_
-3	ה	ה	DET	DET	PronType=Art	1	nsubj	_	_
+3	ה	ה	DET	DET	PronType=Art	1	nsubj	_	SpaceAfter=No
 4	.	_	PUNCT	PUNCT	_	1	punct	_	_
 
 # sent_id = 457
-# text = עכשיו עת להרוג .
+# text = עכשיו עת להרוג.
 1	עכשיו	עכשיו	ADV	ADV	_	2	advmod	_	_
 2	עת	עת	NOUN	NOUN	Gender=Fem|Number=Sing	0	root	_	_
-3	להרוג	הרג	VERB	VERB	HebBinyan=PAAL|VerbForm=Inf|Voice=Act	2	advmod:inf	_	_
+3	להרוג	הרג	VERB	VERB	HebBinyan=PAAL|VerbForm=Inf|Voice=Act	2	advmod:inf	_	SpaceAfter=No
 4	.	_	PUNCT	PUNCT	_	2	punct	_	_
 
 # sent_id = 458
-# text = זו העת להרוג רבותי .
+# text = זו העת להרוג רבותי.
 1	זו	זו	PRON	PRON	Gender=Fem|Number=Sing|Person=3|PronType=Dem	3	nsubj	_	_
 2-3	העת	_	_	_	_	_	_	_	_
 2	ה	ה	DET	DET	PronType=Art	3	det:def	_	_
 3	עת	עת	NOUN	NOUN	Gender=Fem|Number=Sing	0	root	_	_
 4	להרוג	הרג	VERB	VERB	HebBinyan=PAAL|VerbForm=Inf|Voice=Act	3	advmod:inf	_	_
-5-7	רבותי	_	_	_	_	_	_	_	_
+5-7	רבותי	_	_	_	_	_	_	_	SpaceAfter=No
 5	__	_	NOUN	NOUN	Definite=Def|Gender=Fem|Number=Plur	3	nmod	_	_
 6	_של_	של	ADP	ADP	_	7	case:gen	_	_
 7	_אני	הוא	PRON	PRON	Case=Gen|Gender=Fem,Masc|Number=Sing|Person=1|PronType=Prs	5	nmod:poss	_	_
 8	.	_	PUNCT	PUNCT	_	3	punct	_	_
 
 # sent_id = 459
-# text = נצפה לשלום , אך אינך יכול להגיע לשלום , שלא דרך המלחמה .
+# text = נצפה לשלום, אך אינך יכול להגיע לשלום, שלא דרך המלחמה.
 1	נצפה	ציפה	VERB	VERB	Gender=Fem,Masc|Number=Plur|Person=1|Tense=Fut	0	root	_	_
-2-3	לשלום	_	_	_	_	_	_	_	_
+2-3	לשלום	_	_	_	_	_	_	_	SpaceAfter=No
 2	ל	ל	ADP	ADP	_	3	case	_	_
 3	שלום	שלום	NOUN	NOUN	Gender=Masc|Number=Sing	1	obl	_	_
 4	,	_	PUNCT	PUNCT	_	1	punct	_	_
@@ -14843,19 +14843,19 @@
 6	אינך	_	VERB	VERB	Gender=Masc|Number=Sing|Person=3|Polarity=Neg|VerbForm=Part|VerbType=Cop	7	advmod	_	_
 7	יכול	_	AUX	AUX	Gender=Masc|Number=Sing|Person=1,2,3|VerbForm=Part|VerbType=Mod	1	conj	_	_
 8	להגיע	הגיע	VERB	VERB	HebBinyan=HIFIL|VerbForm=Inf|Voice=Act	7	xcomp	_	_
-9-10	לשלום	_	_	_	_	_	_	_	_
+9-10	לשלום	_	_	_	_	_	_	_	SpaceAfter=No
 9	ל	ל	ADP	ADP	_	10	case	_	_
 10	שלום	שלום	NOUN	NOUN	Gender=Masc|Number=Sing	8	iobj	_	_
 11	,	_	PUNCT	PUNCT	_	7	punct	_	_
 12	שלא	שלא	ADV	ADV	_	13	advmod	_	_
 13	דרך	דרך	ADP	ADP	_	15	case	_	_
-14-15	המלחמה	_	_	_	_	_	_	_	_
+14-15	המלחמה	_	_	_	_	_	_	_	SpaceAfter=No
 14	ה	ה	DET	DET	PronType=Art	15	det:def	_	_
 15	מלחמה	מלחמה	NOUN	NOUN	Gender=Fem|Number=Sing	7	obl	_	_
 16	.	_	PUNCT	PUNCT	_	1	punct	_	_
 
 # sent_id = 460
-# text = עת לטוב ועת לרע : אינך יכול להגיע לטוב , אם אתה לא מבער את הרע .
+# text = עת לטוב ועת לרע: אינך יכול להגיע לטוב, אם אתה לא מבער את הרע.
 1	עת	עת	NOUN	NOUN	Gender=Fem|Number=Sing	3	nsubj	_	_
 2-3	לטוב	_	_	_	_	_	_	_	_
 2	ל	ל	ADP	ADP	_	3	case	_	_
@@ -14863,14 +14863,14 @@
 4-5	ועת	_	_	_	_	_	_	_	_
 4	ו	ו	CCONJ	CCONJ	_	7	cc	_	_
 5	עת	עת	NOUN	NOUN	Gender=Fem|Number=Sing	7	nsubj	_	_
-6-7	לרע	_	_	_	_	_	_	_	_
+6-7	לרע	_	_	_	_	_	_	_	SpaceAfter=No
 6	ל	ל	ADP	ADP	_	7	case	_	_
 7	רע	רע	NOUN	NOUN	Gender=Masc|Number=Sing	3	conj	_	_
 8	:	_	PUNCT	PUNCT	_	3	punct	_	_
 9	אינך	_	VERB	VERB	Gender=Fem|Number=Sing|Person=2|Polarity=Neg|VerbForm=Part|VerbType=Cop	3	conj:discourse	_	_
 10	יכול	_	AUX	AUX	Gender=Masc|HebSource=ConvUncertainHead|Number=Sing|Person=1,2,3|VerbForm=Part|VerbType=Mod	9	dep	_	_
 11	להגיע	הגיע	VERB	VERB	HebBinyan=HIFIL|HebSource=ConvUncertainHead|VerbForm=Inf|Voice=Act	9	dep	_	_
-12-14	לטוב	_	_	_	_	_	_	_	_
+12-14	לטוב	_	_	_	_	_	_	_	SpaceAfter=No
 12	ל	ל	ADP	ADP	_	14	case	_	_
 13	ה_	ה	DET	DET	PronType=Art	14	det:def	_	_
 14	טוב	טוב	NOUN	NOUN	Gender=Masc|Number=Sing	11	iobj	_	_
@@ -14880,21 +14880,21 @@
 18	לא	לא	ADV	ADV	Polarity=Neg	19	advmod	_	_
 19	מבער	ביער	VERB	VERB	Gender=Masc|HebBinyan=PIEL|HebSource=ConvUncertainHead|Number=Sing|Person=1,2,3|VerbForm=Part|Voice=Act	9	dep	_	_
 20	את	את	PART	PART	Case=Acc	22	case:acc	_	_
-21-22	הרע	_	_	_	_	_	_	_	_
+21-22	הרע	_	_	_	_	_	_	_	SpaceAfter=No
 21	ה	ה	DET	DET	PronType=Art	22	det:def	_	_
 22	רע	רע	NOUN	NOUN	Gender=Masc|Number=Sing	19	obj	_	_
 23	.	_	PUNCT	PUNCT	_	3	punct	_	_
 
 # sent_id = 461
-# text = זה הרגע .
+# text = זה הרגע.
 1	זה	זה	PRON	PRON	Gender=Masc|Number=Sing|Person=3	3	nsubj	_	_
-2-3	הרגע	_	_	_	_	_	_	_	_
+2-3	הרגע	_	_	_	_	_	_	_	SpaceAfter=No
 2	ה	ה	DET	DET	PronType=Art	3	det:def	_	_
 3	רגע	רגע	NOUN	NOUN	Gender=Masc|Number=Sing	0	root	_	_
 4	.	_	PUNCT	PUNCT	_	3	punct	_	_
 
 # sent_id = 462
-# text = זה הזמן לנקום נקמתו של כל יהודי " .
+# text = זה הזמן לנקום נקמתו של כל יהודי ".
 1	זה	זה	PRON	PRON	Gender=Masc|Number=Sing|Person=3	3	nsubj	_	_
 2-3	הזמן	_	_	_	_	_	_	_	_
 2	ה	ה	DET	DET	PronType=Art	3	det:def	_	_
@@ -14907,11 +14907,11 @@
 8	של	של	PART	PART	Case=Gen	10	case:gen	_	_
 9	כל	כול	DET	DET	Definite=Cons	10	det	_	_
 10	יהודי	יהודי	NOUN	NOUN	Gender=Masc|Number=Sing	5	nmod:poss	_	_
-11	"	_	PUNCT	PUNCT	_	3	punct	_	_
+11	"	_	PUNCT	PUNCT	_	3	punct	_	SpaceAfter=No
 12	.	_	PUNCT	PUNCT	_	3	punct	_	_
 
 # sent_id = 463
-# text = דבריו של יקותיאל בן - יעקב , איש כך המקורב ביותר לרב כהנא , הם המפורשים ביותר , והוא פנה אל רבו , כאילו עוד היה חי : " הרב כהנא רצחו אותך פעמיים .
+# text = דבריו של יקותיאל בן - יעקב, איש כך המקורב ביותר לרב כהנא, הם המפורשים ביותר, והוא פנה אל רבו, כאילו עוד היה חי: " הרב כהנא רצחו אותך פעמיים.
 1-3	דבריו	_	_	_	_	_	_	_	_
 1	דבר_	דבר	NOUN	NOUN	Definite=Def|Gender=Masc|Number=Plur	22	nsubj:cop	_	_
 2	_של_	של	ADP	ADP	_	3	case:gen	_	_
@@ -14920,7 +14920,7 @@
 5	יקותיאל	יקותיאל	PROPN	PROPN	_	1	nmod:poss	_	_
 6	בן	בן	PROPN	PROPN	_	5	flat:name	_	_
 7	-	_	PUNCT	PUNCT	_	6	flat:name	_	_
-8	יעקב	יעקב	PROPN	PROPN	_	6	flat:name	_	_
+8	יעקב	יעקב	PROPN	PROPN	_	6	flat:name	_	SpaceAfter=No
 9	,	_	PUNCT	PUNCT	_	5	punct	_	_
 10	איש	איש	NOUN	NOUN	Gender=Masc|Number=Sing	5	appos	_	_
 11	כך	כך	PROPN	PROPN	_	10	appos	_	_
@@ -14932,20 +14932,20 @@
 15	ל	ל	ADP	ADP	_	17	case	_	_
 16	ה_	ה	DET	DET	PronType=Art	17	det:def	_	_
 17	רב	רב	NOUN	NOUN	Gender=Masc|Number=Sing	13	iobj	_	_
-18	כהנא	כהנא	PROPN	PROPN	_	17	appos	_	_
+18	כהנא	כהנא	PROPN	PROPN	_	17	appos	_	SpaceAfter=No
 19	,	_	PUNCT	PUNCT	_	22	punct	_	_
 20	הם	הוא	VERB	VERB	Gender=Masc|Number=Plur|Person=3|Polarity=Pos|VerbForm=Part|VerbType=Cop	22	cop	_	_
 21-22	המפורשים	_	_	_	_	_	_	_	_
 21	ה	ה	DET	DET	PronType=Art	22	det:def	_	_
 22	מפורשים	מפורש	ADJ	ADJ	Gender=Masc|Number=Plur	0	root	_	_
-23	ביותר	ביותר	ADV	ADV	_	22	advmod	_	_
+23	ביותר	ביותר	ADV	ADV	_	22	advmod	_	SpaceAfter=No
 24	,	_	PUNCT	PUNCT	_	22	punct	_	_
 25-26	והוא	_	_	_	_	_	_	_	_
 25	ו	ו	CCONJ	CCONJ	_	27	cc	_	_
 26	הוא	הוא	PRON	PRON	Gender=Masc|Number=Sing|Person=3|PronType=Prs	27	nsubj	_	_
 27	פנה	פנה	VERB	VERB	Gender=Masc|HebBinyan=PAAL|Number=Sing|Person=3|Tense=Past|Voice=Act	22	conj	_	_
 28	אל	אל	ADP	ADP	_	29	case	_	_
-29-31	רבו	_	_	_	_	_	_	_	_
+29-31	רבו	_	_	_	_	_	_	_	SpaceAfter=No
 29	רב_	רב	NOUN	NOUN	Definite=Def|Gender=Masc|Number=Sing	27	iobj	_	_
 30	_של_	של	ADP	ADP	_	31	case:gen	_	_
 31	_הוא	הוא	PRON	PRON	Case=Gen|Gender=Masc|Number=Sing|Person=3|PronType=Prs	29	nmod:poss	_	_
@@ -14953,7 +14953,7 @@
 33	כאילו	כאילו	CCONJ	CCONJ	_	36	mark	_	_
 34	עוד	עוד	ADV	ADV	_	36	advmod	_	_
 35	היה	היה	VERB	VERB	Gender=Masc|Number=Sing|Person=3|Polarity=Pos|Tense=Past|VerbType=Cop	36	aux	_	_
-36	חי	חי	VERB	VERB	Gender=Masc|HebBinyan=PAAL|Number=Sing|Person=1,2,3|VerbForm=Part|Voice=Act	27	advcl	_	_
+36	חי	חי	VERB	VERB	Gender=Masc|HebBinyan=PAAL|Number=Sing|Person=1,2,3|VerbForm=Part|Voice=Act	27	advcl	_	SpaceAfter=No
 37	:	_	PUNCT	PUNCT	_	22	punct	_	_
 38	"	_	PUNCT	PUNCT	_	40	punct	_	_
 39-40	הרב	_	_	_	_	_	_	_	_
@@ -14964,11 +14964,11 @@
 43-44	אותך	_	_	_	_	_	_	_	_
 43	את_	את	PART	PART	Case=Acc	44	case:acc	_	_
 44	_אתה	הוא	PRON	PRON	Gender=Masc|Number=Sing|Person=2|PronType=Prs	40	obj	_	_
-45	פעמיים	פעם	NOUN	NOUN	Gender=Fem|Number=Dual	40	dep	_	_
+45	פעמיים	פעם	NOUN	NOUN	Gender=Fem|Number=Dual	40	dep	_	SpaceAfter=No
 46	.	_	PUNCT	PUNCT	_	22	punct	_	_
 
 # sent_id = 464
-# text = כאן בארץ פסלו אותך ובארה"ב רצחו אותך .
+# text = כאן בארץ פסלו אותך ובארה"ב רצחו אותך.
 1	כאן	כאן	ADV	ADV	_	5	advmod	_	_
 2-4	בארץ	_	_	_	_	_	_	_	_
 2	ב	ב	ADP	ADP	_	4	case	_	_
@@ -14983,13 +14983,13 @@
 9	ב	ב	ADP	ADP	_	10	case	_	_
 10	ארה"ב	ארה"ב	PROPN	PROPN	Abbr=Yes	11	obl	_	_
 11	רצחו	רצח	VERB	VERB	Gender=Fem,Masc|HebBinyan=PAAL|Number=Plur|Person=3|Tense=Past|Voice=Act	5	conj	_	_
-12-13	אותך	_	_	_	_	_	_	_	_
+12-13	אותך	_	_	_	_	_	_	_	SpaceAfter=No
 12	את_	את	PART	PART	Case=Acc	13	case:acc	_	_
 13	_אתה	הוא	PRON	PRON	Gender=Masc|Number=Sing|Person=2|PronType=Prs	11	obj	_	_
 14	.	_	PUNCT	PUNCT	_	5	punct	_	_
 
 # sent_id = 465
-# text = התקשורת העויינת ממשיכה לרצוח אותך פעם שלישית .
+# text = התקשורת העויינת ממשיכה לרצוח אותך פעם שלישית.
 1-2	התקשורת	_	_	_	_	_	_	_	_
 1	ה	ה	DET	DET	PronType=Art	2	det:def	_	_
 2	תקשורת	תקשורת	NOUN	NOUN	Gender=Fem|Number=Sing	5	nsubj	_	_
@@ -15002,11 +15002,11 @@
 7	את_	את	PART	PART	Case=Acc	8	case:acc	_	_
 8	_אתה	הוא	PRON	PRON	Gender=Masc|Number=Sing|Person=2|PronType=Prs	6	obj	_	_
 9	פעם	פעם	NOUN	NOUN	Gender=Fem|Number=Sing	5	dep	_	_
-10	שלישית	שלישי	NUM	NUM	Gender=Fem|Number=Sing	9	amod	_	_
+10	שלישית	שלישי	NUM	NUM	Gender=Fem|Number=Sing	9	amod	_	SpaceAfter=No
 11	.	_	PUNCT	PUNCT	_	5	punct	_	_
 
 # sent_id = 466
-# text = נבכה ונפסיק לבכות ונקיים את התורה שלימדת אותנו נקמה .
+# text = נבכה ונפסיק לבכות ונקיים את התורה שלימדת אותנו נקמה.
 1	נבכה	בכה	VERB	VERB	Gender=Fem,Masc|Number=Plur|Person=1|Tense=Fut	0	root	_	_
 2-3	ונפסיק	_	_	_	_	_	_	_	_
 2	ו	ו	CCONJ	CCONJ	_	3	cc	_	_
@@ -15025,11 +15025,11 @@
 12-13	אותנו	_	_	_	_	_	_	_	_
 12	את_	את	PART	PART	Case=Acc	13	case:acc	_	_
 13	_אנחנו	הוא	PRON	PRON	Gender=Fem,Masc|Number=Plur|Person=1|PronType=Prs	11	obj	_	_
-14	נקמה	נקמה	NOUN	NOUN	Gender=Fem|HebSource=ConvUncertainLabel|Number=Sing	9	nmod	_	_
+14	נקמה	נקמה	NOUN	NOUN	Gender=Fem|HebSource=ConvUncertainLabel|Number=Sing	9	nmod	_	SpaceAfter=No
 15	.	_	PUNCT	PUNCT	_	1	punct	_	_
 
 # sent_id = 467
-# text = ניתן את רשות הדיבור לחבר תת - מקלע לחבר סכין .
+# text = ניתן את רשות הדיבור לחבר תת - מקלע לחבר סכין.
 1	ניתן	נתן	VERB	VERB	Gender=Fem,Masc|HebBinyan=PAAL|Number=Plur|Person=1|Tense=Fut|Voice=Act	0	root	_	_
 2	את	את	PART	PART	Case=Acc	3	case:acc	_	_
 3	רשות	רשות	NOUN	NOUN	Definite=Cons|Gender=Fem|Number=Sing	1	obj	_	_
@@ -15047,21 +15047,21 @@
 12	ל	ל	ADP	ADP	_	14	case	_	_
 13	ה_	ה	DET	DET	PronType=Art	14	det:def	_	_
 14	חבר	חבר	NOUN	NOUN	Gender=Masc|Number=Sing	1	iobj	_	_
-15	סכין	סכין	NOUN	NOUN	Gender=Fem,Masc|HebSource=ConvUncertainLabel|Number=Sing	14	nmod	_	_
+15	סכין	סכין	NOUN	NOUN	Gender=Fem,Masc|HebSource=ConvUncertainLabel|Number=Sing	14	nmod	_	SpaceAfter=No
 16	.	_	PUNCT	PUNCT	_	1	punct	_	_
 
 # sent_id = 468
-# text = שלום הרב כהנא " .
+# text = שלום הרב כהנא ".
 1	שלום	שלום	NOUN	NOUN	Gender=Masc|Number=Sing	0	root	_	_
 2-3	הרב	_	_	_	_	_	_	_	_
 2	ה	ה	DET	DET	PronType=Art	3	det:def	_	_
 3	רב	רב	NOUN	NOUN	Gender=Masc|Number=Sing	1	nmod	_	_
 4	כהנא	כהנא	PROPN	PROPN	_	3	appos	_	_
-5	"	_	PUNCT	PUNCT	_	1	punct	_	_
+5	"	_	PUNCT	PUNCT	_	1	punct	_	SpaceAfter=No
 6	.	_	PUNCT	PUNCT	_	1	punct	_	_
 
 # sent_id = 469
-# text = אט אט התחיל ההמון לצעוד אל מחוץ לסמטאות לעבר הכביש הראשי .
+# text = אט אט התחיל ההמון לצעוד אל מחוץ לסמטאות לעבר הכביש הראשי.
 1	אט	אט	ADV	ADV	_	3	advmod	_	_
 2	אט	אט	ADV	ADV	_	1	fixed	_	_
 3	התחיל	התחיל	VERB	VERB	Gender=Masc|Number=Sing|Person=3|Tense=Past	0	root	_	_
@@ -15081,13 +15081,13 @@
 14-15	הכביש	_	_	_	_	_	_	_	_
 14	ה	ה	DET	DET	PronType=Art	15	det:def	_	_
 15	כביש	כביש	NOUN	NOUN	Gender=Masc|Number=Sing	6	obl	_	_
-16-17	הראשי	_	_	_	_	_	_	_	_
+16-17	הראשי	_	_	_	_	_	_	_	SpaceAfter=No
 16	ה	ה	DET	DET	PronType=Art	17	det:def	_	_
 17	ראשי	ראשי	ADJ	ADJ	Gender=Masc|Number=Sing	15	amod	_	_
 18	.	_	PUNCT	PUNCT	_	3	punct	_	_
 
 # sent_id = 470
-# text = תחילה בשקט ואחר כך תוך קריאות גוברות והולכות : " מוות לערבים " , " מוות לשמאלנים " , " רוצים נקמה " .
+# text = תחילה בשקט ואחר כך תוך קריאות גוברות והולכות: "מוות לערבים", "מוות לשמאלנים", "רוצים נקמה".
 1	תחילה	תחילה	ADV	ADV	_	2	advmod	_	_
 2-3	בשקט	_	_	_	_	_	_	_	_
 2	ב	ב	ADP	ADP	_	3	case	_	_
@@ -15099,34 +15099,34 @@
 7	תוך	תוך	ADP	ADP	_	8	case	_	_
 8	קריאות	קריאה	NOUN	NOUN	Gender=Fem|HebSource=ConvUncertainHead|Number=Plur	6	dep	_	_
 9	גוברות	גבר	VERB	VERB	Gender=Fem|HebBinyan=PAAL|Number=Plur|Person=1,2,3|VerbForm=Part|Voice=Act	8	amod	_	_
-10-11	והולכות	_	_	_	_	_	_	_	_
+10-11	והולכות	_	_	_	_	_	_	_	SpaceAfter=No
 10	ו	ו	CCONJ	CCONJ	_	11	cc	_	_
 11	הולכות	הלך	VERB	VERB	Gender=Fem|HebBinyan=PAAL|Number=Plur|Person=1,2,3|VerbForm=Part|Voice=Act	9	conj	_	_
 12	:	_	PUNCT	PUNCT	_	14	punct	_	_
-13	"	_	PUNCT	PUNCT	_	14	punct	_	_
+13	"	_	PUNCT	PUNCT	_	14	punct	_	SpaceAfter=No
 14	מוות	מוות	NOUN	NOUN	Gender=Masc|Number=Sing	0	root	_	_
-15-17	לערבים	_	_	_	_	_	_	_	_
+15-17	לערבים	_	_	_	_	_	_	_	SpaceAfter=No
 15	ל	ל	ADP	ADP	_	17	case	_	_
 16	ה_	ה	DET	DET	PronType=Art	17	det:def	_	_
 17	ערבים	ערבי	NOUN	NOUN	Gender=Masc|Number=Plur	14	nmod	_	_
-18	"	_	PUNCT	PUNCT	_	14	punct	_	_
+18	"	_	PUNCT	PUNCT	_	14	punct	_	SpaceAfter=No
 19	,	_	PUNCT	PUNCT	_	14	punct	_	_
-20	"	_	PUNCT	PUNCT	_	21	punct	_	_
+20	"	_	PUNCT	PUNCT	_	21	punct	_	SpaceAfter=No
 21	מוות	מוות	NOUN	NOUN	Gender=Masc|HebSource=ConvUncertainHead|Number=Sing	14	dep	_	_
-22-24	לשמאלנים	_	_	_	_	_	_	_	_
+22-24	לשמאלנים	_	_	_	_	_	_	_	SpaceAfter=No
 22	ל	ל	ADP	ADP	_	24	case	_	_
 23	ה_	ה	DET	DET	PronType=Art	24	det:def	_	_
 24	שמאלנים	שמאלן	NOUN	NOUN	Gender=Masc|Number=Plur	21	nmod	_	_
-25	"	_	PUNCT	PUNCT	_	21	punct	_	_
+25	"	_	PUNCT	PUNCT	_	21	punct	_	SpaceAfter=No
 26	,	_	PUNCT	PUNCT	_	14	punct	_	_
-27	"	_	PUNCT	PUNCT	_	28	punct	_	_
+27	"	_	PUNCT	PUNCT	_	28	punct	_	SpaceAfter=No
 28	רוצים	רצה	VERB	VERB	Gender=Masc|HebBinyan=PAAL|HebSource=ConvUncertainHead|Number=Plur|Person=1,2,3|VerbForm=Part|Voice=Act	14	dep	_	_
-29	נקמה	נקמה	NOUN	NOUN	Gender=Fem|Number=Sing	28	obj	_	_
-30	"	_	PUNCT	PUNCT	_	28	punct	_	_
+29	נקמה	נקמה	NOUN	NOUN	Gender=Fem|Number=Sing	28	obj	_	SpaceAfter=No
+30	"	_	PUNCT	PUNCT	_	28	punct	_	SpaceAfter=No
 31	.	_	PUNCT	PUNCT	_	14	punct	_	_
 
 # sent_id = 471
-# text = הקהל הזה היה צמא לדם והוא חיפש ערבים .
+# text = הקהל הזה היה צמא לדם והוא חיפש ערבים.
 1-2	הקהל	_	_	_	_	_	_	_	_
 1	ה	ה	DET	DET	PronType=Art	2	det:def	_	_
 2	קהל	קהל	NOUN	NOUN	Gender=Masc|Number=Sing	6	nsubj	_	_
@@ -15142,11 +15142,11 @@
 9	ו	ו	CCONJ	CCONJ	_	11	cc	_	_
 10	הוא	הוא	PRON	PRON	Gender=Masc|Number=Sing|Person=3|PronType=Prs	11	nsubj	_	_
 11	חיפש	חיפש	VERB	VERB	Gender=Masc|HebBinyan=PIEL|Number=Sing|Person=3|Tense=Past|Voice=Act	6	conj	_	_
-12	ערבים	ערבי	NOUN	NOUN	Gender=Masc|Number=Plur	11	obj	_	_
+12	ערבים	ערבי	NOUN	NOUN	Gender=Masc|Number=Plur	11	obj	_	SpaceAfter=No
 13	.	_	PUNCT	PUNCT	_	6	punct	_	_
 
 # sent_id = 472
-# text = מדי פעם בפעם פרצה קבוצה של כמה מאות הצידה כאשר נדמה היה שגילתה ערבי .
+# text = מדי פעם בפעם פרצה קבוצה של כמה מאות הצידה כאשר נדמה היה שגילתה ערבי.
 1	מדי	מדי	ADV	ADV	_	5	advmod:phrase	_	_
 2	פעם	פעם	ADV	ADV	HebSource=ConvUncertainHead	1	dep	_	_
 3-4	בפעם	_	_	_	_	_	_	_	_
@@ -15164,20 +15164,20 @@
 14-15	שגילתה	_	_	_	_	_	_	_	_
 14	ש	ש	SCONJ	SCONJ	_	15	mark	_	_
 15	גילתה	גילה	VERB	VERB	Gender=Fem|HebBinyan=PIEL|Number=Sing|Person=3|Tense=Past|Voice=Act	12	ccomp	_	_
-16	ערבי	ערבי	NOUN	NOUN	Gender=Masc|Number=Sing	15	obj	_	_
+16	ערבי	ערבי	NOUN	NOUN	Gender=Masc|Number=Sing	15	obj	_	SpaceAfter=No
 17	.	_	PUNCT	PUNCT	_	5	punct	_	_
 
 # sent_id = 473
-# text = אבל האכזבה רבה .
+# text = אבל האכזבה רבה.
 1	אבל	אבל	CCONJ	CCONJ	_	4	cc	_	_
 2-3	האכזבה	_	_	_	_	_	_	_	_
 2	ה	ה	DET	DET	PronType=Art	3	det:def	_	_
 3	אכזבה	אכזבה	NOUN	NOUN	Gender=Fem|Number=Sing	4	nsubj	_	_
-4	רבה	רב	ADJ	ADJ	Gender=Fem|Number=Sing	0	root	_	_
+4	רבה	רב	ADJ	ADJ	Gender=Fem|Number=Sing	0	root	_	SpaceAfter=No
 5	.	_	PUNCT	PUNCT	_	4	punct	_	_
 
 # sent_id = 474
-# text = בעלי מפעלים רבים על נתיב ההלווייה נעלו את פועליהם מאחורי סוגר ובריח .
+# text = בעלי מפעלים רבים על נתיב ההלווייה נעלו את פועליהם מאחורי סוגר ובריח.
 1	בעלי	בעל	NOUN	NOUN	Definite=Cons|Gender=Masc|Number=Plur	8	nsubj	_	_
 2	מפעלים	מפעל	NOUN	NOUN	Gender=Masc|Number=Plur	1	compound:smixut	_	_
 3	רבים	רב	ADJ	ADJ	Gender=Masc|Number=Plur	2	amod	_	_
@@ -15194,13 +15194,13 @@
 12	_הם	הוא	PRON	PRON	Case=Gen|Gender=Masc|Number=Plur|Person=3|PronType=Prs	10	nmod:poss	_	_
 13	מאחורי	מאחורי	ADP	ADP	_	14	case	_	_
 14	סוגר	סוגר	NOUN	NOUN	Gender=Masc|Number=Sing	8	obl	_	_
-15-16	ובריח	_	_	_	_	_	_	_	_
+15-16	ובריח	_	_	_	_	_	_	_	SpaceAfter=No
 15	ו	ו	CCONJ	CCONJ	_	16	cc	_	_
 16	בריח	בריח	NOUN	NOUN	Gender=Masc|Number=Sing	14	conj	_	_
 17	.	_	PUNCT	PUNCT	_	8	punct	_	_
 
 # sent_id = 475
-# text = אחדים מהם עשו שטות והציצו מבעד לחלונות ; בתוך דקות נופצו שמשות .
+# text = אחדים מהם עשו שטות והציצו מבעד לחלונות; בתוך דקות נופצו שמשות.
 1	אחדים	אחדים	NUM	NUM	_	3	det	_	_
 2-3	מהם	_	_	_	_	_	_	_	_
 2	מהם	מן	ADP	ADP	_	3	case	_	_
@@ -15211,7 +15211,7 @@
 6	ו	ו	CCONJ	CCONJ	_	7	cc	_	_
 7	הציצו	הציץ	VERB	VERB	Gender=Fem,Masc|HebBinyan=HIFIL|Number=Plur|Person=3|Tense=Past|Voice=Act	4	conj	_	_
 8	מבעד	מבעד	ADP	ADP	_	11	case	_	_
-9-11	לחלונות	_	_	_	_	_	_	_	_
+9-11	לחלונות	_	_	_	_	_	_	_	SpaceAfter=No
 9	ל	ל	ADP	ADP	_	11	case	_	_
 10	ה_	ה	DET	DET	PronType=Art	11	det:def	_	_
 11	חלונות	חלון	NOUN	NOUN	Gender=Masc|Number=Plur	7	advmod	_	_
@@ -15219,40 +15219,40 @@
 13	בתוך	בתוך	ADP	ADP	_	14	case	_	_
 14	דקות	דקה	NOUN	NOUN	Gender=Fem|Number=Plur	15	obl	_	_
 15	נופצו	נופץ	VERB	VERB	Gender=Fem,Masc|HebBinyan=PUAL|Number=Plur|Person=3|Tense=Past|Voice=Pass	4	conj	_	_
-16	שמשות	שמשה	NOUN	NOUN	Gender=Fem|Number=Plur	15	nsubj	_	_
+16	שמשות	שמשה	NOUN	NOUN	Gender=Fem|Number=Plur	15	nsubj	_	SpaceAfter=No
 17	.	_	PUNCT	PUNCT	_	4	punct	_	_
 
 # sent_id = 476
-# text = מאחור צרו מאות על בניין הטלוויזיה .
+# text = מאחור צרו מאות על בניין הטלוויזיה.
 1	מאחור	מאחור	ADV	ADV	_	2	advmod	_	_
 2	צרו	צר	VERB	VERB	Gender=Fem,Masc|HebBinyan=PAAL|Number=Plur|Person=3|Tense=Past|Voice=Act	0	root	_	_
 3	מאות	מאה	NUM	NUM	Gender=Fem|Number=Plur	2	nsubj	_	_
 4	על	על	ADP	ADP	_	5	case	_	_
 5	בניין	בניין	NOUN	NOUN	Definite=Cons|Gender=Masc|Number=Sing	2	iobj	_	_
-6-7	הטלוויזיה	_	_	_	_	_	_	_	_
+6-7	הטלוויזיה	_	_	_	_	_	_	_	SpaceAfter=No
 6	ה	ה	DET	DET	PronType=Art	7	det:def	_	_
 7	טלוויזיה	טלוויזיה	NOUN	NOUN	Gender=Fem|Number=Sing	5	compound:smixut	_	_
 8	.	_	PUNCT	PUNCT	_	2	punct	_	_
 
 # sent_id = 477
-# text = פרשי משטרה דחקו אותם לאחור .
+# text = פרשי משטרה דחקו אותם לאחור.
 1	פרשי	פרש	NOUN	NOUN	Definite=Cons|Gender=Masc|Number=Plur	3	nsubj	_	_
 2	משטרה	משטרה	NOUN	NOUN	Gender=Fem|Number=Sing	1	compound:smixut	_	_
 3	דחקו	דחק	VERB	VERB	Gender=Fem,Masc|HebBinyan=PAAL|Number=Plur|Person=3|Tense=Past|Voice=Act	0	root	_	_
 4-5	אותם	_	_	_	_	_	_	_	_
 4	את_	את	PART	PART	Case=Acc	5	case:acc	_	_
 5	_הם	הוא	PRON	PRON	Gender=Masc|Number=Plur|Person=3|PronType=Prs	3	obj	_	_
-6	לאחור	לאחור	ADV	ADV	_	3	advmod	_	_
+6	לאחור	לאחור	ADV	ADV	_	3	advmod	_	SpaceAfter=No
 7	.	_	PUNCT	PUNCT	_	3	punct	_	_
 
 # sent_id = 478
-# text = שוטר נפגע מאבן בראשו .
+# text = שוטר נפגע מאבן בראשו.
 1	שוטר	שוטר	NOUN	NOUN	Gender=Masc|Number=Sing	2	nsubj	_	_
 2	נפגע	נפגע	VERB	VERB	Gender=Masc|HebBinyan=NIFAL|Number=Sing|Person=3|Tense=Past|Voice=Mid	0	root	_	_
 3-4	מאבן	_	_	_	_	_	_	_	_
 3	מ	מ	ADP	ADP	_	4	case	_	_
 4	אבן	אבן	NOUN	NOUN	Gender=Fem|Number=Sing	2	obl	_	_
-5-8	בראשו	_	_	_	_	_	_	_	_
+5-8	בראשו	_	_	_	_	_	_	_	SpaceAfter=No
 5	ב	ב	ADP	ADP	_	6	case	_	_
 6	ראש_	ראש	NOUN	NOUN	Definite=Def|Gender=Masc|Number=Sing	2	obl	_	_
 7	_של_	של	ADP	ADP	_	8	case:gen	_	_
@@ -15260,7 +15260,7 @@
 9	.	_	PUNCT	PUNCT	_	2	punct	_	_
 
 # sent_id = 479
-# text = קבוצה אחרת של מפגינים פרצה למרכז המסחרי סנטר 1 , ליד התחנה המרכזית .
+# text = קבוצה אחרת של מפגינים פרצה למרכז המסחרי סנטר 1, ליד התחנה המרכזית.
 1	קבוצה	קבוצה	NOUN	NOUN	Gender=Fem|Number=Sing	5	nsubj	_	_
 2	אחרת	אחר	ADJ	ADJ	Gender=Fem|Number=Sing	1	amod	_	_
 3	של	של	PART	PART	Case=Gen	4	case:gen	_	_
@@ -15274,29 +15274,29 @@
 9	ה	ה	DET	DET	PronType=Art	10	det:def	_	_
 10	מסחרי	מסחרי	ADJ	ADJ	Gender=Masc|Number=Sing	8	amod	_	_
 11	סנטר	סנטר	NOUN	NOUN	Gender=Masc|Number=Sing	8	appos	_	_
-12	1	_	NUM	NUM	_	11	nummod	_	_
+12	1	_	NUM	NUM	_	11	nummod	_	SpaceAfter=No
 13	,	_	PUNCT	PUNCT	_	5	punct	_	_
 14	ליד	ליד	ADP	ADP	_	16	case	_	_
 15-16	התחנה	_	_	_	_	_	_	_	_
 15	ה	ה	DET	DET	PronType=Art	16	det:def	_	_
 16	תחנה	תחנה	NOUN	NOUN	Gender=Fem|Number=Sing	5	obl	_	_
-17-18	המרכזית	_	_	_	_	_	_	_	_
+17-18	המרכזית	_	_	_	_	_	_	_	SpaceAfter=No
 17	ה	ה	DET	DET	PronType=Art	18	det:def	_	_
 18	מרכזית	מרכזי	ADJ	ADJ	Gender=Fem|Number=Sing	16	nmod	_	_
 19	.	_	PUNCT	PUNCT	_	5	punct	_	_
 
 # sent_id = 480
-# text = יושבי בתי הקפה נבעתו .
+# text = יושבי בתי הקפה נבעתו.
 1	יושבי	יושב	NOUN	NOUN	Definite=Cons|Gender=Masc|Number=Plur	5	nsubj	_	_
 2	בתי	בית	NOUN	NOUN	Definite=Cons|Gender=Masc|Number=Plur	1	compound:smixut	_	_
 3-4	הקפה	_	_	_	_	_	_	_	_
 3	ה	ה	DET	DET	PronType=Art	4	det:def	_	_
 4	קפה	קפה	NOUN	NOUN	Gender=Masc|Number=Sing	2	compound:smixut	_	_
-5	נבעתו	נבעת	VERB	VERB	Gender=Fem,Masc|HebBinyan=NIFAL|Number=Plur|Person=3|Tense=Past|Voice=Mid	0	root	_	_
+5	נבעתו	נבעת	VERB	VERB	Gender=Fem,Masc|HebBinyan=NIFAL|Number=Plur|Person=3|Tense=Past|Voice=Mid	0	root	_	SpaceAfter=No
 6	.	_	PUNCT	PUNCT	_	5	punct	_	_
 
 # sent_id = 481
-# text = אם עם תינוקתה פרצה בזעקות .
+# text = אם עם תינוקתה פרצה בזעקות.
 1	אם	אם	NOUN	NOUN	Gender=Fem|Number=Sing	6	nsubj	_	_
 2	עם	עם	ADP	ADP	_	3	case	_	_
 3-5	תינוקתה	_	_	_	_	_	_	_	_
@@ -15304,13 +15304,13 @@
 4	_של_	של	ADP	ADP	_	5	case:gen	_	_
 5	_היא	הוא	PRON	PRON	Case=Gen|Gender=Fem|Number=Sing|Person=3|PronType=Prs	3	nmod:poss	_	_
 6	פרצה	פרץ	VERB	VERB	Gender=Fem|HebBinyan=PAAL|Number=Sing|Person=3|Tense=Past|Voice=Act	0	root	_	_
-7-8	בזעקות	_	_	_	_	_	_	_	_
+7-8	בזעקות	_	_	_	_	_	_	_	SpaceAfter=No
 7	ב	ב	ADP	ADP	_	8	case	_	_
 8	זעקות	זעקה	NOUN	NOUN	Gender=Fem|Number=Plur	6	iobj	_	_
 9	.	_	PUNCT	PUNCT	_	6	punct	_	_
 
 # sent_id = 482
-# text = מיד אחר כך נופצו חלונות ראווה של חנויות במרכז .
+# text = מיד אחר כך נופצו חלונות ראווה של חנויות במרכז.
 1	מיד	מייד	ADV	ADV	_	2	advmod	_	_
 2	אחר	אחר	ADP	ADP	_	3	case	_	_
 3	כך	כך	PRON	PRON	Person=3|PronType=Dem	4	obl	_	_
@@ -15319,14 +15319,14 @@
 6	ראווה	ראווה	NOUN	NOUN	Gender=Fem|Number=Sing	5	compound:smixut	_	_
 7	של	של	PART	PART	Case=Gen	8	case:gen	_	_
 8	חנויות	חנות	NOUN	NOUN	Gender=Fem|Number=Plur	5	nmod:poss	_	_
-9-11	במרכז	_	_	_	_	_	_	_	_
+9-11	במרכז	_	_	_	_	_	_	_	SpaceAfter=No
 9	ב	ב	ADP	ADP	_	11	case	_	_
 10	ה_	ה	DET	DET	PronType=Art	11	det:def	_	_
 11	מרכז	מרכז	NOUN	NOUN	Gender=Masc|Number=Sing	8	nmod	_	_
 12	.	_	PUNCT	PUNCT	_	4	punct	_	_
 
 # sent_id = 483
-# text = השוטרים הגיעו רק אחרי כמה דקות .
+# text = השוטרים הגיעו רק אחרי כמה דקות.
 1-2	השוטרים	_	_	_	_	_	_	_	_
 1	ה	ה	DET	DET	PronType=Art	2	det:def	_	_
 2	שוטרים	שוטר	NOUN	NOUN	Gender=Masc|Number=Plur	3	nsubj	_	_
@@ -15334,11 +15334,11 @@
 4	רק	רק	ADV	ADV	_	5	advmod	_	_
 5	אחרי	אחרי	ADP	ADP	_	7	case	_	_
 6	כמה	כמה	DET	DET	Definite=Cons	7	det	_	_
-7	דקות	דקה	NOUN	NOUN	Gender=Fem|Number=Plur	3	obl	_	_
+7	דקות	דקה	NOUN	NOUN	Gender=Fem|Number=Plur	3	obl	_	SpaceAfter=No
 8	.	_	PUNCT	PUNCT	_	3	punct	_	_
 
 # sent_id = 484
-# text = מול בית מספר 3 ברחוב גבעת שאול אני עד לאירוע החמור ביותר .
+# text = מול בית מספר 3 ברחוב גבעת שאול אני עד לאירוע החמור ביותר.
 1	מול	מול	ADP	ADP	_	2	case	_	_
 2	בית	בית	NOUN	NOUN	Gender=Masc|Number=Sing	10	nmod	_	_
 3	מספר	מספר	NOUN	NOUN	Gender=Masc|HebSource=ConvUncertainLabel|Number=Sing	2	nmod	_	_
@@ -15357,6 +15357,6 @@
 14-15	החמור	_	_	_	_	_	_	_	_
 14	ה	ה	DET	DET	PronType=Art	15	det:def	_	_
 15	חמור	חמור	ADJ	ADJ	Gender=Masc|Number=Sing	13	amod	_	_
-16	ביותר	ביותר	ADV	ADV	_	15	advmod	_	_
+16	ביותר	ביותר	ADV	ADV	_	15	advmod	_	SpaceAfter=No
 17	.	_	PUNCT	PUNCT	_	10	punct	_	_
 


### PR DESCRIPTION
The CoNLL2017 shared task (http://universaldependencies.org/conll17/)
"Multilingual Parsing from Raw Text to Universal Dependencies"
needs raw texts as input for the participants,
i.e. detokenized as it is usually written in real world,
even if the de/tokenization rules are simple.

I took the raw texts from ad1e708 (the commit before #15)
and I used
```bash
udapy -h >/dev/null || { echo "udapy is not installed, see https://github.com/udapi/udapi-python"; exit 1; }

cat dev.txt | sed '4s/.$/"./' | udapy -s read.Conllu files=he-ud-dev.conllu read.AddSentences ud.SetSpaceAfterFromText > fixed-dev.conllu
cat train.txt |  udapy -s read.Conllu files=he-ud-train.conllu read.AddSentences ud.SetSpaceAfterFromText > fixed-train.conllu

```